### PR TITLE
add instructions for integration tests to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Or, use execute `jest` directly to run a specific integration test, for example:
 npx jest examples/integration-scripts/credentials.test.ts
 ```
 
+It is also possible to run the tests using local instances of vLEI, Keria, and witness network. Set the environment variable `TEST_ENVIRONMENT` to `local`, e.g:
+
+```
+TEST_ENVIRONMENT=local npx jest examples/integration-scripts/credentials.test.ts
+```
+
+This changes the discovery urls to use `localhost` instead of the hostnames inside the docker network.
+
 ### Old integration scripts
 
 To run any of the old integration scripts that has not yet been converted to an integration test. Use `ts-node-esm`

--- a/README.md
+++ b/README.md
@@ -39,13 +39,71 @@ The code is built using Typescript and running code locally requires a Mac or Li
     npm install
     ```
 
-Typescript source files needs to be transpiled before running scripts
+Typescript source files needs to be transpiled before running scripts or integration tests
 
 -   Build:
     ```bash
     npm run build
     ```
 
+### Unit testing
+
+To run unit tests
+
+```bash
+npm test
+```
+
+### Integration testing
+
+The integration tests depends on a local instance of KERIA, vLEI-Server and Witness Demo. These are specified in the [Docker Compose](./docker-compose.yaml) file. To start the dependencies, use docker compose:
+
+```bash
+docker compose up deps
+```
+
+If successful, it should print someting like this:
+
+```bash
+$ docker compose up deps
+[+] Running 5/4
+ ✔ Network signify-ts_default           Created                                           0.0s
+ ✔ Container signify-ts-vlei-server-1   Created                                           0.1s
+ ✔ Container signify-ts-keria-1         Created                                           0.1s
+ ✔ Container signify-ts-witness-demo-1  Created                                           0.1s
+ ✔ Container signify-ts-deps-1          Created                                           0.0s
+Attaching to signify-ts-deps-1
+signify-ts-deps-1  | Dependencies running
+signify-ts-deps-1 exited with code 0
+```
+
+**Important!** The integration tests runs on the build output in `dist/` directory. Make sure to run build before running the integration tests.
+
+```bash
+npm run build
+```
+
+Use the npm script "test:integration" to run all integration tests in sequence:
+
+```bash
+npm run test:integration
+```
+
+Or, use execute `jest` directly to run a specific integration test, for example:
+
+```bash
+npx jest examples/integration-scripts/credentials.test.ts
+```
+
+### Old integration scripts
+
+To run any of the old integration scripts that has not yet been converted to an integration test. Use `ts-node-esm`
+
+```bash
+npx ts-node-esm examples/integration-scripts/challenge.ts
+```
+
+# Diagrams
 
 Account Creation Workflow
 

--- a/examples/integration-scripts/externalModule.test.ts
+++ b/examples/integration-scripts/externalModule.test.ts
@@ -1,9 +1,9 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { BIP39Shim } from './modules/bip39_shim';
+import { resolveEnvironment } from './utils/resolve-env';
 
-const url = 'http://127.0.0.1:3901';
-const boot_url = 'http://127.0.0.1:3903';
+const { url, bootUrl } = resolveEnvironment();
 
 test('bip39_shim', async () => {
     await signify.ready();
@@ -17,7 +17,7 @@ test('bip39_shim', async () => {
         url,
         bran1,
         signify.Tier.low,
-        boot_url,
+        bootUrl,
         [externalModule]
     );
     await client1.boot();

--- a/examples/integration-scripts/randy.test.ts
+++ b/examples/integration-scripts/randy.test.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
+import { resolveEnvironment } from './utils/resolve-env';
 
-const url = 'http://127.0.0.1:3901';
-const boot_url = 'http://127.0.0.1:3903';
+const { url, bootUrl } = resolveEnvironment();
 
 test('randy', async () => {
     await signify.ready();
@@ -12,7 +12,7 @@ test('randy', async () => {
         url,
         bran1,
         signify.Tier.low,
-        boot_url
+        bootUrl
     );
     await client1.boot();
     await client1.connect();

--- a/examples/integration-scripts/salty.test.ts
+++ b/examples/integration-scripts/salty.test.ts
@@ -1,8 +1,8 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
+import { resolveEnvironment } from './utils/resolve-env';
 
-const url = 'http://127.0.0.1:3901';
-const boot_url = 'http://127.0.0.1:3903';
+const { url, bootUrl } = resolveEnvironment();
 
 test('salty', async () => {
     await signify.ready();
@@ -12,7 +12,7 @@ test('salty', async () => {
         url,
         bran1,
         signify.Tier.low,
-        boot_url
+        bootUrl
     );
     await client1.boot();
     await client1.connect();

--- a/examples/integration-scripts/utils/resolve-env.ts
+++ b/examples/integration-scripts/utils/resolve-env.ts
@@ -1,0 +1,44 @@
+export type TestEnvironmentPreset = 'local' | 'docker';
+
+export interface TestEnvironment {
+    url: string;
+    bootUrl: string;
+    vleiServerUrl: string;
+    witnessUrls: string[];
+}
+
+export function resolveEnvironment(
+    input?: TestEnvironmentPreset
+): TestEnvironment {
+    const preset = input ?? process.env.TEST_ENVIRONMENT ?? 'docker';
+
+    const url = 'http://127.0.0.1:3901';
+    const bootUrl = 'http://127.0.0.1:3903';
+
+    switch (preset) {
+        case 'docker':
+            return {
+                url,
+                bootUrl,
+                witnessUrls: [
+                    'http://witness-demo:5642',
+                    'http://witness-demo:5643',
+                    'http://witness-demo:5644',
+                ],
+                vleiServerUrl: 'http://vlei-server:7723',
+            };
+        case 'local':
+            return {
+                url,
+                bootUrl,
+                vleiServerUrl: 'http://localhost:7723',
+                witnessUrls: [
+                    'http://localhost:5642',
+                    'http://localhost:5643',
+                    'http://localhost:5644',
+                ],
+            };
+        default:
+            throw new Error(`Unknown test environment preset '${preset}'`);
+    }
+}

--- a/examples/integration-scripts/witness.test.ts
+++ b/examples/integration-scripts/witness.test.ts
@@ -1,11 +1,10 @@
 // This scrip also work if you start keria with no config file with witness urls
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
+import { resolveEnvironment } from './utils/resolve-env';
 
-const WITNESS_HOST = process.env.WITNESS_HOST ?? 'witness-demo';
 const WITNESS_AID = 'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha';
-const url = 'http://127.0.0.1:3901';
-const boot_url = 'http://127.0.0.1:3903';
+const { url, bootUrl, witnessUrls } = resolveEnvironment();
 
 test('test witness', async () => {
     await signify.ready();
@@ -15,7 +14,7 @@ test('test witness', async () => {
         url,
         bran1,
         signify.Tier.low,
-        boot_url
+        bootUrl
     );
     await client1.boot();
     await client1.connect();
@@ -30,7 +29,7 @@ test('test witness', async () => {
     // Client 1 resolves witness OOBI
     let op1 = await client1
         .oobis()
-        .resolve(`http://${WITNESS_HOST}:5642/oobi/` + WITNESS_AID, 'wit');
+        .resolve(witnessUrls[0] + `/oobi/${WITNESS_AID}`, 'wit');
     while (!op1['done']) {
         op1 = await client1.operations().get(op1.name);
         await new Promise((resolve) => setTimeout(resolve, 1000));


### PR DESCRIPTION
Adding instructions on how to run integration tests since #143.

Edit: Also adds a function to `resolveEnvironment` to easily switch between a docker and local test environment setup.