### PR TITLE
Remove name param from Credentials.list()

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -109,12 +109,11 @@ export class Credentials {
     /**
      * List credentials
      * @async
-     * @param {string} name Name or alias of the identifier
      * @param {CredentialFilter} [kargs] Optional parameters to filter the credentials
      * @returns {Promise<any>} A promise to the list of credentials
      */
-    async list(name: string, kargs: CredentialFilter = {}): Promise<any> {
-        let path = `/identifiers/${name}/credentials/query`;
+    async list(kargs: CredentialFilter = {}): Promise<any> {
+        let path = `/credentials/query`;
         let filtr = kargs.filter === undefined ? {} : kargs.filter;
         let sort = kargs.sort === undefined ? [] : kargs.sort;
         let limit = kargs.limit === undefined ? 25 : kargs.limit;

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -184,10 +184,10 @@ describe('Credentialing', () => {
             limit: 25,
             skip: 5,
         };
-        await credentials.list('aid1', kargs);
+        await credentials.list(kargs);
         let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         let lastBody = JSON.parse(lastCall[1]!.body!.toString());
-        assert.equal(lastCall[0]!, url + '/identifiers/aid1/credentials/query');
+        assert.equal(lastCall[0]!, url + '/credentials/query');
         assert.equal(lastCall[1]!.method, 'POST');
         assert.deepEqual(lastBody, kargs);
 


### PR DESCRIPTION
[This change yesterday](https://github.com/WebOfTrust/keria/commit/56c20c779cd1a93bb33fd25271e58ae802618653#diff-efec556acc809a758da25056e617702341fdc34bd639435343177e138c2e61a5L41) in KERIA removes the `/identifiers/{name}` prefix in the credentials querying endpoint. I learned from Phil the name argument was never used anyway. The proper way to select which credentials to have returned is with the filters.

Unfortunately this broke the [credential querying code](https://github.com/WebOfTrust/keria/commit/56c20c779cd1a93bb33fd25271e58ae802618653#diff-efec556acc809a758da25056e617702341fdc34bd639435343177e138c2e61a5L41) used in SignifyTS.

This PR fixes that breakage.