### PR TITLE
add join function in groups class to join multisig rotation event

### DIFF
--- a/src/keri/app/grouping.ts
+++ b/src/keri/app/grouping.ts
@@ -53,4 +53,39 @@ export class Groups {
         let res = await this.client.fetch(path, method, data);
         return await res.json();
     }
+
+    /**
+     * Join multisig group using rotation event.
+     * This can be used by participants being asked to contribute keys to a rotation event to join an existing group.
+     * @async
+     * @param {string} [name] human readable name of group AID
+     * @param {any} [rot] rotation event
+     * @param {any} [sigs] signatures
+     * @param {string} [gid] prefix
+     * @param {string[]} [smids] array of particpants
+     * @param {string[]} [rmids] array of particpants
+     * @returns {Promise<any>} A promise to the list of replay messages
+     */
+    async join(
+        name: string,
+        rot: any,
+        sigs: any, //string[],
+        gid: string,
+        smids: string[],
+        rmids: string[]
+    ): Promise<any> {
+        let path = `/identifiers/${name}/multisig/join`;
+        let method = 'POST';
+        let data = {
+            tpc: 'multisig',
+            rot: rot.ked,
+            sigs: sigs,
+            gid: gid,
+            smids: smids,
+            rmids: rmids
+        };
+        let res = await this.client.fetch(path, method, data);
+        return await res.json();
+    }
+
 }

--- a/test/app/grouping.test.ts
+++ b/test/app/grouping.test.ts
@@ -181,5 +181,10 @@ describe('Grouping', () => {
                 '/multisig/request/ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose00'
         );
         assert.equal(lastCall[1]!.method, 'GET');
+
+        await groups.join('aid1', { 'ked': {} }, ['sig'], 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose00', ['1', '2', '3'], ['a', 'b', 'c']);
+        lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(lastCall[0]!, url + '/identifiers/aid1/multisig/join');
+        assert.equal(lastCall[1]!.method, 'POST');
     });
 });


### PR DESCRIPTION
Added `join` method in group class that can be used by members to join an existing multisig using rotation event.