### PR TITLE
Fix serializeACDCAttachment to work with the correct anchor per type.

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -712,7 +712,7 @@ export class Ipex {
         const atc = ims.substring(args.anc.size);
 
         const embeds: Record<string, [Serder, string]> = {
-            acdc: [args.acdc, d(serializeACDCAttachment(args.acdc))],
+            acdc: [args.acdc, d(serializeACDCAttachment(args.iss))],
             iss: [args.iss, d(serializeIssExnAttachment(args.anc))],
             anc: [args.anc, atc],
         };

--- a/src/keri/core/utils.ts
+++ b/src/keri/core/utils.ts
@@ -115,12 +115,10 @@ export function bytesToInt(ar: Uint8Array): number {
     return value;
 }
 
-export function serializeACDCAttachment(
-    anc: Serder
-): Uint8Array {
+export function serializeACDCAttachment(anc: Serder): Uint8Array {
     const prefixer = new Prefixer({ qb64: anc.pre });
     const seqner = new Seqner({ sn: anc.sn });
-    const saider = new Saider({qb64: anc.ked['d']})
+    const saider = new Saider({ qb64: anc.ked['d'] });
     const craw = new Uint8Array();
     const ctr = new Counter({ code: CtrDex.SealSourceTriples, count: 1 }).qb64b;
     const prefix = prefixer.qb64b;
@@ -137,11 +135,9 @@ export function serializeACDCAttachment(
     return newCraw;
 }
 
-export function serializeIssExnAttachment(
-    anc: Serder
-): Uint8Array {
+export function serializeIssExnAttachment(anc: Serder): Uint8Array {
     const seqner = new Seqner({ sn: anc.sn });
-    const ancSaider = new Saider({qb64: anc.ked['d']})
+    const ancSaider = new Saider({ qb64: anc.ked['d'] });
     const coupleArray = new Uint8Array(
         seqner.qb64b.length + ancSaider.qb64b.length
     );

--- a/src/keri/core/utils.ts
+++ b/src/keri/core/utils.ts
@@ -115,10 +115,12 @@ export function bytesToInt(ar: Uint8Array): number {
     return value;
 }
 
-export function serializeACDCAttachment(acdc: Serder): Uint8Array {
-    const prefixer = new Prefixer({ raw: b(acdc.raw) });
-    const seqner = new Seqner({ sn: acdc.sn });
-    const saider = new Saider({ qb64: acdc.ked['d'] });
+export function serializeACDCAttachment(
+    anc: Serder
+): Uint8Array {
+    const prefixer = new Prefixer({ qb64: anc.pre });
+    const seqner = new Seqner({ sn: anc.sn });
+    const saider = new Saider({qb64: anc.ked['d']})
     const craw = new Uint8Array();
     const ctr = new Counter({ code: CtrDex.SealSourceTriples, count: 1 }).qb64b;
     const prefix = prefixer.qb64b;
@@ -135,9 +137,11 @@ export function serializeACDCAttachment(acdc: Serder): Uint8Array {
     return newCraw;
 }
 
-export function serializeIssExnAttachment(iss: Serder): Uint8Array {
-    const seqner = new Seqner({ sn: iss.sn });
-    const ancSaider = new Saider({ qb64: iss.ked['d'] });
+export function serializeIssExnAttachment(
+    anc: Serder
+): Uint8Array {
+    const seqner = new Seqner({ sn: anc.sn });
+    const ancSaider = new Saider({qb64: anc.ked['d']})
     const coupleArray = new Uint8Array(
         seqner.qb64b.length + ancSaider.qb64b.length
     );

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -421,9 +421,9 @@ describe('Ipex', () => {
         assert.equal(
             end,
             '-LAg4AACA-e-acdc-IABEMwcsEMUEruPXVwPCW7zmqmN8m0I3CihxolBm-RDrsJo0AAAAAAAAAAAAAAAAAAAAAAAENf3IEYwYtFmlq5Zz' +
-            'oI-zFzeR7E3ZNRN2YH_0KAFbdJW-LAW5AACAA-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAECVCyxNpB4PJkpLbWqI02WXs1wf7VU' +
-            'xPNY2W28SN2qqm-LAa5AACAA-e-anc-AABAADMtDfNihvCSXJNp1VronVojcPGo--0YZ4Kh6CAnowRnn4Or4FgZQqaqCEv6XVS413qfZo' +
-            'Vp8j2uxTTPkItO7ED'
+                'oI-zFzeR7E3ZNRN2YH_0KAFbdJW-LAW5AACAA-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAECVCyxNpB4PJkpLbWqI02WXs1wf7VU' +
+                'xPNY2W28SN2qqm-LAa5AACAA-e-anc-AABAADMtDfNihvCSXJNp1VronVojcPGo--0YZ4Kh6CAnowRnn4Or4FgZQqaqCEv6XVS413qfZo' +
+                'Vp8j2uxTTPkItO7ED'
         );
 
         const [admit, asigs, aend] = await ipex.admit(

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -420,10 +420,10 @@ describe('Ipex', () => {
         ]);
         assert.equal(
             end,
-            '-LAg4AACA' +
-                '-e-acdc-IABBHsidiI6IkFDREMxMEpTT04wMDAxOTdfIiwiZCI6IkVN0AAAAAAAAAAAAAAAAAAAAAAAEMwcsEMUEruPXVwPCW7zmqmN8m0I3CihxolBm-RDrsJo-LAW5AACAA' +
-                '-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAECVCyxNpB4PJkpLbWqI02WXs1wf7VUxPNY2W28SN2qqm-LAa5AACAA' +
-                '-e-anc-AABAADMtDfNihvCSXJNp1VronVojcPGo--0YZ4Kh6CAnowRnn4Or4FgZQqaqCEv6XVS413qfZoVp8j2uxTTPkItO7ED'
+            '-LAg4AACA-e-acdc-IABEMwcsEMUEruPXVwPCW7zmqmN8m0I3CihxolBm-RDrsJo0AAAAAAAAAAAAAAAAAAAAAAAENf3IEYwYtFmlq5Zz' +
+            'oI-zFzeR7E3ZNRN2YH_0KAFbdJW-LAW5AACAA-e-iss-VAS-GAB0AAAAAAAAAAAAAAAAAAAAAAAECVCyxNpB4PJkpLbWqI02WXs1wf7VU' +
+            'xPNY2W28SN2qqm-LAa5AACAA-e-anc-AABAADMtDfNihvCSXJNp1VronVojcPGo--0YZ4Kh6CAnowRnn4Or4FgZQqaqCEv6XVS413qfZo' +
+            'Vp8j2uxTTPkItO7ED'
         );
 
         const [admit, asigs, aend] = await ipex.admit(

--- a/test/core/utils.test.ts
+++ b/test/core/utils.test.ts
@@ -22,6 +22,7 @@ describe(serializeIssExnAttachment, () => {
 describe(serializeACDCAttachment, () => {
     it('serializes acdc data', () => {
         const [, data] = Saider.saidify({
+            i: 'EP-hA0w9X5FDonCDxQv32OTCAvcxkZxgDLOnDb3Jcn3a',
             d: '',
             v: versify(Ident.ACDC, undefined, Serials.JSON, 0),
             a: {
@@ -32,7 +33,7 @@ describe(serializeACDCAttachment, () => {
         const result = serializeACDCAttachment(new Serder(data));
 
         expect(d(result)).toEqual(
-            '-IABBHsiZCI6IkVORTZzbWw4X1NMZVIzdk9NajRJRExLX2Nn0AAAAAAAAAAAAAAAAAAAAAAAENE6sml8_SLeR3vOMj4IDLK_cgd-A-vtg0Jnu7ozdBjW'
+            '-IABEP-hA0w9X5FDonCDxQv32OTCAvcxkZxgDLOnDb3Jcn3a0AAAAAAAAAAAAAAAAAAAAAAAEHGU7u7cSMjMcJ1UyN8r-MnoZ3cDw4sMQNYxRLjqGVJI'
         );
     });
 });


### PR DESCRIPTION
This PR uses the correct events for creating the anchors in the embed of grant messages.