### PR TITLE
Fix integration scripts type checking

### DIFF
--- a/examples/scripts/client.ts
+++ b/examples/scripts/client.ts
@@ -1,23 +1,12 @@
-// @ts-ignore
-let signify: any;
+import signify from "signify-ts";
 
-// @ts-ignore
-import('signify-ts').then(
-    (module) => {
-        signify = module
-        signify.ready().then(() => {
-            console.log("Signify client ready!");
-            connect().then(() => {
-                console.log("Done")
-            });
-        });
-    }
-)
+await connect();
 
 async function connect() {
     let url = "http://127.0.0.1:3901"
     let bran = '0123456789abcdefghijk'
 
+    await signify.ready();
     const client = new signify.SignifyClient(url, bran);
     console.log(client.controller.pre)
     const [evt, sign] = client.controller?.event ?? [];
@@ -96,7 +85,7 @@ async function connect() {
 
     let states = [sigPy, kli, sigTs]
     let ires = identifiers.create("multisig", {
-        algo: "group", mhab: aid,
+        algo: signify.Algos.group, mhab: aid,
         delpre: "EHpD0-CDWOdu5RJ8jHBSUkOqBZ3cXeDVHWNb_Ul89VI7",
         toad: 2,
         wits: [

--- a/examples/scripts/list_notifications.ts
+++ b/examples/scripts/list_notifications.ts
@@ -53,7 +53,7 @@ async function list_notifications() {
                     let serder = new signify.Serder(ixn)
                     let ghab = await identifiers.get(group)
 
-                    let keeper = client.manager.get(ghab)
+                    let keeper = client.manager!.get(ghab)
                     let sigs = keeper.sign(signify.b(serder.raw))
                     let sigers = sigs.map((sig: any) => new signify.Siger({qb64: sig}))
 
@@ -65,7 +65,7 @@ async function list_notifications() {
                     }
 
                     sender = ghab["group"]["mhab"]
-                    keeper = client.manager.get(sender)
+                    keeper = client.manager!.get(sender)
                     let [nexn, end] = signify.exchange("/multisig/vcp",
                         {'gid': ghab["prefix"], 'usage': "test"},
                         sender["prefix"], undefined, undefined, undefined, undefined, embeds)

--- a/examples/scripts/list_notifications.ts
+++ b/examples/scripts/list_notifications.ts
@@ -1,25 +1,14 @@
+import signify from "signify-ts";
 
 const prmpt = require("prompt-sync")({ sigint: true });
-// @ts-ignore
-let signify: any;
 
-// @ts-ignore
-import('signify-ts').then(
-    (module) => {
-        signify = module
-        signify.ready().then(() => {
-            console.log("Signify client ready!");
-            list_notifications().then(() => {
-                console.log("Done")
-            });
-        });
-    }
-)
+await list_notifications();
 
 async function list_notifications() {
     let url = "http://127.0.0.1:3901"
     let bran = '0123456789abcdefghijk'
 
+    await signify.ready();
     const client = new signify.SignifyClient(url, bran);
     await client.connect()
     let d = await client.state()

--- a/examples/scripts/list_notifications.ts
+++ b/examples/scripts/list_notifications.ts
@@ -1,6 +1,7 @@
 import signify from "signify-ts";
+import promptSync from 'prompt-sync';
 
-const prmpt = require("prompt-sync")({ sigint: true });
+const prmpt = promptSync({ sigint: true });
 
 await list_notifications();
 
@@ -71,7 +72,7 @@ async function list_notifications() {
                         sender["prefix"], undefined, undefined, undefined, undefined, embeds)
 
                     console.log(nexn.pretty())
-                    let esigs = keeper.sign(nexn.raw)
+                    let esigs = keeper.sign(signify.b(nexn.raw))
                     await groups.sendRequest(group, nexn.ked, esigs, signify.d(end))
 
                     return await registries.createFromEvents(ghab, group, registryName, vcp, ixn, sigs)

--- a/examples/scripts/make_endroles.ts
+++ b/examples/scripts/make_endroles.ts
@@ -1,24 +1,12 @@
+import signify from "signify-ts";
 
-// @ts-ignore
-let signify: any;
-
-// @ts-ignore
-import('signify-ts').then(
-    (module) => {
-        signify = module
-        signify.ready().then(() => {
-            console.log("Signify client ready!");
-            makeends().then(() => {
-                console.log("Done")
-            });
-        });
-    }
-)
+await makeends();
 
 async function makeends() {
     let url = "http://127.0.0.1:3901"
     let bran = '0123456789abcdefghijk'
 
+    await signify.ready();
     const client = new signify.SignifyClient(url, bran);
     await client.connect()
     let d = await client.state()

--- a/examples/scripts/multisig-sigts.sh
+++ b/examples/scripts/multisig-sigts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-npx --package=signify-ts ts-node client.ts
+npx --package=signify-ts ts-node --esm client.ts
 
 read -n 1 -r -p "Press any key to create endpoints for multisig AID..."
 

--- a/examples/scripts/multisig-sigts.sh
+++ b/examples/scripts/multisig-sigts.sh
@@ -5,4 +5,4 @@ npx --package=signify-ts ts-node --esm client.ts
 
 read -n 1 -r -p "Press any key to create endpoints for multisig AID..."
 
-npx --package=signify-ts ts-node make_endroles.ts
+npx --package=signify-ts ts-node --esm make_endroles.ts

--- a/examples/scripts/package-lock.json
+++ b/examples/scripts/package-lock.json
@@ -12,6 +12,7 @@
         "signify-ts": "file:../../"
       },
       "devDependencies": {
+        "@types/prompt-sync": "^4.2.0",
         "@typescript-eslint/eslint-plugin": "^5.57.1",
         "@typescript-eslint/parser": "^5.57.1",
         "eslint": "^8.38.0",
@@ -197,6 +198,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "node_modules/@types/prompt-sync": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prompt-sync/-/prompt-sync-4.2.0.tgz",
+      "integrity": "sha512-5RPQYDT7MNkt+vq6xp58tSPx4THANyQcBSaw3Ni+KV7MUAgvUUbmCsQmcPVrcc8dwuURSPixz2qTJdJF6ABSKw==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -1788,6 +1795,12 @@
       "version": "7.0.12",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
+      "dev": true
+    },
+    "@types/prompt-sync": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/prompt-sync/-/prompt-sync-4.2.0.tgz",
+      "integrity": "sha512-5RPQYDT7MNkt+vq6xp58tSPx4THANyQcBSaw3Ni+KV7MUAgvUUbmCsQmcPVrcc8dwuURSPixz2qTJdJF6ABSKw==",
       "dev": true
     },
     "@types/semver": {

--- a/examples/scripts/package.json
+++ b/examples/scripts/package.json
@@ -9,6 +9,7 @@
     "signify-ts": "file:../../"
   },
   "devDependencies": {
+    "@types/prompt-sync": "^4.2.0",
     "@typescript-eslint/eslint-plugin": "^5.57.1",
     "@typescript-eslint/parser": "^5.57.1",
     "eslint": "^8.38.0",

--- a/examples/scripts/package.json
+++ b/examples/scripts/package.json
@@ -1,5 +1,6 @@
 {
   "name": "signify-scripts-ts",
+  "type": "module",
   "private": true,
   "version": "0.0.0",
   "scripts": {},

--- a/examples/scripts/tsconfig.node.json
+++ b/examples/scripts/tsconfig.node.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "composite": true,
     "skipLibCheck": true,
+    "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION
I think there's an anti-pattern in the integration tests in singify-ts/examples 

All of the .ts files start with this declaration
`let signify: any;`

This effectively disables any type checking by the typescript compiler, VS Code and other tools

This pull request is a suggestion how to fix this. If this pattern is acceptable then the other scripts should be fixed as well.