### PR TITLE
Integration test setup

### DIFF
--- a/config/keria.json
+++ b/config/keria.json
@@ -1,11 +1,17 @@
 {
-    "iurls": [
-        "http://witness-demo:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller?name=Wan&tag=witness",
-        "http://witness-demo:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller?name=Wes&tag=witness",
-        "http://witness-demo:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller?name=Wil&tag=witness"
-    ],
+    "dt": "2023-12-01T10:05:25.062609+00:00",
     "keria": {
-        "dt": "2022-01-20T12:57:59.823350+00:00",
-        "curls": ["http://keria:3902"]
-    }
-}
+      "dt": "2023-12-01T10:05:25.062609+00:00",
+      "curls": [
+        "http://keria:3902/"
+      ]
+    },
+    "iurls": [
+      "http://witness-demo:5642/oobi/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha/controller",
+      "http://witness-demo:5643/oobi/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM/controller",
+      "http://witness-demo:5644/oobi/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX/controller",
+      "http://witness-demo:5645/oobi/BM35JN8XeJSEfpxopjn5jr7tAHCE5749f0OobhMLCorE/controller",
+      "http://witness-demo:5646/oobi/BIj15u5V11bkbtAxMA7gcNJZcax-7TgaBMLsQnMHpYHP/controller",
+      "http://witness-demo:5647/oobi/BF2rZTW79z4IXocYRQnjjsOuvFUQv-ptCf8Yltd7PfsM/controller"
+    ]
+  }

--- a/examples/integration-scripts/singlesig-ixn.test.ts
+++ b/examples/integration-scripts/singlesig-ixn.test.ts
@@ -1,0 +1,65 @@
+import { EventResult, SignifyClient } from "signify-ts";
+import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
+import { waitOperation } from "./utils/test-util";
+
+let client1: SignifyClient, client2: SignifyClient;
+let name1_id: string, name1_oobi: string;
+let contact1_id: string;
+
+beforeAll(async () => {
+    [client1, client2] = await getOrCreateClients(2);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+});
+beforeAll(async () => {
+    contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+});
+
+interface KeyState {
+    i: string;
+    s: string;
+    [property: string]: any
+}
+
+describe("singlesig-ixn", () => {
+    test("step1", async () => {
+        expect(name1_id).toEqual(contact1_id);
+
+        let keystate1 = await client1.keyStates().get(name1_id);
+        expect(keystate1).toHaveLength(1);
+
+        let keystate2 = await client2.keyStates().get(contact1_id);
+        expect(keystate2).toHaveLength(1);
+
+        // local and remote keystate sequence match
+        expect(keystate1[0].s).toEqual(keystate2[0].s);
+    });
+    test("ixn1", async () => {
+        // local keystate before ixn
+        let keystate0: KeyState = (await client1.keyStates().get(name1_id)).at(0);
+        expect(keystate0).not.toBeNull();
+
+        // ixn
+        let result: EventResult = await client1.identifiers().interact("name1", {});
+        await waitOperation(client1, await result.op());
+
+        // local keystate after ixn
+        let keystate1: KeyState = (await client1.keyStates().get(name1_id)).at(0);
+        expect(parseInt(keystate1.s)).toBeGreaterThan(0);
+        // sequence has incremented
+        expect(parseInt(keystate1.s)).toEqual(parseInt(keystate0.s) + 1);
+
+        // remote keystate after ixn
+        let keystate2: KeyState = (await client2.keyStates().get(contact1_id)).at(0);
+        // remote keystate is one behind
+        expect(parseInt(keystate2.s)).toEqual(parseInt(keystate1.s) - 1);
+
+        // refresh remote keystate
+        let op = await client2.keyStates().query(contact1_id, parseInt(keystate1.s), undefined);
+        op = await waitOperation(client2, op);
+        let keystate3: KeyState = op.response;
+        // local and remote keystate match
+        expect(keystate3.s).toEqual(keystate1.s);
+    });
+});

