### PR TITLE
Simplify usage of credentials().issue() and ipex().grant()

### DIFF
--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -6,18 +6,30 @@ const boot_url = 'http://127.0.0.1:3903';
 const WAN_WITNESS_AID = 'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha';
 const WIL_WITNESS_AID = 'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM';
 const WES_WITNESS_AID = 'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX';
+const WITNESS_HOST = 'witness-demo';
+const WITNESS_OOBIS = [
+    `http://${WITNESS_HOST}:5642/oobi/${WAN_WITNESS_AID}/controller?name=Wan&tag=witness`,
+    `http://${WITNESS_HOST}:5643/oobi/${WIL_WITNESS_AID}/controller?name=Wil&tag=witness`,
+    `http://${WITNESS_HOST}:5644/oobi/${WES_WITNESS_AID}/controller?name=Wes&tag=witness`,
+];
+
 const KLI_WITNESS_DEMO_PREFIXES = [
     WAN_WITNESS_AID,
     WIL_WITNESS_AID,
     WES_WITNESS_AID,
 ];
 
+// Credential Schema discovery through credential schema OOBI resolution
+const qviSchemaSAID = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao';
+const vLEIServerHostUrl = 'http://vlei-server:7723/oobi';
+const schemaOobiUrl = `${vLEIServerHostUrl}/${qviSchemaSAID}`;
+
 // Boots an agent and connects to it, returning the connected SignifyClient
 async function bootAndConnect(
-  bran: string = signify.randomPasscode(),
-  agentUrl: string = url,
-  bootUrl: string = boot_url,
-  tier: signify.Tier = signify.Tier.low
+    bran: string = signify.randomPasscode(),
+    agentUrl: string = url,
+    bootUrl: string = boot_url,
+    tier: signify.Tier = signify.Tier.low
 ) {
     const client = new signify.SignifyClient(agentUrl, bran, tier, bootUrl);
     await client.boot();
@@ -40,8 +52,8 @@ interface Notification {
 
 // checks for notifications on a route and returns them as an array
 async function waitForNotifications(
-  client: signify.SignifyClient,
-  route: string
+    client: signify.SignifyClient,
+    route: string
 ): Promise<Notification[]> {
     const awaitedNotifications = [];
     while (true) {
@@ -58,36 +70,44 @@ async function waitForNotifications(
     return awaitedNotifications;
 }
 
-await run();
+async function resolveWitnesses(client: signify.SignifyClient) {
+    await Promise.all(
+        WITNESS_OOBIS.map((oobi) => client.oobis().resolve(oobi))
+    );
+}
 
-// main test function
-async function run() {
+test('credentials', async () => {
     await signify.ready();
     // Boot three clients one each for issuer, holder, and verifier
     const issuerClient = await bootAndConnect(signify.randomPasscode());
     const holderClient = await bootAndConnect(signify.randomPasscode());
     const verifierClient = await bootAndConnect(signify.randomPasscode());
+    await Promise.all([
+        resolveWitnesses(issuerClient),
+        resolveWitnesses(holderClient),
+        resolveWitnesses(verifierClient),
+    ]);
 
     const state1 = await issuerClient.state();
     const state2 = await holderClient.state();
     const state3 = await verifierClient.state();
     console.log(
-      'Issuer connected.\n\tHolder Controller AID:',
-      state1.controller.state.i,
-      '\n\tIssuer Agent AID: ',
-      state1.agent.i
+        'Issuer connected.\n\tHolder Controller AID:',
+        state1.controller.state.i,
+        '\n\tIssuer Agent AID: ',
+        state1.agent.i
     );
     console.log(
-      'Holder connected.\n\tHolder Controller AID:',
-      state2.controller.state.i,
-      '\n\tHolder Agent AID: ',
-      state2.agent.i
+        'Holder connected.\n\tHolder Controller AID:',
+        state2.controller.state.i,
+        '\n\tHolder Agent AID: ',
+        state2.agent.i
     );
     console.log(
-      'Verifier connected.\n\tVerifier Controller AID:',
-      state3.controller.state.i,
-      '\n\tVerifier Agent AID: ',
-      state3.agent.i
+        'Verifier connected.\n\tVerifier Controller AID:',
+        state3.controller.state.i,
+        '\n\tVerifier Agent AID: ',
+        state3.agent.i
     );
 
     const issuerAidName = 'issuer';
@@ -105,7 +125,7 @@ async function run() {
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
     const issAidResp = await issuerClient.identifiers().get(issuerAidName);
-    const issuerAID = issAidResp.prefix
+    const issuerAID = issAidResp.prefix;
     await issuerClient
         .identifiers()
         .addEndRole(issuerAidName, 'agent', issuerClient!.agent!.pre);
@@ -121,23 +141,25 @@ async function run() {
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
     const hldAidResp = await holderClient.identifiers().get(holderAidName);
-    const holderAID = hldAidResp.prefix
+    const holderAID = hldAidResp.prefix;
     await holderClient
         .identifiers()
         .addEndRole(holderAidName, 'agent', holderClient!.agent!.pre);
     console.log("Recipient's AID:", holderAID);
 
-    let verifierIcpRes = await verifierClient.identifiers().create(verifierAidName, {
-        toad: 3,
-        wits: [...KLI_WITNESS_DEMO_PREFIXES],
-    });
+    let verifierIcpRes = await verifierClient
+        .identifiers()
+        .create(verifierAidName, {
+            toad: 3,
+            wits: [...KLI_WITNESS_DEMO_PREFIXES],
+        });
     let vfyOp = await verifierIcpRes.op();
     while (!vfyOp['done']) {
         vfyOp = await verifierClient.operations().get(vfyOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
     const vfyAidResp = await verifierClient.identifiers().get(verifierAidName);
-    const verifierAID = vfyAidResp.prefix
+    const verifierAID = vfyAidResp.prefix;
     await verifierClient
         .identifiers()
         .addEndRole(verifierAidName, 'agent', verifierClient!.agent!.pre);
@@ -147,11 +169,6 @@ async function run() {
 
     // OOBIs for credential schema and agent discovery
     console.log('Resolving Schema and Agent OOBIs...');
-
-    // Credential Schema discovery through credential schema OOBI resolution
-    const qviSchemaSAID = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao';
-    const vLEIServerHostUrl = 'http://127.0.0.1:7723/oobi';
-    let schemaOobiUrl = `${vLEIServerHostUrl}/${qviSchemaSAID}`;
 
     console.log(`Resolving schema OOBIs with ${schemaOobiUrl}`);
     issOp = await issuerClient.oobis().resolve(schemaOobiUrl, 'schema');
@@ -181,15 +198,21 @@ async function run() {
     console.log('Getting Agent OOBIs for issuer, holder, and verifier');
     let issAgentOOBI = await issuerClient.oobis().get(issuerAidName, 'agent');
     let hldAgentOOBI = await holderClient.oobis().get(holderAidName, 'agent');
-    let vfyAgentOOBI = await verifierClient.oobis().get(verifierAidName, 'agent');
+    let vfyAgentOOBI = await verifierClient
+        .oobis()
+        .get(verifierAidName, 'agent');
 
     // issuer -> holder, verifier
-    issOp = await issuerClient.oobis().resolve(hldAgentOOBI.oobis[0], holderAidName);
+    issOp = await issuerClient
+        .oobis()
+        .resolve(hldAgentOOBI.oobis[0], holderAidName);
     while (!issOp['done']) {
         issOp = await issuerClient.operations().get(issOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    issOp = await issuerClient.oobis().resolve(vfyAgentOOBI.oobis[0], verifierAidName);
+    issOp = await issuerClient
+        .oobis()
+        .resolve(vfyAgentOOBI.oobis[0], verifierAidName);
     while (!issOp['done']) {
         issOp = await issuerClient.operations().get(issOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
@@ -197,12 +220,16 @@ async function run() {
     console.log('Issuer resolved 2 OOBIs: [holder, verifier]');
 
     // holder -> issuer, verifier
-    hldOp = await holderClient.oobis().resolve(issAgentOOBI.oobis[0], issuerAidName);
+    hldOp = await holderClient
+        .oobis()
+        .resolve(issAgentOOBI.oobis[0], issuerAidName);
     while (!hldOp['done']) {
         hldOp = await holderClient.operations().get(hldOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    hldOp = await holderClient.oobis().resolve(vfyAgentOOBI.oobis[0], verifierAidName);
+    hldOp = await holderClient
+        .oobis()
+        .resolve(vfyAgentOOBI.oobis[0], verifierAidName);
     while (!hldOp['done']) {
         hldOp = await holderClient.operations().get(hldOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
@@ -210,12 +237,16 @@ async function run() {
     console.log('Holder resolved 2 OOBIs: [issuer, verifier]');
 
     // verifier -> issuer, holder
-    vfyOp = await verifierClient.oobis().resolve(issAgentOOBI.oobis[0], issuerAidName);
+    vfyOp = await verifierClient
+        .oobis()
+        .resolve(issAgentOOBI.oobis[0], issuerAidName);
     while (!vfyOp['done']) {
         vfyOp = await verifierClient.operations().get(vfyOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
-    vfyOp = await verifierClient.oobis().resolve(hldAgentOOBI.oobis[0], holderAidName);
+    vfyOp = await verifierClient
+        .oobis()
+        .resolve(hldAgentOOBI.oobis[0], holderAidName);
     while (!vfyOp['done']) {
         vfyOp = await verifierClient.operations().get(vfyOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
@@ -247,10 +278,14 @@ async function run() {
     const vcdata = {
         LEI: '5493001KJTIIGC8Y1R17',
     };
-    const issResult = await issuerClient
-        .credentials()
-        .issue(issuerAidName, registry.regk, schemaSAID, holderAID, vcdata);
-    issOp = await issResult.op();
+    const issResult = await issuerClient.credentials().issue({
+        issuerName: issuerAidName,
+        registryId: registry.regk,
+        schemaId: schemaSAID,
+        recipient: holderAID,
+        data: vcdata,
+    });
+    issOp = issResult.op;
     while (!issOp['done']) {
         issOp = await issuerClient.operations().get(issOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
@@ -260,36 +295,20 @@ async function run() {
     assert.equal(issCreds[0].sad.s, schemaSAID);
     assert.equal(issCreds[0].sad.i, issuerAID);
     assert.equal(issCreds[0].status.s, '0'); // 0 = issued
-    console.log(`Issuer: credential created with data: ${JSON.stringify(vcdata)}`);
+    console.log(
+        `Issuer: credential created with data: ${JSON.stringify(vcdata)}`
+    );
 
     // prepare IPEX GRANT message
-    const acdc = new signify.Serder(issResult.acdc);
-    const iss = issResult.iserder;
-    const ianc = issResult.anc;
-
-    const sigers = issResult.sigs.map(
-      (sig: string) => new signify.Siger({ qb64: sig })
-    );
-    const ims = signify.d(signify.messagize(ianc, sigers));
-
-    const atc = ims.substring(ianc.size); // attachment
-    let dt = createTimestamp(); // grant datetime
-
-    const [grant, gsigs, gend] = await issuerClient
-        .ipex()
-        .grant(
-            issuerAidName,
-            holderAID,
-            '',
-            acdc,
-            issResult.acdcSaider,
-            iss,
-            issResult.issExnSaider,
-            issResult.anc,
-            atc,
-            undefined,
-            dt
-        );
+    const dt = createTimestamp(); // grant datetime
+    const [grant, gsigs, gend] = await issuerClient.ipex().grant({
+        senderName: issuerAidName,
+        acdc: issResult.acdc,
+        anc: issResult.anc,
+        iss: issResult.iss,
+        recipient: holderAID,
+        datetime: dt,
+    });
     await issuerClient
         .exchanges()
         .sendFromEvents(issuerAidName, 'credential', grant, gsigs, gend, [
@@ -300,22 +319,20 @@ async function run() {
     // from the holder's perspective - wait for GRANT notification,
     // perform admit, then mark GRANT notification as read
     const holderNotifications = await waitForNotifications(
-      holderClient,
-      '/exn/ipex/grant'
+        holderClient,
+        '/exn/ipex/grant'
     );
     const grantNotification = holderNotifications[0]; // should only have one notification right now
 
     // Note: Credentials are no longer automatically accepted into a wallet.
     //       Pending an implementation in KERIA there will be the ability to
     //       auto-add credentials by automatically admitting credentials.
-    const [admit, sigs, aend] = await holderClient.ipex()
-      .admit(
-        holderAidName,
-        '',
-        grantNotification.a.d!,
-        createTimestamp());
-    await holderClient.ipex()
-      .submitAdmit(holderAidName, admit, sigs, aend, [issuerAID]);
+    const [admit, sigs, aend] = await holderClient
+        .ipex()
+        .admit(holderAidName, '', grantNotification.a.d!, createTimestamp());
+    await holderClient
+        .ipex()
+        .submitAdmit(holderAidName, admit, sigs, aend, [issuerAID]);
     console.log('Holder: IPEX ADMIT sent');
 
     await holderClient.notifications().mark(grantNotification.i);
@@ -329,28 +346,21 @@ async function run() {
         holderCreds = await holderClient.credentials().list();
     }
     const hldVleiAcdc: any = holderCreds[0];
-    assert.equal(holderCreds.length, 1)
-    assert.equal(hldVleiAcdc.sad.s, schemaSAID)
-    assert.equal(hldVleiAcdc.sad.i, issuerAID)
-    assert.equal(hldVleiAcdc.status.s, "0") // 0 = issued
+    assert.equal(holderCreds.length, 1);
+    assert.equal(hldVleiAcdc.sad.s, schemaSAID);
+    assert.equal(hldVleiAcdc.sad.i, issuerAID);
+    assert.equal(hldVleiAcdc.status.s, '0'); // 0 = issued
     console.log('Credential received by recipient');
 
     // Present credential
-    const [grant2, gsigs2, gend2] = await holderClient
-        .ipex()
-        .grant(
-            holderAidName,
-            verifierAID,
-            '',
-            acdc,
-            issResult.acdcSaider,
-            iss,
-            issResult.issExnSaider,
-            issResult.anc,
-            atc,
-            undefined,
-            createTimestamp()
-        );
+    const [grant2, gsigs2, gend2] = await holderClient.ipex().grant({
+        senderName: holderAidName,
+        recipient: verifierAID,
+        acdc: issResult.acdc,
+        anc: issResult.anc,
+        iss: issResult.iss,
+        datetime: createTimestamp(),
+    });
     await holderClient
         .exchanges()
         .sendFromEvents(holderAidName, 'presentation', grant2, gsigs2, gend2, [
@@ -360,15 +370,17 @@ async function run() {
 
     // Verifier check issued credential
     const verifierNotifications = await waitForNotifications(
-      verifierClient,
-      '/exn/ipex/grant'
+        verifierClient,
+        '/exn/ipex/grant'
     );
     let verifierGrantNote = verifierNotifications[0];
 
-    const [admit3, sigs3, aend3] = await verifierClient.ipex()
-      .admit(verifierAidName, '', verifierGrantNote.a.d!, createTimestamp());
-    await verifierClient.ipex()
-      .submitAdmit(verifierAidName, admit3, sigs3, aend3, [holderAID]);
+    const [admit3, sigs3, aend3] = await verifierClient
+        .ipex()
+        .admit(verifierAidName, '', verifierGrantNote.a.d!, createTimestamp());
+    await verifierClient
+        .ipex()
+        .submitAdmit(verifierAidName, admit3, sigs3, aend3, [holderAID]);
     console.log('Verifier: Admit sent for presentation');
 
     await verifierClient.notifications().mark(verifierGrantNote.i);
@@ -381,20 +393,22 @@ async function run() {
         await new Promise((resolve) => setTimeout(resolve, 250));
         verifierCreds = await verifierClient.credentials().list();
     }
-    assert.equal(verifierCreds.length, 1)
-    assert.equal(verifierCreds[0].sad.s, schemaSAID)
-    assert.equal(verifierCreds[0].sad.i, issuerAID)
-    assert.equal(verifierCreds[0].status.s, "0") // 0 = issued
+    assert.equal(verifierCreds.length, 1);
+    assert.equal(verifierCreds[0].sad.s, schemaSAID);
+    assert.equal(verifierCreds[0].sad.i, issuerAID);
+    assert.equal(verifierCreds[0].status.s, '0'); // 0 = issued
     console.log('Credential presented and received by verifier');
 
     // Revoke credential
-    issOp = await issuerClient.credentials().revoke(issuerAidName, issCreds[0].sad.d);
+    issOp = await issuerClient
+        .credentials()
+        .revoke(issuerAidName, issCreds[0].sad.d);
     while (!issOp['done']) {
         issOp = await issuerClient.operations().get(issOp.name);
         await new Promise((resolve) => setTimeout(resolve, 250));
     }
     issCreds = await issuerClient.credentials().list();
-    const issVleiAcdc = issCreds[0]
+    const issVleiAcdc = issCreds[0];
     assert.equal(issCreds.length, 1);
     assert.equal(issVleiAcdc.sad.s, schemaSAID);
     assert.equal(issVleiAcdc.sad.i, issuerAID);
@@ -427,4 +441,4 @@ async function run() {
     // assert.equal(creds3[0].sad.i, aid1.prefix);
     // assert.equal(creds3[0].status.s, '1'); // 1 = revoked
     // console.log('Revocation presented and received by verifier');
-}
+}, 60000);

--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -60,6 +60,12 @@ export class Oobis {
     }
 }
 
+export interface Operation<T = unknown> {
+    done: boolean;
+    name: string;
+    response: T;
+}
+
 /**
  * Operations
  * @remarks
@@ -79,9 +85,9 @@ export class Operations {
      * Get operation status
      * @async
      * @param {string} name Name of the operation
-     * @returns {Promise<any>} A promise to the status of the operation
+     * @returns {Promise<Operation>} A promise to the status of the operation
      */
-    async get(name: string): Promise<any> {
+    async get<T = unknown>(name: string): Promise<Operation<T>> {
         let path = `/operations/${name}`;
         let data = null;
         let method = 'GET';

--- a/src/keri/core/utils.ts
+++ b/src/keri/core/utils.ts
@@ -99,7 +99,7 @@ export function range(start: number, stop: number, step: number) {
 export function intToBytes(value: number, length: number): Uint8Array {
     const byteArray = new Uint8Array(length); // Assuming a 4-byte integer (32 bits)
 
-    for (let index = byteArray.length-1; index >= 0; index--) {
+    for (let index = byteArray.length - 1; index >= 0; index--) {
         let byte = value & 0xff;
         byteArray[index] = byte;
         value = (value - byte) / 256;
@@ -109,18 +109,16 @@ export function intToBytes(value: number, length: number): Uint8Array {
 
 export function bytesToInt(ar: Uint8Array): number {
     let value = 0;
-    for (let i = 0; i <ar.length; i++) {
+    for (let i = 0; i < ar.length; i++) {
         value = value * 256 + ar[i];
     }
     return value;
 }
 
-export function serializeACDCAttachment(
-    acdc: Serder,
-    saider: Saider
-): Uint8Array {
+export function serializeACDCAttachment(acdc: Serder): Uint8Array {
     let prefixer = new Prefixer({ raw: b(acdc.raw) });
     let seqner = new Seqner({ sn: acdc.sn });
+    let saider = new Saider({ qb64: acdc.ked['d'] });
     let craw = new Uint8Array();
     let ctr = new Counter({ code: CtrDex.SealSourceTriples, count: 1 }).qb64b;
     let prefix = prefixer.qb64b;
@@ -137,11 +135,9 @@ export function serializeACDCAttachment(
     return newCraw;
 }
 
-export function serializeIssExnAttachment(
-    anc: Serder,
-    ancSaider: Saider
-): Uint8Array {
-    let seqner = new Seqner({ sn: anc.sn });
+export function serializeIssExnAttachment(iss: Serder): Uint8Array {
+    let seqner = new Seqner({ sn: iss.sn });
+    let ancSaider = new Saider({ qb64: iss.ked['d'] });
     let coupleArray = new Uint8Array(
         seqner.qb64b.length + ancSaider.qb64b.length
     );

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -7,6 +7,7 @@ import libsodium from 'libsodium-wrappers-sumo';
 import fetchMock from 'jest-fetch-mock';
 import 'whatwg-fetch';
 import {
+    b,
     Ident,
     Ilks,
     interact,
@@ -207,17 +208,16 @@ describe('Credentialing', () => {
         const registry = 'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX';
         const schema = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao';
         const isuee = 'EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p';
-        await credentials.issue(
-            'aid1',
-            registry,
-            schema,
-            isuee,
-            { LEI: '1234' },
-            {},
-            {},
-            undefined,
-            false
-        );
+        await credentials.issue({
+            issuerName: 'aid1',
+            registryId: registry,
+            schemaId: schema,
+            recipient: isuee,
+            data: { LEI: '1234' },
+            source: {},
+            rules: {},
+            privacy: false,
+        });
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         lastBody = JSON.parse(lastCall[1]!.body!.toString());
         assert.equal(lastCall[0]!, url + '/identifiers/aid1/credentials');
@@ -359,19 +359,15 @@ describe('Ipex', () => {
             kind: undefined,
         });
 
-        let [grant, gsigs, end] = await ipex.grant(
-            'multisig',
-            holder,
-            '',
-            new Serder(acdc),
-            acdcSaider,
-            iserder,
-            issSaider,
+        let [grant, gsigs, end] = await ipex.grant({
+            senderName: 'multisig',
+            recipient: holder,
+            message: '',
+            acdc: new Serder(acdc),
+            iss: iserder,
             anc,
-            '-vtest',
-            undefined,
-            mockCredential.sad.a.dt
-        );
+            datetime: mockCredential.sad.a.dt,
+        });
 
         assert.deepStrictEqual(grant.ked, {
             v: 'KERI10JSON0004b1_',
@@ -426,8 +422,8 @@ describe('Ipex', () => {
             end,
             '-LAg4AACA' +
                 '-e-acdc-IABBHsidiI6IkFDREMxMEpTT04wMDAxOTdfIiwiZCI6IkVN0AAAAAAAAAAAAAAAAAAAAAAAEMwcsEMUEruPXVwPCW7zmqmN8m0I3CihxolBm-RDrsJo-LAW5AACAA' +
-                '-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAENf3IEYwYtFmlq5ZzoI-zFzeR7E3ZNRN2YH_0KAFbdJW-LAE5AACAA' +
-                '-e-anc-vtest'
+                '-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAECVCyxNpB4PJkpLbWqI02WXs1wf7VUxPNY2W28SN2qqm-LAa5AACAA' +
+                '-e-anc-AABAADMtDfNihvCSXJNp1VronVojcPGo--0YZ4Kh6CAnowRnn4Or4FgZQqaqCEv6XVS413qfZoVp8j2uxTTPkItO7ED'
         );
 
         let [admit, asigs, aend] = await ipex.admit(

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -6,12 +6,12 @@ import {
 
 describe(serializeIssExnAttachment, () => {
     it('serializes iss data', () => {
-        const [saider, data] = Saider.saidify({
+        const [, data] = Saider.saidify({
             d: '',
             v: versify(Ident.KERI, undefined, Serials.JSON, 0),
         });
 
-        const result = serializeIssExnAttachment(new Serder(data), saider);
+        const result = serializeIssExnAttachment(new Serder(data));
 
         expect(d(result)).toEqual(
             '-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAEKZPmzJqhx76bcC2ftPQgeRirmOd8ZBOtGVqHJrSm7F1'
@@ -21,7 +21,7 @@ describe(serializeIssExnAttachment, () => {
 
 describe(serializeACDCAttachment, () => {
     it('serializes acdc data', () => {
-        const [saider, data] = Saider.saidify({
+        const [, data] = Saider.saidify({
             d: '',
             v: versify(Ident.ACDC, undefined, Serials.JSON, 0),
             a: {
@@ -29,7 +29,7 @@ describe(serializeACDCAttachment, () => {
             },
         });
 
-        const result = serializeACDCAttachment(new Serder(data), saider);
+        const result = serializeACDCAttachment(new Serder(data));
 
         expect(d(result)).toEqual(
             '-IABBHsiZCI6IkVORTZzbWw4X1NMZVIzdk9NajRJRExLX2Nn0AAAAAAAAAAAAAAAAAAAAAAAENE6sml8_SLeR3vOMj4IDLK_cgd-A-vtg0Jnu7ozdBjW'


### PR DESCRIPTION
I am working on multisig issuance using signify and found it very hard to follow the flow for multisig issuance => grant. To get a grasp of it I cleaned up the code for issue + grant and I think I found some complicated and repeated code.

In short:

- Adding IpexGrantArgs and IssueCredentialArgs/IssueCredentialResult interfaces.
- Simplifying the flow in credentials().issue() function to avoid unnecessary re-assigning of variables and merging of objects.
- Moving the attachment creation of the embeds into ipex().grant() function to make it easier to use from a caller. This was repeated in all scripts.
- Enabling the integration tests for multisig.test.ts and credential.test.ts
- Added the "Operation" type.

I think it should be all correct since it works. I also took inspiration from the commit here https://github.com/pfeairheller/signify-ts/commit/dc98330b7f31960f6b379997101f93353c88b3da to remove the redundant Saider arguments when creating the attachments.

If you do not like it, just let me know and I will close this. I don't necessarily need to get this merged. I just implemented it so that I could figure out how to do multisig credential issuance on my end and thought it was an improvement.