### PR TITLE
fix: remove TextEncoder import from node:util

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -15,7 +15,6 @@ import {
 import { Saider } from '../core/saider';
 import { Serder } from '../core/serder';
 import { Siger } from '../core/siger';
-import { TextDecoder } from 'util';
 import { TraitDex } from './habery';
 import {
     serializeACDCAttachment,

--- a/src/keri/core/eventing.ts
+++ b/src/keri/core/eventing.ts
@@ -19,7 +19,6 @@ import { Siger } from './siger';
 import { Cigar } from './cigar';
 import { Counter, CtrDex } from './counter';
 import { Seqner } from './seqner';
-import { TextEncoder } from 'util';
 
 const MaxIntThold = 2 ** 32 - 1;
 


### PR DESCRIPTION
TextEncoder should be used from global namespace. In the browser, calls to a function that imports from "node:util" currently fails.

For compatibility, see https://developer.mozilla.org/en-US/docs/Web/API/TextEncoder#browser_compatibility and https://caniuse.com/textencoder.