### PR TITLE
Multisig grant and admit messages and fixes in seqner

### DIFF
--- a/examples/integration-scripts/multisig.ts
+++ b/examples/integration-scripts/multisig.ts
@@ -427,9 +427,7 @@ async function run() {
 
     // Check for completion
     op1 = await waitForOp(client1, op1);
-
     op2 = await waitForOp(client2, op2);
-
     op3 = await waitForOp(client3, op3);
     console.log(`End role authorization for agent ${eid1}completed!`);
 
@@ -555,172 +553,172 @@ async function run() {
     op3 = await waitForOp(client3, op3);
     console.log('Multisig interaction completed!');
 
-    // // Members agree out of band to rotate keys
-    // console.log('Members agree out of band to rotate keys');
-    // icpResult1 = await client1.identifiers().rotate('member1');
-    // op1 = await icpResult1.op();
-    // op1 = await waitForOp(client1, op1);
-    // aid1 = await client1.identifiers().get('member1');
+    // Members agree out of band to rotate keys
+    console.log('Members agree out of band to rotate keys');
+    icpResult1 = await client1.identifiers().rotate('member1');
+    op1 = await icpResult1.op();
+    op1 = await waitForOp(client1, op1);
+    aid1 = await client1.identifiers().get('member1');
 
-    // console.log('Member1 rotated keys');
-    // icpResult2 = await client2.identifiers().rotate('member2');
-    // op2 = await icpResult2.op();
-    // op2 = await waitForOp(client2, op2);
-    // aid2 = await client2.identifiers().get('member2');
-    // console.log('Member2 rotated keys');
-    // icpResult3 = await client3.identifiers().rotate('member3');
-    // op3 = await icpResult3.op();
-    // op3 = await waitForOp(client3, op3);
-    // aid3 = await client3.identifiers().get('member3');
-    // console.log('Member3 rotated keys');
+    console.log('Member1 rotated keys');
+    icpResult2 = await client2.identifiers().rotate('member2');
+    op2 = await icpResult2.op();
+    op2 = await waitForOp(client2, op2);
+    aid2 = await client2.identifiers().get('member2');
+    console.log('Member2 rotated keys');
+    icpResult3 = await client3.identifiers().rotate('member3');
+    op3 = await icpResult3.op();
+    op3 = await waitForOp(client3, op3);
+    aid3 = await client3.identifiers().get('member3');
+    console.log('Member3 rotated keys');
 
-    // // Update new key states
-    // op1 = await client1.keyStates().query(aid2.prefix, 1);
-    // op1 = await waitForOp(client1, op1);
-    // let aid2State = op1['response'];
-    // op1 = await client1.keyStates().query(aid3.prefix, 1);
-    // op1 = await waitForOp(client1, op1);
-    // let aid3State = op1['response'];
+    // Update new key states
+    op1 = await client1.keyStates().query(aid2.prefix, 1);
+    op1 = await waitForOp(client1, op1);
+    let aid2State = op1['response'];
+    op1 = await client1.keyStates().query(aid3.prefix, 1);
+    op1 = await waitForOp(client1, op1);
+    let aid3State = op1['response'];
 
-    // op2 = await client2.keyStates().query(aid3.prefix, 1);
-    // op2 = await waitForOp(client2, op2);
-    // op2 = await client2.keyStates().query(aid1.prefix, 1);
-    // op2 = await waitForOp(client2, op2);
-    // let aid1State = op2['response'];
+    op2 = await client2.keyStates().query(aid3.prefix, 1);
+    op2 = await waitForOp(client2, op2);
+    op2 = await client2.keyStates().query(aid1.prefix, 1);
+    op2 = await waitForOp(client2, op2);
+    let aid1State = op2['response'];
 
-    // op3 = await client3.keyStates().query(aid1.prefix, 1);
-    // op3 = await waitForOp(client3, op3);
-    // op3 = await client3.keyStates().query(aid2.prefix, 1);
-    // op3 = await waitForOp(client3, op3);
+    op3 = await client3.keyStates().query(aid1.prefix, 1);
+    op3 = await waitForOp(client3, op3);
+    op3 = await client3.keyStates().query(aid2.prefix, 1);
+    op3 = await waitForOp(client3, op3);
 
-    // op4 = await client4.keyStates().query(aid1.prefix, 1);
-    // op4 = await waitForOp(client4, op4);
-    // op4 = await client4.keyStates().query(aid2.prefix, 1);
-    // op4 = await waitForOp(client4, op4);
-    // op4 = await client4.keyStates().query(aid3.prefix, 1);
-    // op4 = await waitForOp(client4, op4);
+    op4 = await client4.keyStates().query(aid1.prefix, 1);
+    op4 = await waitForOp(client4, op4);
+    op4 = await client4.keyStates().query(aid2.prefix, 1);
+    op4 = await waitForOp(client4, op4);
+    op4 = await client4.keyStates().query(aid3.prefix, 1);
+    op4 = await waitForOp(client4, op4);
     
-    // rstates = [aid1State, aid2State, aid3State];
-    // states = rstates;
+    rstates = [aid1State, aid2State, aid3State];
+    states = rstates;
 
-    // // Multisig Rotation
+    // Multisig Rotation
 
-    // // Member1 initiates a rotation event
-    // eventResponse1 = await client1
-    //     .identifiers()
-    //     .rotate('multisig', { states: states, rstates: rstates });
-    // op1 = await eventResponse1.op();
-    // serder = eventResponse1.serder;
-    // sigs = eventResponse1.sigs;
-    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    // Member1 initiates a rotation event
+    eventResponse1 = await client1
+        .identifiers()
+        .rotate('multisig', { states: states, rstates: rstates });
+    op1 = await eventResponse1.op();
+    serder = eventResponse1.serder;
+    sigs = eventResponse1.sigs;
+    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    // ims = signify.d(signify.messagize(serder, sigers));
-    // atc = ims.substring(serder.size);
-    // let rembeds = {
-    //     rot: [serder, atc],
-    // };
+    ims = signify.d(signify.messagize(serder, sigers));
+    atc = ims.substring(serder.size);
+    let rembeds = {
+        rot: [serder, atc],
+    };
 
-    // smids = states.map((state) => state['i']);
-    // recp = [aid2State, aid3State].map((state) => state['i']);
+    smids = states.map((state) => state['i']);
+    recp = [aid2State, aid3State].map((state) => state['i']);
 
-    // await client1
-    //     .exchanges()
-    //     .send(
-    //         'member1',
-    //         'multisig',
-    //         aid1,
-    //         '/multisig/rot',
-    //         { gid: serder.pre, smids: smids, rmids: smids },
-    //         rembeds,
-    //         recp
-    //     );
-    // console.log(
-    //     'Member1 initiates rotation event, waiting for others to join...'
-    // );
+    await client1
+        .exchanges()
+        .send(
+            'member1',
+            'multisig',
+            aid1,
+            '/multisig/rot',
+            { gid: serder.pre, smids: smids, rmids: smids },
+            rembeds,
+            recp
+        );
+    console.log(
+        'Member1 initiates rotation event, waiting for others to join...'
+    );
 
-    // // Member2 check for notifications and join the rotation event
-    // msgSaid = await waitForMessage(client2, '/multisig/rot');
-    // console.log('Member2 received exchange message to join the rotation event');
+    // Member2 check for notifications and join the rotation event
+    msgSaid = await waitForMessage(client2, '/multisig/rot');
+    console.log('Member2 received exchange message to join the rotation event');
 
-    // await new Promise((resolve) => setTimeout(resolve, 5000));
-    // res = await client2.groups().getRequest(msgSaid);
-    // exn = res[0].exn;
+    await new Promise((resolve) => setTimeout(resolve, 5000));
+    res = await client2.groups().getRequest(msgSaid);
+    exn = res[0].exn;
 
-    // icpResult2 = await client2
-    //     .identifiers()
-    //     .rotate('multisig', { states: states, rstates: rstates });
-    // op2 = await icpResult2.op();
-    // serder = icpResult2.serder;
-    // sigs = icpResult2.sigs;
-    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    icpResult2 = await client2
+        .identifiers()
+        .rotate('multisig', { states: states, rstates: rstates });
+    op2 = await icpResult2.op();
+    serder = icpResult2.serder;
+    sigs = icpResult2.sigs;
+    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    // ims = signify.d(signify.messagize(serder, sigers));
-    // atc = ims.substring(serder.size);
-    // rembeds = {
-    //     rot: [serder, atc],
-    // };
+    ims = signify.d(signify.messagize(serder, sigers));
+    atc = ims.substring(serder.size);
+    rembeds = {
+        rot: [serder, atc],
+    };
 
-    // smids = exn.a.smids;
-    // recp = [aid1State, aid3State].map((state) => state['i']);
+    smids = exn.a.smids;
+    recp = [aid1State, aid3State].map((state) => state['i']);
 
-    // await client2
-    //     .exchanges()
-    //     .send(
-    //         'member2',
-    //         'multisig',
-    //         aid2,
-    //         '/multisig/ixn',
-    //         { gid: serder.pre, smids: smids, rmids: smids },
-    //         rembeds,
-    //         recp
-    //     );
-    // console.log('Member2 joins rotation event, waiting for others...');
+    await client2
+        .exchanges()
+        .send(
+            'member2',
+            'multisig',
+            aid2,
+            '/multisig/ixn',
+            { gid: serder.pre, smids: smids, rmids: smids },
+            rembeds,
+            recp
+        );
+    console.log('Member2 joins rotation event, waiting for others...');
 
-    // // Member3 check for notifications and join the rotation event
-    // msgSaid = await waitForMessage(client3, '/multisig/rot');
-    // console.log('Member3 received exchange message to join the rotation event');
-    // res = await client3.groups().getRequest(msgSaid);
-    // exn = res[0].exn;
+    // Member3 check for notifications and join the rotation event
+    msgSaid = await waitForMessage(client3, '/multisig/rot');
+    console.log('Member3 received exchange message to join the rotation event');
+    res = await client3.groups().getRequest(msgSaid);
+    exn = res[0].exn;
 
-    // icpResult3 = await client3
-    //     .identifiers()
-    //     .rotate('multisig', { states: states, rstates: rstates });
-    // op3 = await icpResult3.op();
-    // serder = icpResult3.serder;
-    // sigs = icpResult3.sigs;
-    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    icpResult3 = await client3
+        .identifiers()
+        .rotate('multisig', { states: states, rstates: rstates });
+    op3 = await icpResult3.op();
+    serder = icpResult3.serder;
+    sigs = icpResult3.sigs;
+    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    // ims = signify.d(signify.messagize(serder, sigers));
-    // atc = ims.substring(serder.size);
-    // rembeds = {
-    //     rot: [serder, atc],
-    // };
+    ims = signify.d(signify.messagize(serder, sigers));
+    atc = ims.substring(serder.size);
+    rembeds = {
+        rot: [serder, atc],
+    };
 
-    // smids = exn.a.smids;
-    // recp = [aid1State, aid2State].map((state) => state['i']);
+    smids = exn.a.smids;
+    recp = [aid1State, aid2State].map((state) => state['i']);
 
-    // await client3
-    //     .exchanges()
-    //     .send(
-    //         'member3',
-    //         'multisig',
-    //         aid3,
-    //         '/multisig/ixn',
-    //         { gid: serder.pre, smids: smids, rmids: smids },
-    //         rembeds,
-    //         recp
-    //     );
-    // console.log('Member3 joins rotation event, waiting for others...');
+    await client3
+        .exchanges()
+        .send(
+            'member3',
+            'multisig',
+            aid3,
+            '/multisig/ixn',
+            { gid: serder.pre, smids: smids, rmids: smids },
+            rembeds,
+            recp
+        );
+    console.log('Member3 joins rotation event, waiting for others...');
 
-    // // Check for completion
-    // op1 = await waitForOp(client1, op1);
-    // op2 = await waitForOp(client2, op2);
-    // op3 = await waitForOp(client3, op3);
-    // console.log('Multisig rotation completed!');
+    // Check for completion
+    op1 = await waitForOp(client1, op1);
+    op2 = await waitForOp(client2, op2);
+    op3 = await waitForOp(client3, op3);
+    console.log('Multisig rotation completed!');
 
-    // hab = await client1.identifiers().get('multisig');
-    // aid = hab['prefix'];
-
+    hab = await client1.identifiers().get('multisig');
+    aid = hab['prefix'];
+    
     // Multisig Registry creation
     aid1 = await client1.identifiers().get('member1');
     aid2 = await client2.identifiers().get('member2');
@@ -1010,6 +1008,16 @@ async function run() {
 
     let m = await client1.identifiers().get('multisig');
 
+    // Update states
+    op1 = await client1.keyStates().query(m.prefix, 4);
+    op1 = await waitForOp(client1, op1);
+    op2 = await client2.keyStates().query(m.prefix, 4);
+    op2 = await waitForOp(client2, op2);
+    op3 = await client3.keyStates().query(m.prefix, 4);
+    op3 = await waitForOp(client3, op3);
+    op4 = await client4.keyStates().query(m.prefix, 4);
+    op4 = await waitForOp(client4, op4);
+
     // IPEX grant message
     console.log('Starting grant message');
     stamp = new Date().toISOString().replace('Z', '000+00:00');
@@ -1041,7 +1049,6 @@ async function run() {
     );
     atc = gims.substring(grant.size);
     atc += end;
-
     let gembeds: any = {
         exn: [grant, atc],
     };
@@ -1151,13 +1158,6 @@ async function run() {
         );
 
     console.log('Member3 joined grant message, waiting for others to join...');
-
-
-    // // Update latest key states from multisig
-
-
-    // op4 = await client4.keyStates().query(m.prefix, 4);
-    // op4 = await waitForOp(client4, op4);
 
     msgSaid = await waitForMessage(client4, '/exn/ipex/grant');
     console.log('Holder received exchange message with the grant message');

--- a/examples/integration-scripts/multisig.ts
+++ b/examples/integration-scripts/multisig.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import signify, { Serder } from 'signify-ts';
+import { SignifyClient } from '../../dist';
 
 const url = 'http://127.0.0.1:3901';
 const boot_url = 'http://127.0.0.1:3903';
@@ -8,155 +9,68 @@ await run();
 
 async function run() {
     await signify.ready();
-    // Boot three clients
-    const bran1 = signify.randomPasscode();
-    const bran2 = signify.randomPasscode();
-    const bran3 = signify.randomPasscode();
-    const client1 = new signify.SignifyClient(
-        url,
-        bran1,
-        signify.Tier.low,
-        boot_url
-    );
-    const client2 = new signify.SignifyClient(
-        url,
-        bran2,
-        signify.Tier.low,
-        boot_url
-    );
-    const client3 = new signify.SignifyClient(
-        url,
-        bran3,
-        signify.Tier.low,
-        boot_url
-    );
-    await client1.boot();
-    await client2.boot();
-    await client3.boot();
-    await client1.connect();
-    await client2.connect();
-    await client3.connect();
-    const state1 = await client1.state();
-    const state2 = await client2.state();
-    const state3 = await client3.state();
-    console.log(
-        'Client 1 connected. Client AID:',
-        state1.controller.state.i,
-        'Agent AID: ',
-        state1.agent.i
-    );
-    console.log(
-        'Client 2 connected. Client AID:',
-        state2.controller.state.i,
-        'Agent AID: ',
-        state2.agent.i
-    );
-    console.log(
-        'Client 3 connected. Client AID:',
-        state3.controller.state.i,
-        'Agent AID: ',
-        state3.agent.i
-    );
+    // Boot Four clients
+    const client1 = await bootClient();
+    const client2 = await bootClient();
+    const client3 = await bootClient();
+    const client4 = await bootClient();
 
-    // Create three identifiers, one for each client
-    let icpResult1 = await client1.identifiers().create('member1', {
-        toad: 3,
-        wits: [
-            'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
-            'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
-            'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
-        ],
-    });
-    let op1 = await icpResult1.op();
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid1 = await client1.identifiers().get('member1');
-    await client1
-        .identifiers()
-        .addEndRole('member1', 'agent', client1!.agent!.pre);
-    console.log("Member1's AID:", aid1.prefix);
-
-    let icpResult2 = await client2.identifiers().create('member2', {
-        toad: 3,
-        wits: [
-            'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
-            'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
-            'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
-        ],
-    });
-    let op2 = await icpResult2.op();
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid2 = await client2.identifiers().get('member2');
-    await client2
-        .identifiers()
-        .addEndRole('member2', 'agent', client2!.agent!.pre);
-    console.log("Member2's AID:", aid2.prefix);
-
-    let icpResult3 = await client3.identifiers().create('member3', {
-        toad: 3,
-        wits: [
-            'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
-            'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
-            'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
-        ],
-    });
-    let op3 = await icpResult3.op();
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid3 = await client3.identifiers().get('member3');
-    await client3
-        .identifiers()
-        .addEndRole('member3', 'agent', client3!.agent!.pre);
-    console.log("Member3's AID:", aid3.prefix);
+    // Create four identifiers, one for each client
+    let aid1 = await createAID(client1, 'member1');
+    let aid2 = await createAID(client2, 'member2');
+    let aid3 = await createAID(client3, 'member3');
+    let aid4 = await createAID(client4, 'holder');
 
     // Exchange OOBIs
+    let schemaSAID = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao';
+    let schemaOobi = 'http://127.0.0.1:7723/oobi/' + schemaSAID;
     console.log('Resolving OOBIs');
     let oobi1 = await client1.oobis().get('member1', 'agent');
     let oobi2 = await client2.oobis().get('member2', 'agent');
     let oobi3 = await client3.oobis().get('member3', 'agent');
+    let oobi4 = await client4.oobis().get('holder', 'agent');
 
-    op1 = await client1.oobis().resolve(oobi2.oobis[0], 'member2');
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    let op1 = await client1.oobis().resolve(oobi2.oobis[0], 'member2');
+    op1 = await waitForOp(client1, op1);
     op1 = await client1.oobis().resolve(oobi3.oobis[0], 'member3');
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    console.log('Member1 resolved 2 OOBIs');
+    op1 = await waitForOp(client1, op1);
+    op1 = await client1.oobis().resolve(schemaOobi, 'schema');
+    op1 = await waitForOp(client1, op1);
+    op1 = await client1.oobis().resolve(oobi4.oobis[0], 'holder');
+    op1 = await waitForOp(client1, op1);
+    console.log('Member1 resolved 4 OOBIs');
 
-    op2 = await client2.oobis().resolve(oobi1.oobis[0], 'member1');
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    let op2 = await client2.oobis().resolve(oobi1.oobis[0], 'member1');
+    op2 = await waitForOp(client2, op2);
     op2 = await client2.oobis().resolve(oobi3.oobis[0], 'member3');
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    console.log('Member2 resolved 2 OOBIs');
+    op2 = await waitForOp(client2, op2);
+    op2 = await client2.oobis().resolve(schemaOobi, 'schema');
+    op2 = await waitForOp(client2, op2);
+    op2 = await client2.oobis().resolve(oobi4.oobis[0], 'holder');
+    op2 = await waitForOp(client2, op2);
+    console.log('Member2 resolved 4 OOBIs');
 
-    op3 = await client3.oobis().resolve(oobi1.oobis[0], 'member1');
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    let op3 = await client3.oobis().resolve(oobi1.oobis[0], 'member1');
+    op3 = await waitForOp(client3, op3);
     op3 = await client3.oobis().resolve(oobi2.oobis[0], 'member2');
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    console.log('Member3 resolved 2 OOBIs');
+    op3 = await waitForOp(client3, op3);
+    op3 = await client3.oobis().resolve(schemaOobi, 'schema');
+    op3 = await waitForOp(client3, op3);
+    op3 = await client3.oobis().resolve(oobi4.oobis[0], 'holder');
+    op3 = await waitForOp(client3, op3);
+    console.log('Member3 resolved 4 OOBIs');
+
+    let op4 = await client4.oobis().resolve(oobi1.oobis[0], 'member1');
+    op4 = await waitForOp(client4, op4);
+    op4 = await client4.oobis().resolve(oobi2.oobis[0], 'member2');
+    op4 = await waitForOp(client4, op4);
+    op4 = await client4.oobis().resolve(oobi3.oobis[0], 'member3');
+    op4 = await waitForOp(client4, op4);
+
+    op4 = await client4.oobis().resolve(schemaOobi, 'schema');
+    op4 = await waitForOp(client4, op4);
+
+    console.log('Holder resolved 4 OOBIs');
 
     // First member challenge the other members with a random list of words
     // List of words should be passed to the other members out of band
@@ -171,10 +85,7 @@ async function run() {
     console.log('Member3 responded challenge with signed words');
 
     op1 = await client1.challenges().verify('member1', aid2.prefix, words);
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
     console.log('Member1 verified challenge response from member2');
     let exnwords = new Serder(op1.response.exn);
     op1 = await client1
@@ -183,10 +94,7 @@ async function run() {
     console.log('Member1 marked challenge response as accepted');
 
     op1 = await client1.challenges().verify('member1', aid3.prefix, words);
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
     console.log('Member1 verified challenge response from member3');
     exnwords = new Serder(op1.response.exn);
     op1 = await client1
@@ -197,7 +105,7 @@ async function run() {
     // First member start the creation of a multisig identifier
     let rstates = [aid1['state'], aid2['state'], aid3['state']];
     let states = rstates;
-    icpResult1 = await client1.identifiers().create('multisig', {
+    let icpResult1 = await client1.identifiers().create('multisig', {
         algo: signify.Algos.group,
         mhab: aid1,
         isith: 3,
@@ -240,26 +148,15 @@ async function run() {
     console.log('Member1 initiated multisig, waiting for others to join...');
 
     // Second member check notifications and join the multisig
-    let msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client2.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/icp') {
-                msgSaid = notif.a.d;
-                await client2.notifications().mark(notif.i);
-                console.log(
-                    'Member2 received exchange message to join multisig'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+
+    let msgSaid = await waitForMessage(client2, '/multisig/icp');
+    console.log('Member2 received exchange message to join multisig');
 
     let res = await client2.groups().getRequest(msgSaid);
     let exn = res[0].exn;
     let icp = exn.e.icp;
 
-    icpResult2 = await client2.identifiers().create('multisig', {
+    let icpResult2 = await client2.identifiers().create('multisig', {
         algo: signify.Algos.group,
         mhab: aid2,
         isith: icp.kt,
@@ -297,25 +194,13 @@ async function run() {
     console.log('Member2 joined multisig, waiting for others...');
 
     // Third member check notifications and join the multisig
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client3.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/icp') {
-                msgSaid = notif.a.d;
-                await client3.notifications().mark(notif.i);
-                console.log(
-                    'Member3 received exchange message to join multisig'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client3, '/multisig/icp');
+    console.log('Member3 received exchange message to join multisig');
 
     res = await client3.groups().getRequest(msgSaid);
     exn = res[0].exn;
     icp = exn.e.icp;
-    icpResult3 = await client3.identifiers().create('multisig', {
+    let icpResult3 = await client3.identifiers().create('multisig', {
         algo: signify.Algos.group,
         mhab: aid3,
         isith: icp.kt,
@@ -353,18 +238,9 @@ async function run() {
     console.log('Member3 joined, multisig waiting for others...');
 
     // Check for completion
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
+    op2 = await waitForOp(client2, op2);
+    op3 = await waitForOp(client3, op3);
     console.log('Multisig created!');
     const identifiers1 = await client1.identifiers().list();
     assert.equal(identifiers1.aids.length, 2);
@@ -459,20 +335,8 @@ async function run() {
     );
 
     //Member2 check for notifications and join the authorization
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client2.notifications().list(1);
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/rpy') {
-                msgSaid = notif.a.d;
-                await client2.notifications().mark(notif.i);
-                console.log(
-                    'Member2 received exchange message to join the end role authorization'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client2, '/multisig/rpy');
+    console.log('Member2 received exchange message to join the end role authorization');
     res = await client2.groups().getRequest(msgSaid);
     exn = res[0].exn;
     // stamp, eid and role are provided in the exn message
@@ -517,20 +381,8 @@ async function run() {
     );
 
     //Member3 check for notifications and join the authorization
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client3.notifications().list(1);
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/rpy') {
-                msgSaid = notif.a.d;
-                await client3.notifications().mark(notif.i);
-                console.log(
-                    'Member3 received exchange message to join the end role authorization'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client3, '/multisig/rpy');
+    console.log('Member3 received exchange message to join the end role authorization');
     res = await client3.groups().getRequest(msgSaid);
     exn = res[0].exn;
     rpystamp = exn.e.rpy.dt;
@@ -574,26 +426,27 @@ async function run() {
     );
 
     // Check for completion
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
 
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op2 = await waitForOp(client2, op2);
 
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op3 = await waitForOp(client3, op3);
     console.log(`End role authorization for agent ${eid1}completed!`);
+
+    // Holder resolve multisig OOBI
+    let oobimultisig = await client1.oobis().get('multisig', 'agent');
+    op4 = await client4.oobis().resolve(oobimultisig.oobis[0], 'multisig');
+    op4 = await waitForOp(client4, op4);
+    console.log(`Holder resolved multisig OOBI`);
 
     // MultiSig Interaction
 
     // Member1 initiates an interaction event
-    let data = { i: 'EE77q3_zWb5ojgJr-R1vzsL5yiL4Nzm-bfSOQzQl02dy' };
+    let data = {
+        i: 'EBgew7O4yp8SBle0FU-wwN3GtnaroI0BQfBGAj33QiIG',
+        s: '0',
+        d: 'EBgew7O4yp8SBle0FU-wwN3GtnaroI0BQfBGAj33QiIG'
+      };
     let eventResponse1 = await client1.identifiers().interact('multisig', data);
     op1 = await eventResponse1.op();
     serder = eventResponse1.serder;
@@ -625,20 +478,8 @@ async function run() {
     );
 
     // Member2 check for notifications and join the interaction event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client2.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/ixn') {
-                msgSaid = notif.a.d;
-                await client2.notifications().mark(notif.i);
-                console.log(
-                    'Member2 received exchange message to join the interaction event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client2, '/multisig/ixn');
+    console.log('Member2 received exchange message to join the interaction event');
     res = await client2.groups().getRequest(msgSaid);
     exn = res[0].exn;
     let ixn = exn.e.ixn;
@@ -673,20 +514,8 @@ async function run() {
     console.log('Member2 joins interaction event, waiting for others...');
 
     // Member3 check for notifications and join the interaction event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client3.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/ixn') {
-                msgSaid = notif.a.d;
-                await client3.notifications().mark(notif.i);
-                console.log(
-                    'Member3 received exchange message to join the interaction event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client3, '/multisig/ixn');
+    console.log('Member3 received exchange message to join the interaction event');
     res = await client3.groups().getRequest(msgSaid);
     exn = res[0].exn;
     ixn = exn.e.ixn;
@@ -721,247 +550,192 @@ async function run() {
     console.log('Member3 joins interaction event, waiting for others...');
 
     // Check for completion
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
+    op2 = await waitForOp(client2, op2);
+    op3 = await waitForOp(client3, op3);
     console.log('Multisig interaction completed!');
 
-    // Members agree out of band to rotate keys
-    console.log('Members agree out of band to rotate keys');
-    icpResult1 = await client1.identifiers().rotate('member1');
-    op1 = await icpResult1.op();
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    aid1 = await client1.identifiers().get('member1');
+    // // Members agree out of band to rotate keys
+    // console.log('Members agree out of band to rotate keys');
+    // icpResult1 = await client1.identifiers().rotate('member1');
+    // op1 = await icpResult1.op();
+    // op1 = await waitForOp(client1, op1);
+    // aid1 = await client1.identifiers().get('member1');
 
-    console.log('Member1 rotated keys');
-    icpResult2 = await client2.identifiers().rotate('member2');
-    op2 = await icpResult2.op();
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    aid2 = await client2.identifiers().get('member2');
-    console.log('Member2 rotated keys');
-    icpResult3 = await client3.identifiers().rotate('member3');
-    op3 = await icpResult3.op();
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    aid3 = await client3.identifiers().get('member3');
-    console.log('Member3 rotated keys');
+    // console.log('Member1 rotated keys');
+    // icpResult2 = await client2.identifiers().rotate('member2');
+    // op2 = await icpResult2.op();
+    // op2 = await waitForOp(client2, op2);
+    // aid2 = await client2.identifiers().get('member2');
+    // console.log('Member2 rotated keys');
+    // icpResult3 = await client3.identifiers().rotate('member3');
+    // op3 = await icpResult3.op();
+    // op3 = await waitForOp(client3, op3);
+    // aid3 = await client3.identifiers().get('member3');
+    // console.log('Member3 rotated keys');
 
-    // Update new key states
-    op1 = await client1.keyStates().query(aid2.prefix, 1);
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid2State = op1['response'];
-    op1 = await client1.keyStates().query(aid3.prefix, 1);
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid3State = op1['response'];
+    // // Update new key states
+    // op1 = await client1.keyStates().query(aid2.prefix, 1);
+    // op1 = await waitForOp(client1, op1);
+    // let aid2State = op1['response'];
+    // op1 = await client1.keyStates().query(aid3.prefix, 1);
+    // op1 = await waitForOp(client1, op1);
+    // let aid3State = op1['response'];
 
-    op2 = await client2.keyStates().query(aid3.prefix, 1);
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    op2 = await client2.keyStates().query(aid1.prefix, 1);
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    let aid1State = op2['response'];
+    // op2 = await client2.keyStates().query(aid3.prefix, 1);
+    // op2 = await waitForOp(client2, op2);
+    // op2 = await client2.keyStates().query(aid1.prefix, 1);
+    // op2 = await waitForOp(client2, op2);
+    // let aid1State = op2['response'];
 
-    op3 = await client3.keyStates().query(aid1.prefix, 1);
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    op3 = await client3.keyStates().query(aid2.prefix, 1);
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    // op3 = await client3.keyStates().query(aid1.prefix, 1);
+    // op3 = await waitForOp(client3, op3);
+    // op3 = await client3.keyStates().query(aid2.prefix, 1);
+    // op3 = await waitForOp(client3, op3);
 
-    rstates = [aid1State, aid2State, aid3State];
-    states = rstates;
+    // op4 = await client4.keyStates().query(aid1.prefix, 1);
+    // op4 = await waitForOp(client4, op4);
+    // op4 = await client4.keyStates().query(aid2.prefix, 1);
+    // op4 = await waitForOp(client4, op4);
+    // op4 = await client4.keyStates().query(aid3.prefix, 1);
+    // op4 = await waitForOp(client4, op4);
+    
+    // rstates = [aid1State, aid2State, aid3State];
+    // states = rstates;
 
-    // Multisig Rotation
+    // // Multisig Rotation
 
-    // Member1 initiates a rotation event
-    eventResponse1 = await client1
-        .identifiers()
-        .rotate('multisig', { states: states, rstates: rstates });
-    op1 = await eventResponse1.op();
-    serder = eventResponse1.serder;
-    sigs = eventResponse1.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    // // Member1 initiates a rotation event
+    // eventResponse1 = await client1
+    //     .identifiers()
+    //     .rotate('multisig', { states: states, rstates: rstates });
+    // op1 = await eventResponse1.op();
+    // serder = eventResponse1.serder;
+    // sigs = eventResponse1.sigs;
+    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    ims = signify.d(signify.messagize(serder, sigers));
-    atc = ims.substring(serder.size);
-    let rembeds = {
-        rot: [serder, atc],
-    };
+    // ims = signify.d(signify.messagize(serder, sigers));
+    // atc = ims.substring(serder.size);
+    // let rembeds = {
+    //     rot: [serder, atc],
+    // };
 
-    smids = states.map((state) => state['i']);
-    recp = [aid2State, aid3State].map((state) => state['i']);
+    // smids = states.map((state) => state['i']);
+    // recp = [aid2State, aid3State].map((state) => state['i']);
 
-    await client1
-        .exchanges()
-        .send(
-            'member1',
-            'multisig',
-            aid1,
-            '/multisig/rot',
-            { gid: serder.pre, smids: smids, rmids: smids },
-            rembeds,
-            recp
-        );
-    console.log(
-        'Member1 initiates rotation event, waiting for others to join...'
-    );
+    // await client1
+    //     .exchanges()
+    //     .send(
+    //         'member1',
+    //         'multisig',
+    //         aid1,
+    //         '/multisig/rot',
+    //         { gid: serder.pre, smids: smids, rmids: smids },
+    //         rembeds,
+    //         recp
+    //     );
+    // console.log(
+    //     'Member1 initiates rotation event, waiting for others to join...'
+    // );
 
-    // Member2 check for notifications and join the rotation event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client2.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/rot') {
-                msgSaid = notif.a.d;
-                await client2.notifications().mark(notif.i);
-                console.log(
-                    'Member2 received exchange message to join the rotation event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    // // Member2 check for notifications and join the rotation event
+    // msgSaid = await waitForMessage(client2, '/multisig/rot');
+    // console.log('Member2 received exchange message to join the rotation event');
 
-    await new Promise((resolve) => setTimeout(resolve, 5000));
-    res = await client2.groups().getRequest(msgSaid);
-    exn = res[0].exn;
+    // await new Promise((resolve) => setTimeout(resolve, 5000));
+    // res = await client2.groups().getRequest(msgSaid);
+    // exn = res[0].exn;
 
-    icpResult2 = await client2
-        .identifiers()
-        .rotate('multisig', { states: states, rstates: rstates });
-    op2 = await icpResult2.op();
-    serder = icpResult2.serder;
-    sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    // icpResult2 = await client2
+    //     .identifiers()
+    //     .rotate('multisig', { states: states, rstates: rstates });
+    // op2 = await icpResult2.op();
+    // serder = icpResult2.serder;
+    // sigs = icpResult2.sigs;
+    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    ims = signify.d(signify.messagize(serder, sigers));
-    atc = ims.substring(serder.size);
-    rembeds = {
-        rot: [serder, atc],
-    };
+    // ims = signify.d(signify.messagize(serder, sigers));
+    // atc = ims.substring(serder.size);
+    // rembeds = {
+    //     rot: [serder, atc],
+    // };
 
-    smids = exn.a.smids;
-    recp = [aid1State, aid3State].map((state) => state['i']);
+    // smids = exn.a.smids;
+    // recp = [aid1State, aid3State].map((state) => state['i']);
 
-    await client2
-        .exchanges()
-        .send(
-            'member2',
-            'multisig',
-            aid2,
-            '/multisig/ixn',
-            { gid: serder.pre, smids: smids, rmids: smids },
-            rembeds,
-            recp
-        );
-    console.log('Member2 joins rotation event, waiting for others...');
+    // await client2
+    //     .exchanges()
+    //     .send(
+    //         'member2',
+    //         'multisig',
+    //         aid2,
+    //         '/multisig/ixn',
+    //         { gid: serder.pre, smids: smids, rmids: smids },
+    //         rembeds,
+    //         recp
+    //     );
+    // console.log('Member2 joins rotation event, waiting for others...');
 
-    // Member3 check for notifications and join the rotation event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client3.notifications().list(1);
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/rot') {
-                msgSaid = notif.a.d;
-                await client3.notifications().mark(notif.i);
-                console.log(
-                    'Member3 received exchange message to join the rotation event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    res = await client3.groups().getRequest(msgSaid);
-    exn = res[0].exn;
+    // // Member3 check for notifications and join the rotation event
+    // msgSaid = await waitForMessage(client3, '/multisig/rot');
+    // console.log('Member3 received exchange message to join the rotation event');
+    // res = await client3.groups().getRequest(msgSaid);
+    // exn = res[0].exn;
 
-    icpResult3 = await client3
-        .identifiers()
-        .rotate('multisig', { states: states, rstates: rstates });
-    op3 = await icpResult3.op();
-    serder = icpResult3.serder;
-    sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    // icpResult3 = await client3
+    //     .identifiers()
+    //     .rotate('multisig', { states: states, rstates: rstates });
+    // op3 = await icpResult3.op();
+    // serder = icpResult3.serder;
+    // sigs = icpResult3.sigs;
+    // sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
-    ims = signify.d(signify.messagize(serder, sigers));
-    atc = ims.substring(serder.size);
-    rembeds = {
-        rot: [serder, atc],
-    };
+    // ims = signify.d(signify.messagize(serder, sigers));
+    // atc = ims.substring(serder.size);
+    // rembeds = {
+    //     rot: [serder, atc],
+    // };
 
-    smids = exn.a.smids;
-    recp = [aid1State, aid2State].map((state) => state['i']);
+    // smids = exn.a.smids;
+    // recp = [aid1State, aid2State].map((state) => state['i']);
 
-    await client3
-        .exchanges()
-        .send(
-            'member3',
-            'multisig',
-            aid3,
-            '/multisig/ixn',
-            { gid: serder.pre, smids: smids, rmids: smids },
-            rembeds,
-            recp
-        );
-    console.log('Member3 joins rotation event, waiting for others...');
+    // await client3
+    //     .exchanges()
+    //     .send(
+    //         'member3',
+    //         'multisig',
+    //         aid3,
+    //         '/multisig/ixn',
+    //         { gid: serder.pre, smids: smids, rmids: smids },
+    //         rembeds,
+    //         recp
+    //     );
+    // console.log('Member3 joins rotation event, waiting for others...');
 
-    // Check for completion
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    console.log('Multisig rotation completed!');
+    // // Check for completion
+    // op1 = await waitForOp(client1, op1);
+    // op2 = await waitForOp(client2, op2);
+    // op3 = await waitForOp(client3, op3);
+    // console.log('Multisig rotation completed!');
+
+    // hab = await client1.identifiers().get('multisig');
+    // aid = hab['prefix'];
 
     // Multisig Registry creation
+    aid1 = await client1.identifiers().get('member1');
+    aid2 = await client2.identifiers().get('member2');
+    aid3 = await client3.identifiers().get('member3');
 
     console.log('Starting multisig registry creation');
 
     let vcpRes1 = await client1.registries().create({
-        name: 'member1',
+        name: 'multisig',
         registryName: 'vLEI Registry',
         nonce: 'AHSNDV3ABI6U8OIgKaj3aky91ZpNL54I5_7-qwtC6q2s',
     });
     op1 = await vcpRes1.op();
     serder = vcpRes1.regser;
+    let regk = serder.pre;
     let anc = vcpRes1.serder;
     sigs = vcpRes1.sigs;
 
@@ -990,32 +764,19 @@ async function run() {
     console.log('Member1 initiated registry, waiting for others to join...');
 
     // Member2 check for notifications and join the create registry event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client2.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/vcp') {
-                msgSaid = notif.a.d;
-                await client2.notifications().mark(notif.i);
-                console.log(
-                    'Member2 received exchange message to join the create registry event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 5000));
+    msgSaid = await waitForMessage(client2, '/multisig/vcp');
+    console.log('Member2 received exchange message to join the create registry event');
     res = await client2.groups().getRequest(msgSaid);
     exn = res[0].exn;
 
     let vcpRes2 = await client2.registries().create({
-        name: 'member2',
+        name: 'multisig',
         registryName: 'vLEI Registry',
         nonce: 'AHSNDV3ABI6U8OIgKaj3aky91ZpNL54I5_7-qwtC6q2s',
     });
     op2 = await vcpRes2.op();
     serder = vcpRes2.regser;
+    let regk2 = serder.pre;
     anc = vcpRes2.serder;
     sigs = vcpRes2.sigs;
 
@@ -1043,34 +804,22 @@ async function run() {
     console.log('Member2 joins registry event, waiting for others...');
 
     // Member3 check for notifications and join the create registry event
-    msgSaid = '';
-    while (msgSaid == '') {
-        let notifications = await client3.notifications().list();
-        for (let notif of notifications.notes) {
-            if (notif.a.r == '/multisig/vcp') {
-                msgSaid = notif.a.d;
-                await client3.notifications().mark(notif.i);
-                console.log(
-                    'Member3 received exchange message to join the create registry event'
-                );
-            }
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    msgSaid = await waitForMessage(client3, '/multisig/vcp');
+    console.log('Member3 received exchange message to join the create registry event');
 
-    await new Promise((resolve) => setTimeout(resolve, 5000));
     res = await client3.groups().getRequest(msgSaid);
     exn = res[0].exn;
 
     let vcpRes3 = await client3.registries().create({
-        name: 'member3',
+        name: 'multisig',
         registryName: 'vLEI Registry',
         nonce: 'AHSNDV3ABI6U8OIgKaj3aky91ZpNL54I5_7-qwtC6q2s',
     });
     op3 = await vcpRes3.op();
-    serder = vcpRes2.regser;
-    anc = vcpRes2.serder;
-    sigs = vcpRes2.sigs;
+    serder = vcpRes3.regser;
+    let regk3 = serder.pre;
+    anc = vcpRes3.serder;
+    sigs = vcpRes3.sigs;
 
     sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
 
@@ -1095,19 +844,400 @@ async function run() {
         );
 
     // Done
-    while (!op1['done']) {
-        op1 = await client1.operations().get(op1.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-
-    while (!op2['done']) {
-        op2 = await client2.operations().get(op2.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-
-    while (!op3['done']) {
-        op3 = await client3.operations().get(op3.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
+    op1 = await waitForOp(client1, op1);
+    op2 = await waitForOp(client2, op2);
+    op3 = await waitForOp(client3, op3);
     console.log('Multisig create registry completed!');
+
+    //Create Credential
+    console.log('Starting multisig credential creation');
+
+    const vcdata = {
+        LEI: '5493001KJTIIGC8Y1R17',
+    };
+    let holder = aid4.prefix
+
+    let TIME = new Date().toISOString().replace('Z', '000+00:00');;
+    let credRes = await client1
+        .credentials()
+        .issue(
+            'multisig',
+            regk,
+            schemaSAID,
+            holder,
+            vcdata,
+            undefined,
+            undefined,
+            TIME
+        );
+    op1 = await credRes.op();
+
+    let acdc = new signify.Serder(credRes.acdc);
+    let iss = credRes.iserder;
+    let ianc = credRes.anc;
+    let isigs = credRes.sigs;
+    let acdcSaider = credRes.acdcSaider;
+    let issExnSaider = credRes.issExnSaider;
+
+    sigers = isigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    ims = signify.d(signify.messagize(ianc, sigers));
+    let atc1 = ims.substring(ianc.size);
+
+    let vcembeds = {
+        acdc: [acdc, ''],
+        iss: [iss, ''],
+        anc: [ianc, atc1],
+    };
+    recp = [aid2['state'], aid3['state']].map((state) => state['i']);
+    await client1
+        .exchanges()
+        .send(
+            'member1',
+            'multisig',
+            aid1,
+            '/multisig/iss',
+            { gid: aid },
+            vcembeds,
+            recp
+        );
+
+    console.log('Member1 initiated credential creation, waiting for others to join...');
+
+    // Member2 check for notifications and join the credential create  event
+    msgSaid = await waitForMessage(client2, '/multisig/iss');
+    console.log('Member2 received exchange message to join the credential create event');
+    res = await client2.groups().getRequest(msgSaid);
+    exn = res[0].exn;
+
+    let credRes2 = await client2
+        .credentials()
+        .issue(
+            'multisig',
+            regk2,
+            schemaSAID,
+            holder,
+            vcdata,
+            undefined,
+            undefined,
+            exn.e.acdc.a.dt
+        );
+
+    op2 = await credRes2.op();
+
+    acdc = new signify.Serder(credRes2.acdc);
+    iss = credRes2.iserder;
+    ianc = credRes2.anc;
+    isigs = credRes2.sigs;
+
+    sigers = isigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    ims = signify.d(signify.messagize(ianc, sigers));
+    let atc2 = ims.substring(ianc.size);
+
+    vcembeds = {
+        acdc: [acdc, ''],
+        iss: [iss, ''],
+        anc: [ianc, atc2],
+    };
+
+    recp = [aid1['state'], aid3['state']].map((state) => state['i']);
+    await client2
+        .exchanges()
+        .send(
+            'member2',
+            'multisig',
+            aid2,
+            '/multisig/iss',
+            { gid: aid },
+            vcembeds,
+            recp
+        );
+    console.log('Member2 joins credential create event, waiting for others...');
+
+    // Member3 check for notifications and join the create registry event
+    msgSaid = await waitForMessage(client3, '/multisig/iss');
+    console.log('Member3 received exchange message to join the credential create event');
+    res = await client3.groups().getRequest(msgSaid);
+    exn = res[0].exn;
+
+    let credRes3 = await client3
+        .credentials()
+        .issue(
+            'multisig',
+            regk3,
+            schemaSAID,
+            holder,
+            vcdata,
+            undefined,
+            undefined,
+            exn.e.acdc.a.dt
+        );
+
+    op3 = await credRes3.op();
+    acdc = new signify.Serder(credRes3.acdc);
+    iss = credRes3.iserder;
+    ianc = credRes3.anc;
+    isigs = credRes3.sigs;
+
+    sigers = isigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    ims = signify.d(signify.messagize(ianc, sigers));
+    let atc3 = ims.substring(ianc.size);
+
+    vcembeds = {
+        acdc: [acdc, ''],
+        iss: [iss, ''],
+        anc: [ianc, atc3],
+    };
+
+    recp = [aid1['state'], aid2['state']].map((state) => state['i']);
+    await client3
+        .exchanges()
+        .send(
+            'member3',
+            'multisig',
+            aid3,
+            '/multisig/iss',
+            { gid: aid },
+            vcembeds,
+            recp
+        );
+    console.log('Member3 joins credential create event, waiting for others...');
+
+    // Check completion
+    op1 = await waitForOp(client1, op1);
+    op2 = await waitForOp(client2, op2);
+    op3 = await waitForOp(client3, op3);
+    console.log('Multisig create credential completed!');
+
+    let m = await client1.identifiers().get('multisig');
+
+    // IPEX grant message
+    console.log('Starting grant message');
+    stamp = new Date().toISOString().replace('Z', '000+00:00');
+
+    let [grant, gsigs, end] = await client1
+        .ipex()
+        .grant('multisig', holder, '', acdc, acdcSaider, iss, issExnSaider, ianc, atc1, undefined, stamp);
+
+    await client1
+        .exchanges()
+        .sendFromEvents(
+            'multisig',
+            'credential',
+            grant,
+            gsigs,
+            end,
+            [holder]
+        );
+
+    mstate = m['state'];
+    seal = [
+        'SealEvent',
+        { i: m['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
+    ];
+    sigers = gsigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+
+    let gims = signify.d(
+        signify.messagize(grant, sigers, seal)
+    );
+    atc = gims.substring(grant.size);
+    atc += end;
+
+    let gembeds: any = {
+        exn: [grant, atc],
+    };
+    recp = [aid2['state'], aid3['state']].map((state) => state['i']);
+    await client1
+        .exchanges()
+        .send(
+            'member1',
+            'multisig',
+            aid1,
+            '/multisig/exn',
+            { gid: m['prefix'] },
+            gembeds,
+            recp
+        );
+    
+    console.log('Member1 initiated grant message, waiting for others to join...');
+
+    msgSaid = await waitForMessage(client2, '/multisig/exn');
+    console.log('Member2 received exchange message to join the grant message');
+    res = await client2.groups().getRequest(msgSaid);
+    exn = res[0].exn;
+
+    let [grant2, gsigs2, end2] = await client2
+        .ipex()
+        .grant('multisig', holder, '', acdc, acdcSaider, iss, issExnSaider, ianc, atc2, undefined, stamp);
+    
+    await client2
+        .exchanges()
+        .sendFromEvents(
+            'multisig',
+            'credential',
+            grant2,
+            gsigs2,
+            end2,
+            [holder]
+        );
+    
+    sigers = gsigs2.map((sig: any) => new signify.Siger({ qb64: sig }));
+
+    gims = signify.d(
+        signify.messagize(grant2, sigers, seal)
+    );
+    atc = gims.substring(grant2.size);
+    atc += end2;
+
+    gembeds = {
+        exn: [grant2, atc],
+    };
+    recp = [aid1['state'], aid3['state']].map((state) => state['i']);
+    await client2
+        .exchanges()
+        .send(
+            'member2',
+            'multisig',
+            aid2,
+            '/multisig/exn',
+            { gid: m['prefix'] },
+            gembeds,
+            recp
+        );
+
+    console.log('Member2 joined grant message, waiting for others to join...');
+
+    msgSaid = await waitForMessage(client3, '/multisig/exn');
+    console.log('Member3 received exchange message to join the grant message');
+    res = await client3.groups().getRequest(msgSaid);
+    exn = res[0].exn;
+
+    let [grant3, gsigs3, end3] = await client3
+        .ipex()
+        .grant('multisig', holder, '', acdc, acdcSaider, iss, issExnSaider, ianc, atc3, undefined, stamp);
+    
+    await client3
+        .exchanges()
+        .sendFromEvents(
+            'multisig',
+            'credential',
+            grant3,
+            gsigs3,
+            end3,
+            [holder]
+        );
+
+    sigers = gsigs3.map((sig: any) => new signify.Siger({ qb64: sig }));
+
+    gims = signify.d(
+        signify.messagize(grant3, sigers, seal)
+    );
+    atc = gims.substring(grant3.size);
+    atc += end3;
+
+    gembeds = {
+        exn: [grant3, atc],
+    };
+    recp = [aid1['state'], aid2['state']].map((state) => state['i']);
+    await client3
+        .exchanges()
+        .send(
+            'member3',
+            'multisig',
+            aid3,
+            '/multisig/exn',
+            { gid: m['prefix'] },
+            gembeds,
+            recp
+        );
+
+    console.log('Member3 joined grant message, waiting for others to join...');
+
+
+    // // Update latest key states from multisig
+
+
+    // op4 = await client4.keyStates().query(m.prefix, 4);
+    // op4 = await waitForOp(client4, op4);
+
+    msgSaid = await waitForMessage(client4, '/exn/ipex/grant');
+    console.log('Holder received exchange message with the grant message');
+    res = await client4.exchanges().get('holder',msgSaid);
+
+    let [admit, asigs, aend] = await client4
+        .ipex()
+        .admit('holder', '', res.exn.d);
+
+    res = await client4.ipex().submitAdmit('holder', admit, asigs, aend, [m['prefix']] );
+    
+    console.log('Holder creates and sends admit message');
+
+    msgSaid = await waitForMessage(client1, '/exn/ipex/admit');
+    console.log('Member1 received exchange message with the admit response');
+    let creds = await client4.credentials().list('holder');
+    console.log(`Holder holds ${creds.length} credential`)
+
+
+}
+
+async function waitForOp(client:SignifyClient, op:any) {
+    while (!op['done']) {
+        op = await client.operations().get(op.name);
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    return op
+}
+
+async function waitForMessage(client:SignifyClient, route:string) {
+    let msgSaid = '';
+    while (msgSaid == '') {
+        let notifications = await client.notifications().list();
+        for (let notif of notifications.notes) {
+            if (notif.a.r == route) {
+                msgSaid = notif.a.d;
+                await client.notifications().mark(notif.i);
+            }
+        }
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    return msgSaid
+    
+}
+
+async function bootClient():Promise<SignifyClient>{
+    let bran = signify.randomPasscode();
+    let client = new signify.SignifyClient(
+        url,
+        bran,
+        signify.Tier.low,
+        boot_url
+    );
+    await client.boot();
+    await client.connect();
+    let state = await client.state();
+    console.log(
+        'Client AID:',
+        state.controller.state.i,
+        'Agent AID: ',
+        state.agent.i
+    );
+    return client
+}
+
+async function createAID(client:SignifyClient, name:string){
+    let icpResult1 = await client.identifiers().create(name, {
+        toad: 3,
+        wits: [
+            'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
+            'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
+            'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
+        ],
+    });
+    let op = await icpResult1.op();
+    op = await waitForOp(client, op);
+    let aid = await client.identifiers().get(name);
+    await client
+        .identifiers()
+        .addEndRole(name, 'agent', client!.agent!.pre);
+    console.log(name, "AID:", aid.prefix);
+    return aid
 }

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -126,6 +126,22 @@ export class Exchanges {
         let res = await this.client.fetch(path, method, data);
         return await res.json();
     }
+
+
+    /**
+     * Get exn messages
+     * @async
+     * @returns {Promise<any>} A promise to the exn message
+     * @param name
+     * @param said
+     */
+    async get(name:string, said:string) {
+        let path = `/identifiers/${name}/exchanges/${said}`;
+        let method = 'GET';
+        let res = await this.client.fetch(path, method, null);
+        return await res.json();
+
+    }
 }
 
 export function exchange(

--- a/src/keri/core/eventing.ts
+++ b/src/keri/core/eventing.ts
@@ -433,7 +433,7 @@ export function messagize(
                         .qb64b
                 );
                 atc = concat(atc, new TextEncoder().encode(seal[1].i));
-                atc = concat(atc, new Seqner(seal[1].s).qb64b);
+                atc = concat(atc, new Seqner({sn: parseInt(seal[1].s)}).qb64b);
                 atc = concat(atc, new TextEncoder().encode(seal[1].d));
             } else if (seal[0] == 'SealLast') {
                 atc = concat(

--- a/src/keri/core/utils.ts
+++ b/src/keri/core/utils.ts
@@ -99,21 +99,19 @@ export function range(start: number, stop: number, step: number) {
 export function intToBytes(value: number, length: number): Uint8Array {
     const byteArray = new Uint8Array(length); // Assuming a 4-byte integer (32 bits)
 
-    for (let index = 0; index < byteArray.length; index++) {
+    for (let index = byteArray.length-1; index >= 0; index--) {
         let byte = value & 0xff;
         byteArray[index] = byte;
         value = (value - byte) / 256;
     }
-
     return byteArray;
 }
 
 export function bytesToInt(ar: Uint8Array): number {
     let value = 0;
-    for (let i = ar.length - 1; i >= 0; i--) {
+    for (let i = 0; i <ar.length; i++) {
         value = value * 256 + ar[i];
     }
-
     return value;
 }
 

--- a/test/app/exchanging.test.ts
+++ b/test/app/exchanging.test.ts
@@ -377,4 +377,25 @@ describe('exchange', () => {
         assert.equal(lastCall[0]!, url + '/identifiers/aid1/exchanges');
         assert.equal(lastCall[1]!.method, 'POST');
     });
+
+    it('Get exchange', async () => {
+        await libsodium.ready;
+        const bran = '0123456789abcdefghijk';
+        let client = new SignifyClient(url, bran, Tier.low, boot_url);
+        await client.boot();
+        await client.connect();
+        let exchanges = client.exchanges();
+        await exchanges.get(
+            'aid1',
+            'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+        );
+        let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(
+            lastCall[0]!,
+            url +
+                '/identifiers/aid1/exchanges/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+        );
+        assert.equal(lastCall[1]!.method, 'GET');
+
+    });
 });

--- a/test/core/seqner.test.ts
+++ b/test/core/seqner.test.ts
@@ -26,6 +26,7 @@ describe('Seqner', () => {
         seqner = new Seqner({ snh: '1' });
         assert.equal(seqner.sn, 1);
         assert.equal(seqner.snh, '1');
+        assert.equal(seqner.qb64, '0AAAAAAAAAAAAAAAAAAAAAAB');
 
         seqner = new Seqner({ sn: 1 });
         assert.equal(seqner.sn, 1);
@@ -34,10 +35,12 @@ describe('Seqner', () => {
         seqner = new Seqner({ sn: 16 });
         assert.equal(seqner.sn, 16);
         assert.equal(seqner.snh, '10');
+        assert.equal(seqner.qb64, '0AAAAAAAAAAAAAAAAAAAAAAQ');
 
         seqner = new Seqner({ sn: 15 });
         assert.equal(seqner.sn, 15);
         assert.equal(seqner.snh, 'f');
+        assert.equal(seqner.qb64, '0AAAAAAAAAAAAAAAAAAAAAAP');
 
         seqner = new Seqner({ snh: 'f' });
         assert.equal(seqner.sn, 15);

--- a/test/core/tholder.test.ts
+++ b/test/core/tholder.test.ts
@@ -7,7 +7,7 @@ describe('THolder', () => {
         let tholder = new Tholder({ sith: 'b' });
         assert.equal(tholder.thold, 11);
         assert.equal(tholder.size, 11);
-        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 115, 65]));
+        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 65, 76])); // b(MAAL)
         assert.equal(tholder.sith, 'b');
         assert.equal(tholder.json, '"b"');
         assert.equal(tholder.num, 11);
@@ -20,7 +20,7 @@ describe('THolder', () => {
         tholder = new Tholder({ sith: 11 });
         assert.equal(tholder.thold, 11);
         assert.equal(tholder.size, 11);
-        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 115, 65]));
+        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 65, 76])); // b(MAAL)
         assert.equal(tholder.sith, 'b');
         assert.equal(tholder.json, '"b"');
         assert.equal(tholder.num, 11);
@@ -33,7 +33,7 @@ describe('THolder', () => {
         tholder = new Tholder({ thold: 2 });
         assert.equal(tholder.thold, 2);
         assert.equal(tholder.size, 2);
-        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 73, 65]));
+        assert.deepEqual(tholder.limen, new Uint8Array([77, 65, 65, 67])); // b(MAAI)
         assert.equal(tholder.sith, '2');
         assert.equal(tholder.json, '"2"');
         assert.equal(tholder.num, 2);


### PR DESCRIPTION
This PR replaces PR #124. It adds examples on the integration script `multisig.ts` showing how to pass `grant` and `admit` messages between a multisig issuer and a single sig holder.
It also fixed a serialization error on the seqner and holder that used little endian instead of big endian. Test results were validated against tests in `keripy`