--- a/examples/integration-scripts/singlesig-rot.test.ts
+++ b/examples/integration-scripts/singlesig-rot.test.ts
@@ -1,0 +1,76 @@
+import { EventResult, RotateIdentifierArgs, SignifyClient } from "signify-ts";
+import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
+import { waitOperation } from "./utils/test-util";
+
+let client1: SignifyClient, client2: SignifyClient;
+let name1_id: string, name1_oobi: string;
+let contact1_id: string;
+
+beforeAll(async () => {
+    [client1, client2] = await getOrCreateClients(2);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+});
+beforeAll(async () => {
+    contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+});
+
+interface KeyState {
+    i: string;
+    s: string;
+    k: string[];
+    n: string[];
+    [property: string]: any
+}
+
+describe("singlesig-rot", () => {
+    test("step1", async () => {
+        expect(name1_id).toEqual(contact1_id);
+
+        let keystate1 = await client1.keyStates().get(name1_id);
+        expect(keystate1).toHaveLength(1);
+
+        let keystate2 = await client2.keyStates().get(contact1_id);
+        expect(keystate2).toHaveLength(1);
+
+        // local and remote keystate sequence match
+        expect(keystate1[0].s).toEqual(keystate2[0].s);
+    });
+    test("rot1", async () => {
+        // local keystate before rot
+        let keystate0: KeyState = (await client1.keyStates().get(name1_id)).at(0);
+        expect(keystate0).not.toBeNull();
+        expect(keystate0.k).toHaveLength(1);
+        expect(keystate0.n).toHaveLength(1);
+
+        // rot
+        let args: RotateIdentifierArgs = {};
+        let result: EventResult = await client1.identifiers().rotate("name1", args);
+        await waitOperation(client1, await result.op());
+
+        // local keystate after rot
+        let keystate1: KeyState = (await client1.keyStates().get(name1_id)).at(0);
+        expect(parseInt(keystate1.s)).toBeGreaterThan(0);
+        // sequence has incremented
+        expect(parseInt(keystate1.s)).toEqual(parseInt(keystate0.s) + 1);
+        // current keys changed
+        expect(keystate1.k[0]).not.toEqual(keystate0.k[0]);
+        // next key hashes changed
+        expect(keystate1.n[0]).not.toEqual(keystate0.n[0]);
+
+        // remote keystate after rot
+        let keystate2: KeyState = (await client2.keyStates().get(contact1_id)).at(0);
+        // remote keystate is one behind
+        expect(parseInt(keystate2.s)).toEqual(parseInt(keystate1.s) - 1);
+
+        // refresh remote keystate
+        let op = await client2.keyStates().query(contact1_id, parseInt(keystate1.s), undefined);
+        op = await waitOperation(client2, op);
+        let keystate3: KeyState = op.response;
+        // local and remote keystate match
+        expect(keystate3.s).toEqual(keystate1.s);
+        expect(keystate3.k[0]).toEqual(keystate1.k[0]);
+        expect(keystate3.n[0]).toEqual(keystate1.n[0]);
+    });
+});

--- a/examples/integration-scripts/test-setup-clients.test.ts
+++ b/examples/integration-scripts/test-setup-clients.test.ts
@@ -1,0 +1,29 @@
+import { SignifyClient } from "signify-ts";
+import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
+
+let client1: SignifyClient, client2: SignifyClient;
+let name1_id: string, name1_oobi: string;
+let name2_id: string, name2_oobi: string;
+let contact1_id: string, contact2_id: string;;
+
+beforeAll(async () => {
+    // create two clients with random secrets
+    [client1, client2] = await getOrCreateClients(2);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+    [name2_id, name2_oobi] = await getOrCreateIdentifier(client2, "name2");
+});
+beforeAll(async () => {
+    contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+    contact2_id = await getOrCreateContact(client1, "contact2", name2_oobi);
+});
+
+describe("test-setup-clients", () => {
+    test("step1", async () => {
+        expect(name1_id).toEqual(contact1_id);
+    });
+    test("step2", async () => {
+        expect(name2_id).toEqual(contact2_id);
+    });
+});

--- a/examples/integration-scripts/test-setup-single-client.test.ts
+++ b/examples/integration-scripts/test-setup-single-client.test.ts
@@ -1,0 +1,24 @@
+import { SignifyClient } from "signify-ts";
+import { getOrCreateClients, getOrCreateIdentifier } from "./utils/test-setup";
+
+let client: SignifyClient;
+let name1_id: string, name1_oobi: string;
+
+beforeAll(async () => {
+    // Create client with pre-defined secret. Allows working with known identifiers
+    [client] = await getOrCreateClients(1, ["0ADF2TpptgqcDE5IQUF1HeTp"]);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client, "name1");
+});
+
+describe("test-setup-single-client", () => {
+    test("step1", async () => {
+        expect(client.agent?.pre).toEqual("EC60ue9GOpQGrLBlS9T0dO6JkBTbv3V05Y4O730QBBoc");
+        expect(client.controller?.pre).toEqual("EB3UGWwIMq7ppzcQ697ImQIuXlBG5jzh-baSx-YG3-tY");
+    });
+    test("step2", async () => {
+        expect(name1_id).toEqual("ENpvkzG5PhOXPn0LOBIRR6wyd8YXZPW9dn7Drxd7jJcH");
+        expect(name1_oobi).toEqual("http://localhost:3902/oobi/ENpvkzG5PhOXPn0LOBIRR6wyd8YXZPW9dn7Drxd7jJcH/agent/EC60ue9GOpQGrLBlS9T0dO6JkBTbv3V05Y4O730QBBoc");
+    });
+});

