### PR TITLE
fix: remove name parameter from exchanges.get method

### DIFF
--- a/examples/integration-scripts/multisig.ts
+++ b/examples/integration-scripts/multisig.ts
@@ -1161,7 +1161,7 @@ async function run() {
 
     msgSaid = await waitForMessage(client4, '/exn/ipex/grant');
     console.log('Holder received exchange message with the grant message');
-    res = await client4.exchanges().get('holder',msgSaid);
+    res = await client4.exchanges().get(msgSaid);
 
     let [admit, asigs, aend] = await client4
         .ipex()

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -127,20 +127,17 @@ export class Exchanges {
         return await res.json();
     }
 
-
     /**
-     * Get exn messages
+     * Get exn message by said
      * @async
-     * @returns {Promise<any>} A promise to the exn message
-     * @param name
-     * @param said
+     * @returns A promise to the exn message
+     * @param said The said of the exn message
      */
-    async get(name:string, said:string) {
-        let path = `/identifiers/${name}/exchanges/${said}`;
-        let method = 'GET';
-        let res = await this.client.fetch(path, method, null);
+    async get(said: string): Promise<any> {
+        const path = `/exchanges/${said}`;
+        const method = 'GET';
+        const res = await this.client.fetch(path, method, null);
         return await res.json();
-
     }
 }
 

--- a/test/app/exchanging.test.ts
+++ b/test/app/exchanging.test.ts
@@ -381,21 +381,16 @@ describe('exchange', () => {
     it('Get exchange', async () => {
         await libsodium.ready;
         const bran = '0123456789abcdefghijk';
-        let client = new SignifyClient(url, bran, Tier.low, boot_url);
+        const client = new SignifyClient(url, bran, Tier.low, boot_url);
         await client.boot();
         await client.connect();
-        let exchanges = client.exchanges();
-        await exchanges.get(
-            'aid1',
-            'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
-        );
-        let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        const exchanges = client.exchanges();
+        await exchanges.get('EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao');
+        const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0]!,
-            url +
-                '/identifiers/aid1/exchanges/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+            url + '/exchanges/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
         assert.equal(lastCall[1]!.method, 'GET');
-
     });
 });


### PR DESCRIPTION
Please merge this only if you decide to merge the corresponding PR in keria https://github.com/WebOfTrust/keria/pull/128.