### PR TITLE
fix: do not sign credential events in grant method

### DIFF
--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -310,6 +310,7 @@ test('credentials', async () => {
         acdc: issResult.acdc,
         anc: issResult.anc,
         iss: issResult.iss,
+        sigs: issResult.sigs,
         recipient: holderAID,
         datetime: dt,
     });
@@ -363,6 +364,7 @@ test('credentials', async () => {
         acdc: issResult.acdc,
         anc: issResult.anc,
         iss: issResult.iss,
+        sigs: issResult.sigs,
         datetime: createTimestamp(),
     });
     await holderClient

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -3,6 +3,7 @@ import signify, {
     SignifyClient,
     Serder,
     IssueCredentialResult,
+    Operation,
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 
@@ -133,7 +134,7 @@ test('multisig', async function run() {
     let serder = icpResult1.serder;
 
     let sigs = icpResult1.sigs;
-    let sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    let sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     let ims = signify.d(signify.messagize(serder, sigers));
     let atc = ims.substring(serder.size);
@@ -179,7 +180,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -223,7 +224,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -320,12 +321,12 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     let roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
     atc = roleims.substring(rpy.size);
-    let roleembeds: any = {
+    let roleembeds = {
         rpy: [rpy, atc],
     };
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
@@ -368,7 +369,7 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
@@ -415,7 +416,7 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
@@ -463,7 +464,7 @@ test('multisig', async function run() {
     op1 = await eventResponse1.op();
     serder = eventResponse1.serder;
     sigs = eventResponse1.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -503,7 +504,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -541,7 +542,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -628,7 +629,7 @@ test('multisig', async function run() {
     op1 = await eventResponse1.op();
     serder = eventResponse1.serder;
     sigs = eventResponse1.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -668,7 +669,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -704,7 +705,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -755,7 +756,7 @@ test('multisig', async function run() {
     let anc = vcpRes1.serder;
     sigs = vcpRes1.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -798,7 +799,7 @@ test('multisig', async function run() {
     anc = vcpRes2.serder;
     sigs = vcpRes2.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -841,7 +842,7 @@ test('multisig', async function run() {
     anc = vcpRes3.serder;
     sigs = vcpRes3.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -962,6 +963,7 @@ test('multisig', async function run() {
         acdc: credRes.acdc,
         anc: credRes.anc,
         iss: credRes.iss,
+        sigs: credRes.sigs,
         recipient: holder,
         datetime: stamp,
     });
@@ -975,12 +977,12 @@ test('multisig', async function run() {
         'SealEvent',
         { i: m['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = gsigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     let gims = signify.d(signify.messagize(grant, sigers, seal));
     atc = gims.substring(grant.size);
     atc += end;
-    let gembeds: any = {
+    let gembeds = {
         exn: [grant, atc],
     };
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
@@ -1010,7 +1012,8 @@ test('multisig', async function run() {
         recipient: holder,
         acdc: credRes2.acdc,
         anc: credRes2.anc,
-        iss: credRes3.iss,
+        iss: credRes2.iss,
+        sigs: credRes2.sigs,
         datetime: stamp,
     });
 
@@ -1020,7 +1023,7 @@ test('multisig', async function run() {
             holder,
         ]);
 
-    sigers = gsigs2.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs2.map((sig) => new signify.Siger({ qb64: sig }));
 
     gims = signify.d(signify.messagize(grant2, sigers, seal));
     atc = gims.substring(grant2.size);
@@ -1055,6 +1058,7 @@ test('multisig', async function run() {
         acdc: credRes3.acdc,
         anc: credRes3.anc,
         iss: credRes3.iss,
+        sigs: credRes3.sigs,
         datetime: stamp,
     });
 
@@ -1064,7 +1068,7 @@ test('multisig', async function run() {
             holder,
         ]);
 
-    sigers = gsigs3.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs3.map((sig) => new signify.Siger({ qb64: sig }));
 
     gims = signify.d(signify.messagize(grant3, sigers, seal));
     atc = gims.substring(grant3.size);
@@ -1108,7 +1112,7 @@ test('multisig', async function run() {
     console.log(`Holder holds ${creds.length} credential`);
 }, 240000);
 
-async function waitForOp(client: SignifyClient, op: any) {
+async function waitForOp(client: SignifyClient, op: Operation) {
     while (!op['done']) {
         op = await client.operations().get(op.name);
         await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -1153,8 +1157,8 @@ async function createAID(client: SignifyClient, name: string, wits: string[]) {
         toad: wits.length,
         wits: wits,
     });
-    let op = await icpResult1.op();
-    op = await waitForOp(client, op);
+    const op = await icpResult1.op();
+    await waitForOp(client, op);
     const aid = await client.identifiers().get(name);
     await client.identifiers().addEndRole(name, 'agent', client!.agent!.pre);
     console.log(name, 'AID:', aid.prefix);

--- a/examples/integration-scripts/single-issuer-holder.test.ts
+++ b/examples/integration-scripts/single-issuer-holder.test.ts
@@ -104,6 +104,7 @@ async function issueCredential(
             acdc: result.acdc,
             anc: result.anc,
             iss: result.iss,
+            sigs: result.sigs,
         });
 
         await client

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -88,6 +88,7 @@ export interface IssueCredentialResult {
     acdc: Serder;
     anc: Serder;
     iss: Serder;
+    sigs: string[];
     op: Operation;
 }
 
@@ -112,6 +113,7 @@ export interface IpexGrantArgs {
      */
     agree?: string;
     datetime?: string;
+    sigs: string[];
     acdc: Serder;
     iss: Serder;
     anc: Serder;
@@ -266,6 +268,7 @@ export class Credentials {
             acdc: new Serder(acdc),
             iss: new Serder(iss),
             anc,
+            sigs,
             op,
         };
     }
@@ -705,9 +708,7 @@ export class Ipex {
             i: args.recipient,
         };
 
-        const keeper = this.client.manager?.get(hab);
-        const sigs = await keeper.sign(b(args.anc.raw));
-        const sigers = sigs.map((sig: string) => new Siger({ qb64: sig }));
+        const sigers = args.sigs.map((sig: string) => new Siger({ qb64: sig }));
         const ims = d(messagize(args.anc, sigers));
         const atc = ims.substring(args.anc.size);
 

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -334,7 +334,7 @@ describe('Ipex', () => {
         const ipex = client.ipex();
 
         const holder = 'ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k';
-        const [acdcSaider, acdc] = Saider.saidify(mockCredential.sad);
+        const [, acdc] = Saider.saidify(mockCredential.sad);
 
         // Create iss
         const vs = versify(Ident.KERI, undefined, Serials.JSON, 0);
@@ -348,7 +348,7 @@ describe('Ipex', () => {
             dt: mockCredential.sad.a.dt,
         };
 
-        const [issSaider, iss] = Saider.saidify(_iss);
+        const [, iss] = Saider.saidify(_iss);
         const iserder = new Serder(iss);
         const anc = interact({
             pre: mockCredential.sad.i,
@@ -359,6 +359,9 @@ describe('Ipex', () => {
             kind: undefined,
         });
 
+        const hab = await client.identifiers().get('multisig');
+        const sigs = client.manager?.get(hab).sign(b(anc.raw));
+
         const [grant, gsigs, end] = await ipex.grant({
             senderName: 'multisig',
             recipient: holder,
@@ -366,6 +369,7 @@ describe('Ipex', () => {
             acdc: new Serder(acdc),
             iss: iserder,
             anc,
+            sigs,
             datetime: mockCredential.sad.a.dt,
         });
 


### PR DESCRIPTION
I believe I moved one too many things into the grant() function in #150.

@pfeairheller mentioned this:

> But the current implementation of grant() in SigTS assumes you are only granting a credential you have issued and thus it signs the credential instead of accepting a signature, like the case where you are presenting a credential you already hold.