### PR TITLE
Fix type of isith and nsith to include array of string

### DIFF
--- a/src/keri/app/signify.ts
+++ b/src/keri/app/signify.ts
@@ -441,8 +441,8 @@ export class SignifyClient {
 /** Arguments required to create an identfier */
 export interface CreateIdentiferArgs {
     transferable?: boolean,
-    isith?: string | number,
-    nsith?: string | number,
+    isith?: string | number | string[],
+    nsith?: string | number | string[],
     wits?: string[],
     toad?: number,
     proxy?: string,
@@ -467,7 +467,7 @@ export interface CreateIdentiferArgs {
 /** Arguments required to rotate an identfier */
 export interface RotateIdentifierArgs {
     transferable?: boolean,
-    nsith?: string | number,
+    nsith?: string | number | string[],
     toad?: number,
     cuts?: string[],
     adds?: string[],

--- a/test/app/apping.test.ts
+++ b/test/app/apping.test.ts
@@ -1,6 +1,7 @@
 import {strict as assert} from "assert";
 import {randomPasscode, randomNonce} from '../../src/keri/app/apping'
 import libsodium from "libsodium-wrappers-sumo"
+import {CreateIdentiferArgs, RotateIdentifierArgs} from "../../src/keri/app/signify";
 
 describe('Controller', () => {
     it('Random passcode', async () => {
@@ -15,6 +16,34 @@ describe('Controller', () => {
         assert.equal(nonce.length, 44)
     })
 
+    it('CreateIdentiferArgs', () => {
+        let args: CreateIdentiferArgs;
+        args = {
+            isith: 1,
+            nsith: 1
+        };
+        args = {
+            isith: "1",
+            nsith: "1"
+        };
+        args = {
+            isith: ["1"],
+            nsith: ["1"]
+        };
+    })
+
+    it('RotateIdentifierArgs', () => {
+        let args: RotateIdentifierArgs;
+        args = {
+            nsith: 1
+        };
+        args = {
+            nsith: "1"
+        };
+        args = {
+            nsith: ["1"]
+        };
+    })
 
 
 })

--- a/test/app/apping.test.ts
+++ b/test/app/apping.test.ts
@@ -30,6 +30,7 @@ describe('Controller', () => {
             isith: ["1"],
             nsith: ["1"]
         };
+        args !== null; // avoids TS6133
     })
 
     it('RotateIdentifierArgs', () => {
@@ -43,6 +44,7 @@ describe('Controller', () => {
         args = {
             nsith: ["1"]
         };
+        args !== null; // avoids TS6133
     })
 
 


### PR DESCRIPTION
Adding string[] to type union to allow assigning isith and nsith value such as ["1/2", "1/2"]