--- a/examples/integration-scripts/test-setup-single-client.test.ts
+++ b/examples/integration-scripts/test-setup-single-client.test.ts
@@ -1,5 +1,6 @@
 import { SignifyClient } from "signify-ts";
 import { getOrCreateClients, getOrCreateIdentifier } from "./utils/test-setup";
+import { resolveEnvironment } from "./utils/resolve-env";
 
 let client: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -18,7 +19,22 @@ describe("test-setup-single-client", () => {
         expect(client.controller?.pre).toEqual("EB3UGWwIMq7ppzcQ697ImQIuXlBG5jzh-baSx-YG3-tY");
     });
     test("step2", async () => {
-        expect(name1_id).toEqual("ENpvkzG5PhOXPn0LOBIRR6wyd8YXZPW9dn7Drxd7jJcH");
-        expect(name1_oobi).toEqual("http://localhost:3902/oobi/ENpvkzG5PhOXPn0LOBIRR6wyd8YXZPW9dn7Drxd7jJcH/agent/EC60ue9GOpQGrLBlS9T0dO6JkBTbv3V05Y4O730QBBoc");
+        let env = resolveEnvironment();
+        let oobi = await client.oobis().get("name1", "witness");
+        expect(oobi.oobis).toHaveLength(3);
+        switch (env.preset) {
+            case "local":
+                expect(name1_oobi).toEqual(`http://localhost:3902/oobi/${name1_id}/agent/EC60ue9GOpQGrLBlS9T0dO6JkBTbv3V05Y4O730QBBoc`);
+                expect(oobi.oobis[0]).toEqual(`http://localhost:5642/oobi/${name1_id}/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha`);
+                expect(oobi.oobis[1]).toEqual(`http://localhost:5643/oobi/${name1_id}/witness/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM`);
+                expect(oobi.oobis[2]).toEqual(`http://localhost:5644/oobi/${name1_id}/witness/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX`);
+                break;
+            case "docker":
+                expect(name1_oobi).toEqual(`http://keria:3902/oobi/${name1_id}/agent/EC60ue9GOpQGrLBlS9T0dO6JkBTbv3V05Y4O730QBBoc`);
+                expect(oobi.oobis[0]).toEqual(`http://witness-demo:5642/oobi/${name1_id}/witness/BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha`);
+                expect(oobi.oobis[1]).toEqual(`http://witness-demo:5643/oobi/${name1_id}/witness/BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM`);
+                expect(oobi.oobis[2]).toEqual(`http://witness-demo:5644/oobi/${name1_id}/witness/BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX`);
+                break;
+        }
     });
 });

--- a/examples/integration-scripts/utils/resolve-env.ts
+++ b/examples/integration-scripts/utils/resolve-env.ts
@@ -5,7 +5,12 @@ export interface TestEnvironment {
     bootUrl: string;
     vleiServerUrl: string;
     witnessUrls: string[];
+    witnessIds: string[];
 }
+
+const WAN = "BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha";
+const WIL = "BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM";
+const WES = "BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX";
 
 export function resolveEnvironment(
     input?: TestEnvironmentPreset
@@ -25,6 +30,7 @@ export function resolveEnvironment(
                     'http://witness-demo:5643',
                     'http://witness-demo:5644',
                 ],
+                witnessIds: [WAN, WIL, WES],
                 vleiServerUrl: 'http://vlei-server:7723',
             };
         case 'local':
@@ -37,6 +43,7 @@ export function resolveEnvironment(
                     'http://localhost:5643',
                     'http://localhost:5644',
                 ],
+                witnessIds: [WAN, WIL, WES],
             };
         default:
             throw new Error(`Unknown test environment preset '${preset}'`);

