### PR TITLE
Integration test for rotating single-sig delegate identifier

### DIFF
--- a/examples/integration-scripts/singlesig-drt.test.ts
+++ b/examples/integration-scripts/singlesig-drt.test.ts
@@ -41,7 +41,7 @@ describe('singlesig-drt', () => {
         let delegate1 = await client2.identifiers().get('delegate1');
         let seal = {
             i: delegate1.prefix,
-            s: 0,
+            s: '0',
             d: delegate1.prefix,
         };
         let result = await client1.identifiers().interact('name1', seal);

--- a/examples/integration-scripts/singlesig-drt.test.ts
+++ b/examples/integration-scripts/singlesig-drt.test.ts
@@ -1,0 +1,67 @@
+import {
+    CreateIdentiferArgs,
+    RotateIdentifierArgs,
+    SignifyClient,
+} from 'signify-ts';
+import {
+    getOrCreateClients,
+    getOrCreateContact,
+    getOrCreateIdentifier,
+} from './utils/test-setup';
+import { waitOperation } from './utils/test-util';
+
+let client1: SignifyClient, client2: SignifyClient;
+let name1_id: string, name1_oobi: string;
+let contact1_id: string;
+
+beforeAll(async () => {
+    [client1, client2] = await getOrCreateClients(2);
+});
+beforeAll(async () => {
+    [name1_id, name1_oobi] = await getOrCreateIdentifier(client1, 'name1');
+});
+beforeAll(async () => {
+    contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
+});
+
+describe('singlesig-drt', () => {
+    test('delegate1a', async () => {
+        // delegate creates identifier without witnesses
+        // TODO: should have witness config
+        let kargs: CreateIdentiferArgs = {
+            delpre: name1_id,
+        };
+        let result = await client2.identifiers().create('delegate1', kargs);
+        let op = await result.op();
+        let delegate1 = await client2.identifiers().get('delegate1');
+        expect(op.name).toEqual(`delegation.${delegate1.prefix}`);
+    });
+    test('delegator1', async () => {
+        // delegator approves delegate
+        let delegate1 = await client2.identifiers().get('delegate1');
+        let seal = {
+            i: delegate1.prefix,
+            s: 0,
+            d: delegate1.prefix,
+        };
+        let result = await client1.identifiers().interact('name1', seal);
+        let op = waitOperation(client1, await result.op());
+    });
+    test('delegate1b', async () => {
+        // delegate waits for completion
+        let delegate1 = await client2.identifiers().get('delegate1');
+        let op: any = { name: `delegation.${delegate1.prefix}` };
+        op = await waitOperation(client2, op);
+        expect(delegate1.prefix).toEqual(op.response.i);
+    });
+    // TODO: identifiers.rotate fails with 500 server error
+    test.failing('delegate1c', async () => {
+        // delegate rotates identifier
+        let kargs: RotateIdentifierArgs = {};
+        let result = await client2.identifiers().rotate('delegate1', kargs);
+        let op = await result.op();
+        let delegate1 = await client2.identifiers().get('delegate1');
+        expect(op.name).toEqual(`delegation.${delegate1.prefix}`);
+        op = await waitOperation(client2, op);
+    });
+});

--- a/examples/integration-scripts/singlesig-drt.test.ts
+++ b/examples/integration-scripts/singlesig-drt.test.ts
@@ -54,8 +54,9 @@ describe('singlesig-drt', () => {
         op = await waitOperation(client2, op);
         expect(delegate1.prefix).toEqual(op.response.i);
     });
+    // https://github.com/WebOfTrust/signify-ts/issues/159
     // TODO: identifiers.rotate fails with 500 server error
-    test.failing('delegate1c', async () => {
+    test('delegate1c', async () => {
         // delegate rotates identifier
         let kargs: RotateIdentifierArgs = {};
         let result = await client2.identifiers().rotate('delegate1', kargs);


### PR DESCRIPTION
The last test is marked as failing. Reproduces issue #159 

Keria stack trace

```
signify-ts-keria-1         | 2023-12-02 09:12:11 [FALCON] [ERROR] PUT /identifiers/delegate1 => Traceback (most recent call last):
signify-ts-keria-1         |   File "/keria/venv/lib/python3.10/site-packages/keri/app/habbing.py", line 2443, in processEvent
signify-ts-keria-1         |     self.kvy.processEvent(serder=serder, sigers=sigers)
signify-ts-keria-1         |   File "/keria/venv/lib/python3.10/site-packages/keri/core/eventing.py", line 2994, in processEvent
signify-ts-keria-1         |     kever.update(serder=serder, sigers=sigers, wigers=wigers,
signify-ts-keria-1         |   File "/keria/venv/lib/python3.10/site-packages/keri/core/eventing.py", line 1940, in update
signify-ts-keria-1         |     raise ValidationError("Attempted non delegated rotation on "
signify-ts-keria-1         | keri.kering.ValidationError: Attempted non delegated rotation on delegated pre = EA8nuk8Z3ZwhL4PmECqNs6w4hUk47RGeiRTn0UKvRf74 with evt = {'v': 'KERI10JSON000160_', 't': 'rot', 'd': 'EA0dFkf7S1w3uJANMeZlcWAzTQRbgqURdjpFxSbjgekk', 'i': 'EA8nuk8Z3ZwhL4PmECqNs6w4hUk47RGeiRTn0UKvRf74', 's': '1', 'p': 'EA8nuk8Z3ZwhL4PmECqNs6w4hUk47RGeiRTn0UKvRf74', 'kt': '1', 'k': ['DLmuY28mF6Golgq2SJVENE4iLXqNc2nMcb7bh6eiLSqZ'], 'nt': '1', 'n': ['ELY_6-spjz3o-ceMXis4i81maZaRgzk45vjVWKMaxOAs'], 'bt': '0', 'br': [], 'ba': [], 'a': []}.
signify-ts-keria-1         |
signify-ts-keria-1         | During handling of the above exception, another exception occurred:
signify-ts-keria-1         |
signify-ts-keria-1         | Traceback (most recent call last):
signify-ts-keria-1         |   File "falcon/app.py", line 365, in falcon.app.App.__call__
signify-ts-keria-1         |   File "/keria/src/keria/app/aiding.py", line 470, in on_put
signify-ts-keria-1         |     op = self.rotate(agent, name, body)
signify-ts-keria-1         |   File "/keria/src/keria/app/aiding.py", line 506, in rotate
signify-ts-keria-1         |     hab.rotate(serder=serder, sigers=sigers)
signify-ts-keria-1         |   File "/keria/venv/lib/python3.10/site-packages/keri/app/habbing.py", line 2404, in rotate
signify-ts-keria-1         |     self.processEvent(serder, sigers)
signify-ts-keria-1         |   File "/keria/venv/lib/python3.10/site-packages/keri/app/habbing.py", line 2445, in processEvent
signify-ts-keria-1         |     raise kering.ConfigurationError(f"Improper Habitat event type={serder.ked['t']} for "
signify-ts-keria-1         | keri.kering.ConfigurationError: Improper Habitat event type=rot for pre=EA8nuk8Z3ZwhL4PmECqNs6w4hUk47RGeiRTn0UKvRf74.
signify-ts-keria-1         |
```