### PR TITLE
Integration test for singlesig delegate identifier

### DIFF
--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -1,0 +1,74 @@
+import { CreateIdentiferArgs, EventResult, SignifyClient } from "signify-ts";
+import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
+import { waitOperation } from "./utils/test-util";
+import { resolveEnvironment } from "./utils/resolve-env";
+
+let client1: SignifyClient, client2: SignifyClient;
+let name1_id: string, name1_oobi: string;
+let contact1_id: string;
+
+beforeAll(async () => {
+    [client1, client2] = await getOrCreateClients(2);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+});
+beforeAll(async () => {
+    contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+});
+
+describe("singlesig-dip", () => {
+    test("delegate1a", async () => {
+        let kargs: CreateIdentiferArgs = {
+            delpre: name1_id
+        };
+        let result = await client2.identifiers().create("delegate1", kargs);
+        let op = await result.op();
+        let dip1 = await client2.identifiers().get("delegate1");
+        expect(op.name).toEqual(`delegation.${dip1.prefix}`);
+    });
+    test("delegator1", async () => {
+        let dip1 = await client2.identifiers().get("delegate1");
+        let seal = {
+            i: dip1.prefix,
+            s: 0,
+            d: dip1.prefix
+        };
+        let result = await client1.identifiers().interact("name1", seal);
+        let op = waitOperation(client1, await result.op());
+    })
+    test("delegate1b", async () => {
+        let dip1 = await client2.identifiers().get("delegate1");
+        let op: any = { name: `delegation.${dip1.prefix}` };
+        op = await waitOperation(client2, op);
+        expect(dip1.prefix).toEqual(op.response.i);
+    });
+    test("delegate2a", async () => {
+        let env = resolveEnvironment();
+        let kargs: CreateIdentiferArgs = {
+            delpre: name1_id,
+            toad: env.witnessIds.length,
+            wits: env.witnessIds
+        };
+        let result = await client2.identifiers().create("delegate2", kargs);
+        let op = await result.op();
+        let dip1 = await client2.identifiers().get("delegate2");
+        expect(op.name).toEqual(`delegation.${dip1.prefix}`);
+    });
+    test("delegator2", async () => {
+        let dip1 = await client2.identifiers().get("delegate2");
+        let seal = {
+            i: dip1.prefix,
+            s: 0,
+            d: dip1.prefix
+        };
+        let result = await client1.identifiers().interact("name1", seal);
+        let op = waitOperation(client1, await result.op());
+    })
+    test("delegate2b", async () => {
+        let dip1 = await client2.identifiers().get("delegate2");
+        let op: any = { name: `delegation.${dip1.prefix}` };
+        op = await waitOperation(client2, op);
+        expect(dip1.prefix).toEqual(op.response.i);
+    });
+});

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -19,31 +19,35 @@ beforeAll(async () => {
 
 describe("singlesig-dip", () => {
     test("delegate1a", async () => {
+        // delegate creates identifier without witnesses
         let kargs: CreateIdentiferArgs = {
             delpre: name1_id
         };
         let result = await client2.identifiers().create("delegate1", kargs);
         let op = await result.op();
-        let dip1 = await client2.identifiers().get("delegate1");
-        expect(op.name).toEqual(`delegation.${dip1.prefix}`);
+        let delegate1 = await client2.identifiers().get("delegate1");
+        expect(op.name).toEqual(`delegation.${delegate1.prefix}`);
     });
     test("delegator1", async () => {
-        let dip1 = await client2.identifiers().get("delegate1");
+        // delegator approves delegate
+        let delegate1 = await client2.identifiers().get("delegate1");
         let seal = {
-            i: dip1.prefix,
+            i: delegate1.prefix,
             s: 0,
-            d: dip1.prefix
+            d: delegate1.prefix
         };
         let result = await client1.identifiers().interact("name1", seal);
         let op = waitOperation(client1, await result.op());
     })
     test("delegate1b", async () => {
-        let dip1 = await client2.identifiers().get("delegate1");
-        let op: any = { name: `delegation.${dip1.prefix}` };
+        // delegate waits for completion
+        let delegate1 = await client2.identifiers().get("delegate1");
+        let op: any = { name: `delegation.${delegate1.prefix}` };
         op = await waitOperation(client2, op);
-        expect(dip1.prefix).toEqual(op.response.i);
+        expect(delegate1.prefix).toEqual(op.response.i);
     });
     test("delegate2a", async () => {
+        // delegate creates identifier with default witness config
         let env = resolveEnvironment();
         let kargs: CreateIdentiferArgs = {
             delpre: name1_id,
@@ -52,23 +56,26 @@ describe("singlesig-dip", () => {
         };
         let result = await client2.identifiers().create("delegate2", kargs);
         let op = await result.op();
-        let dip1 = await client2.identifiers().get("delegate2");
-        expect(op.name).toEqual(`delegation.${dip1.prefix}`);
+        let delegate2 = await client2.identifiers().get("delegate2");
+        expect(op.name).toEqual(`delegation.${delegate2.prefix}`);
     });
     test("delegator2", async () => {
-        let dip1 = await client2.identifiers().get("delegate2");
+        // delegator approves delegate
+        let delegate2 = await client2.identifiers().get("delegate2");
         let seal = {
-            i: dip1.prefix,
+            i: delegate2.prefix,
             s: 0,
-            d: dip1.prefix
+            d: delegate2.prefix
         };
         let result = await client1.identifiers().interact("name1", seal);
         let op = waitOperation(client1, await result.op());
     })
-    test("delegate2b", async () => {
-        let dip1 = await client2.identifiers().get("delegate2");
-        let op: any = { name: `delegation.${dip1.prefix}` };
+    // https://github.com/WebOfTrust/signify-ts/issues/145
+    test.failing("delegate2b", async () => {
+        // delegate waits for completion
+        let delegate2 = await client2.identifiers().get("delegate2");
+        let op: any = { name: `delegation.${delegate2.prefix}` };
         op = await waitOperation(client2, op);
-        expect(dip1.prefix).toEqual(op.response.i);
-    });
+        expect(delegate2.prefix).toEqual(op.response.i);
+    }, 30000);
 });

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -1,4 +1,4 @@
-import { CreateIdentiferArgs, EventResult, SignifyClient } from "signify-ts";
+import { CreateIdentiferArgs, SignifyClient } from "signify-ts";
 import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
 import { waitOperation } from "./utils/test-util";
 import { resolveEnvironment } from "./utils/resolve-env";

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -37,7 +37,7 @@ describe('singlesig-dip', () => {
         let delegate1 = await client2.identifiers().get('delegate1');
         let seal = {
             i: delegate1.prefix,
-            s: 0,
+            s: '0',
             d: delegate1.prefix,
         };
         let result = await client1.identifiers().interact('name1', seal);
@@ -68,13 +68,12 @@ describe('singlesig-dip', () => {
         let delegate2 = await client2.identifiers().get('delegate2');
         let seal = {
             i: delegate2.prefix,
-            s: 0,
+            s: '0',
             d: delegate2.prefix,
         };
         let result = await client1.identifiers().interact('name1', seal);
         let op = waitOperation(client1, await result.op());
     });
-    // https://github.com/WebOfTrust/signify-ts/issues/145
     test('delegate2b', async () => {
         // delegate waits for completion
         let delegate2 = await client2.identifiers().get('delegate2');

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -75,15 +75,11 @@ describe('singlesig-dip', () => {
         let op = waitOperation(client1, await result.op());
     });
     // https://github.com/WebOfTrust/signify-ts/issues/145
-    test.failing(
-        'delegate2b',
-        async () => {
-            // delegate waits for completion
-            let delegate2 = await client2.identifiers().get('delegate2');
-            let op: any = { name: `delegation.${delegate2.prefix}` };
-            op = await waitOperation(client2, op);
-            expect(delegate2.prefix).toEqual(op.response.i);
-        },
-        30000
-    );
+    test('delegate2b', async () => {
+        // delegate waits for completion
+        let delegate2 = await client2.identifiers().get('delegate2');
+        let op: any = { name: `delegation.${delegate2.prefix}` };
+        op = await waitOperation(client2, op);
+        expect(delegate2.prefix).toEqual(op.response.i);
+    });
 });

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -1,7 +1,11 @@
-import { CreateIdentiferArgs, SignifyClient } from "signify-ts";
-import { getOrCreateClients, getOrCreateContact, getOrCreateIdentifier } from "./utils/test-setup";
-import { waitOperation } from "./utils/test-util";
-import { resolveEnvironment } from "./utils/resolve-env";
+import { CreateIdentiferArgs, SignifyClient } from 'signify-ts';
+import {
+    getOrCreateClients,
+    getOrCreateContact,
+    getOrCreateIdentifier,
+} from './utils/test-setup';
+import { waitOperation } from './utils/test-util';
+import { resolveEnvironment } from './utils/resolve-env';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -11,71 +15,75 @@ beforeAll(async () => {
     [client1, client2] = await getOrCreateClients(2);
 });
 beforeAll(async () => {
-    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, "name1");
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, 'name1');
 });
 beforeAll(async () => {
-    contact1_id = await getOrCreateContact(client2, "contact1", name1_oobi);
+    contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
 });
 
-describe("singlesig-dip", () => {
-    test("delegate1a", async () => {
+describe('singlesig-dip', () => {
+    test('delegate1a', async () => {
         // delegate creates identifier without witnesses
         let kargs: CreateIdentiferArgs = {
-            delpre: name1_id
+            delpre: name1_id,
         };
-        let result = await client2.identifiers().create("delegate1", kargs);
+        let result = await client2.identifiers().create('delegate1', kargs);
         let op = await result.op();
-        let delegate1 = await client2.identifiers().get("delegate1");
+        let delegate1 = await client2.identifiers().get('delegate1');
         expect(op.name).toEqual(`delegation.${delegate1.prefix}`);
     });
-    test("delegator1", async () => {
+    test('delegator1', async () => {
         // delegator approves delegate
-        let delegate1 = await client2.identifiers().get("delegate1");
+        let delegate1 = await client2.identifiers().get('delegate1');
         let seal = {
             i: delegate1.prefix,
             s: 0,
-            d: delegate1.prefix
+            d: delegate1.prefix,
         };
-        let result = await client1.identifiers().interact("name1", seal);
+        let result = await client1.identifiers().interact('name1', seal);
         let op = waitOperation(client1, await result.op());
-    })
-    test("delegate1b", async () => {
+    });
+    test('delegate1b', async () => {
         // delegate waits for completion
-        let delegate1 = await client2.identifiers().get("delegate1");
+        let delegate1 = await client2.identifiers().get('delegate1');
         let op: any = { name: `delegation.${delegate1.prefix}` };
         op = await waitOperation(client2, op);
         expect(delegate1.prefix).toEqual(op.response.i);
     });
-    test("delegate2a", async () => {
+    test('delegate2a', async () => {
         // delegate creates identifier with default witness config
         let env = resolveEnvironment();
         let kargs: CreateIdentiferArgs = {
             delpre: name1_id,
             toad: env.witnessIds.length,
-            wits: env.witnessIds
+            wits: env.witnessIds,
         };
-        let result = await client2.identifiers().create("delegate2", kargs);
+        let result = await client2.identifiers().create('delegate2', kargs);
         let op = await result.op();
-        let delegate2 = await client2.identifiers().get("delegate2");
+        let delegate2 = await client2.identifiers().get('delegate2');
         expect(op.name).toEqual(`delegation.${delegate2.prefix}`);
     });
-    test("delegator2", async () => {
+    test('delegator2', async () => {
         // delegator approves delegate
-        let delegate2 = await client2.identifiers().get("delegate2");
+        let delegate2 = await client2.identifiers().get('delegate2');
         let seal = {
             i: delegate2.prefix,
             s: 0,
-            d: delegate2.prefix
+            d: delegate2.prefix,
         };
-        let result = await client1.identifiers().interact("name1", seal);
+        let result = await client1.identifiers().interact('name1', seal);
         let op = waitOperation(client1, await result.op());
-    })
+    });
     // https://github.com/WebOfTrust/signify-ts/issues/145
-    test.failing("delegate2b", async () => {
-        // delegate waits for completion
-        let delegate2 = await client2.identifiers().get("delegate2");
-        let op: any = { name: `delegation.${delegate2.prefix}` };
-        op = await waitOperation(client2, op);
-        expect(delegate2.prefix).toEqual(op.response.i);
-    }, 30000);
+    test.failing(
+        'delegate2b',
+        async () => {
+            // delegate waits for completion
+            let delegate2 = await client2.identifiers().get('delegate2');
+            let op: any = { name: `delegation.${delegate2.prefix}` };
+            op = await waitOperation(client2, op);
+            expect(delegate2.prefix).toEqual(op.response.i);
+        },
+        30000
+    );
 });


### PR DESCRIPTION
The second test is marked as failing as it reproduces issue https://github.com/WebOfTrust/signify-ts/issues/145

This test also causes the latest Keria to crash with following stack trace

`TEST_ENVIRONMENT=local npx jest --runInBand ./examples/integration-scripts/singlesig-dip.test.ts`

Keria

```
Traceback (most recent call last):
  File "/home/uroot/.local/bin/keria", line 33, in <module>
    sys.exit(load_entry_point('keria', 'console_scripts', 'keria')())
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 31, in main
    raise ex
  File "/home/uroot/keria/src/keria/app/cli/keria.py", line 25, in main
    doers = args.handler(args)
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 20, in <lambda>
    parser.set_defaults(handler=lambda args: launch(args))
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 84, in launch
    runAgent(name=args.name,
  File "/home/uroot/keria/src/keria/app/cli/commands/start.py", line 117, in runAgent
    directing.runController(doers=doers, expire=expire)
  File "/home/uroot/keripy/src/keri/app/directing.py", line 665, in runController
    doist.do(doers=doers)
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 156, in do
    self.recur()  # increments .tyme runs recur context
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 275, in recur
    tock = dog.send(self.tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 922, in do
    self.done = self.recur(tyme=tyme)  # equv of doist.recur
  File "/home/uroot/.local/lib/python3.10/site-packages/hio/base/doing.py", line 1026, in recur
    tock = dog.send(tyme)  # yielded tock == 0.0 means re-run asap
  File "/home/uroot/keripy/src/keri/app/delegating.py", line 138, in escrowDo
    self.processEscrows()
  File "/home/uroot/keripy/src/keri/app/delegating.py", line 143, in processEscrows
    self.processPartialWitnessEscrow()
  File "/home/uroot/keripy/src/keri/app/delegating.py", line 193, in processPartialWitnessEscrow
    self.hby.db.cdel.put(keys=(pre, seqner.qb64), val=serder.saider)
AttributeError: 'SerderKERI' object has no attribute 'saider'. Did you mean: 'said'?
```