--- a/examples/integration-scripts/utils/resolve-env.ts
+++ b/examples/integration-scripts/utils/resolve-env.ts
@@ -1,6 +1,7 @@
 export type TestEnvironmentPreset = 'local' | 'docker';
 
 export interface TestEnvironment {
+    preset: TestEnvironmentPreset;
     url: string;
     bootUrl: string;
     vleiServerUrl: string;
@@ -23,6 +24,7 @@ export function resolveEnvironment(
     switch (preset) {
         case 'docker':
             return {
+                preset: preset,
                 url,
                 bootUrl,
                 witnessUrls: [
@@ -35,6 +37,7 @@ export function resolveEnvironment(
             };
         case 'local':
             return {
+                preset: preset,
                 url,
                 bootUrl,
                 vleiServerUrl: 'http://localhost:7723',

--- a/examples/integration-scripts/utils/test-setup.ts
+++ b/examples/integration-scripts/utils/test-setup.ts
@@ -1,0 +1,137 @@
+import { CreateIdentiferArgs, EventResult, SignifyClient, Tier, randomPasscode, ready } from "signify-ts";
+import { resolveEnvironment } from "./resolve-env";
+import { waitOperation } from "./test-util";
+
+/**
+ * Connect or boot a number of SignifyClient instances
+ * @example
+ * <caption>Create two clients with random secrets</caption>
+ * let client1: SignifyClient, client2: SignifyClient;
+ * beforeAll(async () => {
+ *   [client1, client2] = await getOrCreateClients(2);
+ * });
+ * @example
+ * <caption>Launch jest from shell with pre-defined secrets</caption>
+ * $ SIGNIFY_SECRETS="0ACqshJKkJ7DDXcaDuwnmI8s,0ABqicvyicXGvIVg6Ih-dngE" npx jest ./tests
+ */
+export async function getOrCreateClients(count: number, brans: string[] | undefined = undefined): Promise<SignifyClient[]> {
+    let tasks: Promise<SignifyClient>[] = [];
+    let secrets = process.env["SIGNIFY_SECRETS"]?.split(",");
+    for (let i = 0; i < count; i++) {
+        tasks.push(getOrCreateClient(brans?.at(i) ?? secrets?.at(i) ?? undefined));
+    }
+    let clients: SignifyClient[] = await Promise.all(tasks);
+    console.log(`SIGNIFY_SECRETS="${clients.map(i => i.bran).join(",")}"`);
+    return clients;
+}
+
+/**
+ * Connect or boot a SignifyClient instance
+ */
+export async function getOrCreateClient(bran: string | undefined = undefined): Promise<SignifyClient> {
+    let env = resolveEnvironment();
+    await ready();
+    bran ??= randomPasscode();
+    bran = bran.padEnd(21, "_");
+    let client = new SignifyClient(env.url, bran, Tier.low, env.bootUrl);
+    try {
+        await client.connect();
+    } catch {
+        let res = await client.boot();
+        if (!res.ok) throw new Error();
+        await client.connect();
+    }
+    console.log("client", { agent: client.agent?.pre, controller: client.controller.pre });
+    return client;
+}
+
+/**
+ * Get or create a Keri identifier. Uses default witness config from `resolveEnvironment`
+ * @example
+ * <caption>Create a Keri identifier before running tests</caption>
+ * let name1_id: string, name1_oobi: string;
+ * beforeAll(async () => {
+ *   [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+ * });
+ * @see resolveEnvironment
+ */
+export async function getOrCreateIdentifier(client: SignifyClient, name: string): Promise<[string, string]> {
+    let id: any = undefined;
+    try {
+        let identfier = await client.identifiers().get(name);
+        // console.log("identifiers.get", identfier);
+        id = identfier.prefix;
+    } catch {
+        let env = resolveEnvironment();
+        let args: CreateIdentiferArgs = {
+            toad: env.witnessIds.length,
+            wits: env.witnessIds
+        };
+        let result: EventResult = await client.identifiers().create(name, args);
+        let op = await result.op();
+        op = await waitOperation(client, op);
+        // console.log("identifiers.create", op);
+        id = op.response.i;
+    }
+    let eid = client.agent?.pre!;
+    if (!await hasEndRole(client, name, "agent", eid)) {
+        let result: EventResult = await client.identifiers().addEndRole(name, "agent", eid);
+        let op = await result.op();
+        op = await waitOperation(client, op);
+        // console.log("identifiers.addEndRole", op);
+    }
+    let oobi = await client.oobis().get(name, "agent");
+    let result: [string, string] = [id, oobi.oobis[0]];
+    console.log(name, result);
+    return result;
+}
+
+/**
+ * Get list of end role authorizations for a Keri idenfitier
+ */
+export async function getEndRoles(client: SignifyClient, alias: string, role?: string): Promise<any> {
+    let path = (role !== undefined) ? `/identifiers/${alias}/endroles/${role}` : `/identifiers/${alias}/endroles`;
+    let response: Response = await client.fetch(path, "GET", null);
+    if (!response.ok) throw new Error(await response.text());
+    let result = await response.json();
+    // console.log("getEndRoles", result);
+    return result;
+}
+
+/**
+ * Test if end role is authorized for a Keri identifier
+ */
+export async function hasEndRole(client: SignifyClient, alias: string, role: string, eid: string): Promise<boolean> {
+    let list = await getEndRoles(client, alias, role);
+    for (let i of list) {
+        if (i.role === role && i.eid === eid) {
+            return true;
+        }
+    }
+    return false;
+}
+
+/**
+ * Get or resolve a Keri contact
+ * @example
+ * <caption>Create a Keri contact before running tests</caption>
+ * let contact1_id: string;
+ * beforeAll(async () => {
+ *   contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+ * });
+ */
+export async function getOrCreateContact(client: SignifyClient, name: string, oobi: string): Promise<string> {
+    let list = await client.contacts().list(undefined, "alias", `^${name}$`);
+    // console.log("contacts.list", list);
+    if (list.length > 0) {
+        let contact = list[0];
+        if (contact.oobi === oobi) {
+            // console.log("contacts.id", contact.id);
+            return contact.id;
+        }
+    }
+    let op = await client.oobis().resolve(oobi, name);
+    op = await waitOperation(client, op);
+    // console.log("oobis.resolve", op);
+    return op.response.i;
+}

--- a/examples/integration-scripts/utils/test-setup.ts
+++ b/examples/integration-scripts/utils/test-setup.ts
@@ -55,7 +55,7 @@ export async function getOrCreateClient(bran: string | undefined = undefined): P
  * });
  * @see resolveEnvironment
  */
-export async function getOrCreateIdentifier(client: SignifyClient, name: string): Promise<[string, string]> {
+export async function getOrCreateIdentifier(client: SignifyClient, name: string, kargs: CreateIdentiferArgs | undefined = undefined): Promise<[string, string]> {
     let id: any = undefined;
     try {
         let identfier = await client.identifiers().get(name);
@@ -63,11 +63,11 @@ export async function getOrCreateIdentifier(client: SignifyClient, name: string)
         id = identfier.prefix;
     } catch {
         let env = resolveEnvironment();
-        let args: CreateIdentiferArgs = {
+        kargs ??= {
             toad: env.witnessIds.length,
             wits: env.witnessIds
         };
-        let result: EventResult = await client.identifiers().create(name, args);
+        let result: EventResult = await client.identifiers().create(name, kargs);
         let op = await result.op();
         op = await waitOperation(client, op);
         // console.log("identifiers.create", op);

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -1,0 +1,21 @@
+import { SignifyClient } from "signify-ts";
+
+export function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * Poll for operation to become completed
+ */
+export async function waitOperation(client: SignifyClient, op: any, retries: number | undefined = undefined): Promise<any> {
+    const WAIT = 500; // 0.5 seconds
+    retries ??= 10; // default 10 retries or 5 seconds
+    while (retries-- > 0) {
+        op = await client.operations().get(op.name);
+        if (op.done === true) return op;
+        await sleep(WAIT);
+    }
+    throw new Error(`Timeout: operation ${op.name}`);
+}


### PR DESCRIPTION
@lenkan @rodolfomiranda 

This is a suggestion of a pattern how to setup integration tests

There are three helper methods `getOrCreateClients`, `getOrCreateIdentifier` and `getOrCreateContact` to take care of the initial setting up of Signify clients, Keri identifiers and Oobi resolution before running actual integration tests.

I implemented two complete integration tests as examples: singlesig-ixn.test.ts and singlesig-rot.test.ts

`getOrCreateClients` allows creating Signify clients with a random or pre-defined secret. The environment variable `SIGNIFY_SECRETS` allows passing pre-defined secrets from the command line.