### PR TITLE
use waitOperation utility function in multisig test to fail faster

### DIFF
--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -5,6 +5,7 @@ import signify, {
     IssueCredentialResult,
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
+import { waitOperation } from './utils/test-util';
 
 const { url, bootUrl, vleiServerUrl } = resolveEnvironment();
 const WITNESS_AIDS = [
@@ -44,44 +45,44 @@ test('multisig', async function run() {
     ]);
 
     let op1 = await client1.oobis().resolve(oobi2.oobis[0], 'member2');
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     op1 = await client1.oobis().resolve(oobi3.oobis[0], 'member3');
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     op1 = await client1.oobis().resolve(SCHEMA_OOBI, 'schema');
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     op1 = await client1.oobis().resolve(oobi4.oobis[0], 'holder');
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     console.log('Member1 resolved 4 OOBIs');
 
     let op2 = await client2.oobis().resolve(oobi1.oobis[0], 'member1');
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     op2 = await client2.oobis().resolve(oobi3.oobis[0], 'member3');
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     op2 = await client2.oobis().resolve(SCHEMA_OOBI, 'schema');
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     op2 = await client2.oobis().resolve(oobi4.oobis[0], 'holder');
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     console.log('Member2 resolved 4 OOBIs');
 
     let op3 = await client3.oobis().resolve(oobi1.oobis[0], 'member1');
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     op3 = await client3.oobis().resolve(oobi2.oobis[0], 'member2');
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     op3 = await client3.oobis().resolve(SCHEMA_OOBI, 'schema');
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     op3 = await client3.oobis().resolve(oobi4.oobis[0], 'holder');
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     console.log('Member3 resolved 4 OOBIs');
 
     let op4 = await client4.oobis().resolve(oobi1.oobis[0], 'member1');
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
     op4 = await client4.oobis().resolve(oobi2.oobis[0], 'member2');
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
     op4 = await client4.oobis().resolve(oobi3.oobis[0], 'member3');
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
 
     op4 = await client4.oobis().resolve(SCHEMA_OOBI, 'schema');
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
 
     console.log('Holder resolved 4 OOBIs');
 
@@ -98,7 +99,7 @@ test('multisig', async function run() {
     console.log('Member3 responded challenge with signed words');
 
     op1 = await client1.challenges().verify('member1', aid2.prefix, words);
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member2');
     let exnwords = new Serder(op1.response.exn);
     op1 = await client1
@@ -107,7 +108,7 @@ test('multisig', async function run() {
     console.log('Member1 marked challenge response as accepted');
 
     op1 = await client1.challenges().verify('member1', aid3.prefix, words);
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member3');
     exnwords = new Serder(op1.response.exn);
     op1 = await client1
@@ -132,7 +133,7 @@ test('multisig', async function run() {
     let serder = icpResult1.serder;
 
     let sigs = icpResult1.sigs;
-    let sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    let sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     let ims = signify.d(signify.messagize(serder, sigers));
     let atc = ims.substring(serder.size);
@@ -178,7 +179,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -222,7 +223,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -247,9 +248,9 @@ test('multisig', async function run() {
     console.log('Member3 joined, multisig waiting for others...');
 
     // Check for completion
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log('Multisig created!');
     const identifiers1 = await client1.identifiers().list();
     assert.equal(identifiers1.aids.length, 2);
@@ -319,12 +320,12 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     let roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
     atc = roleims.substring(rpy.size);
-    let roleembeds: any = {
+    let roleembeds = {
         rpy: [rpy, atc],
     };
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
@@ -367,7 +368,7 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
@@ -414,7 +415,7 @@ test('multisig', async function run() {
         'SealEvent',
         { i: hab['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
     roleims = signify.d(
         signify.messagize(rpy, sigers, seal, undefined, undefined, false)
     );
@@ -439,15 +440,15 @@ test('multisig', async function run() {
     );
 
     // Check for completion
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log(`End role authorization for agent ${eid1}completed!`);
 
     // Holder resolve multisig OOBI
     const oobimultisig = await client1.oobis().get('multisig', 'agent');
     op4 = await client4.oobis().resolve(oobimultisig.oobis[0], 'multisig');
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
     console.log(`Holder resolved multisig OOBI`);
 
     // MultiSig Interaction
@@ -462,7 +463,7 @@ test('multisig', async function run() {
     op1 = await eventResponse1.op();
     serder = eventResponse1.serder;
     sigs = eventResponse1.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -502,7 +503,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -540,7 +541,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -565,55 +566,55 @@ test('multisig', async function run() {
     console.log('Member3 joins interaction event, waiting for others...');
 
     // Check for completion
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log('Multisig interaction completed!');
 
     // Members agree out of band to rotate keys
     console.log('Members agree out of band to rotate keys');
     icpResult1 = await client1.identifiers().rotate('member1');
     op1 = await icpResult1.op();
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     aid1 = await client1.identifiers().get('member1');
 
     console.log('Member1 rotated keys');
     icpResult2 = await client2.identifiers().rotate('member2');
     op2 = await icpResult2.op();
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     aid2 = await client2.identifiers().get('member2');
     console.log('Member2 rotated keys');
     icpResult3 = await client3.identifiers().rotate('member3');
     op3 = await icpResult3.op();
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     aid3 = await client3.identifiers().get('member3');
     console.log('Member3 rotated keys');
 
     // Update new key states
     op1 = await client1.keyStates().query(aid2.prefix, 1);
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     const aid2State = op1['response'];
     op1 = await client1.keyStates().query(aid3.prefix, 1);
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     const aid3State = op1['response'];
 
     op2 = await client2.keyStates().query(aid3.prefix, 1);
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     op2 = await client2.keyStates().query(aid1.prefix, 1);
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     const aid1State = op2['response'];
 
     op3 = await client3.keyStates().query(aid1.prefix, 1);
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     op3 = await client3.keyStates().query(aid2.prefix, 1);
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
 
     op4 = await client4.keyStates().query(aid1.prefix, 1);
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
     op4 = await client4.keyStates().query(aid2.prefix, 1);
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
     op4 = await client4.keyStates().query(aid3.prefix, 1);
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
 
     rstates = [aid1State, aid2State, aid3State];
     states = rstates;
@@ -627,7 +628,7 @@ test('multisig', async function run() {
     op1 = await eventResponse1.op();
     serder = eventResponse1.serder;
     sigs = eventResponse1.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -667,7 +668,7 @@ test('multisig', async function run() {
     op2 = await icpResult2.op();
     serder = icpResult2.serder;
     sigs = icpResult2.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -703,7 +704,7 @@ test('multisig', async function run() {
     op3 = await icpResult3.op();
     serder = icpResult3.serder;
     sigs = icpResult3.sigs;
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(serder, sigers));
     atc = ims.substring(serder.size);
@@ -728,9 +729,9 @@ test('multisig', async function run() {
     console.log('Member3 joins rotation event, waiting for others...');
 
     // Check for completion
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log('Multisig rotation completed!');
 
     hab = await client1.identifiers().get('multisig');
@@ -754,7 +755,7 @@ test('multisig', async function run() {
     let anc = vcpRes1.serder;
     sigs = vcpRes1.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -797,7 +798,7 @@ test('multisig', async function run() {
     anc = vcpRes2.serder;
     sigs = vcpRes2.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -840,7 +841,7 @@ test('multisig', async function run() {
     anc = vcpRes3.serder;
     sigs = vcpRes3.sigs;
 
-    sigers = sigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     ims = signify.d(signify.messagize(anc, sigers));
     atc = ims.substring(anc.size);
@@ -863,9 +864,9 @@ test('multisig', async function run() {
         );
 
     // Done
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log('Multisig create registry completed!');
 
     //Create Credential
@@ -935,22 +936,22 @@ test('multisig', async function run() {
     console.log('Member3 joins credential create event, waiting for others...');
 
     // Check completion
-    op1 = await waitForOp(client1, op1);
-    op2 = await waitForOp(client2, op2);
-    op3 = await waitForOp(client3, op3);
+    op1 = await waitOperation(client1, op1);
+    op2 = await waitOperation(client2, op2);
+    op3 = await waitOperation(client3, op3);
     console.log('Multisig create credential completed!');
 
     const m = await client1.identifiers().get('multisig');
 
     // Update states
     op1 = await client1.keyStates().query(m.prefix, 4);
-    op1 = await waitForOp(client1, op1);
+    op1 = await waitOperation(client1, op1);
     op2 = await client2.keyStates().query(m.prefix, 4);
-    op2 = await waitForOp(client2, op2);
+    op2 = await waitOperation(client2, op2);
     op3 = await client3.keyStates().query(m.prefix, 4);
-    op3 = await waitForOp(client3, op3);
+    op3 = await waitOperation(client3, op3);
     op4 = await client4.keyStates().query(m.prefix, 4);
-    op4 = await waitForOp(client4, op4);
+    op4 = await waitOperation(client4, op4);
 
     // IPEX grant message
     console.log('Starting grant message');
@@ -974,12 +975,12 @@ test('multisig', async function run() {
         'SealEvent',
         { i: m['prefix'], s: mstate['ee']['s'], d: mstate['ee']['d'] },
     ];
-    sigers = gsigs.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs.map((sig) => new signify.Siger({ qb64: sig }));
 
     let gims = signify.d(signify.messagize(grant, sigers, seal));
     atc = gims.substring(grant.size);
     atc += end;
-    let gembeds: any = {
+    let gembeds = {
         exn: [grant, atc],
     };
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
@@ -1019,7 +1020,7 @@ test('multisig', async function run() {
             holder,
         ]);
 
-    sigers = gsigs2.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs2.map((sig) => new signify.Siger({ qb64: sig }));
 
     gims = signify.d(signify.messagize(grant2, sigers, seal));
     atc = gims.substring(grant2.size);
@@ -1063,7 +1064,7 @@ test('multisig', async function run() {
             holder,
         ]);
 
-    sigers = gsigs3.map((sig: any) => new signify.Siger({ qb64: sig }));
+    sigers = gsigs3.map((sig) => new signify.Siger({ qb64: sig }));
 
     gims = signify.d(signify.messagize(grant3, sigers, seal));
     atc = gims.substring(grant3.size);
@@ -1107,14 +1108,6 @@ test('multisig', async function run() {
     console.log(`Holder holds ${creds.length} credential`);
 }, 360000);
 
-async function waitForOp(client: SignifyClient, op: any) {
-    while (!op['done']) {
-        op = await client.operations().get(op.name);
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    return op;
-}
-
 async function waitForMessage(client: SignifyClient, route: string) {
     let msgSaid = '';
     while (msgSaid == '') {
@@ -1151,8 +1144,7 @@ async function createAID(client: SignifyClient, name: string, wits: string[]) {
         toad: wits.length,
         wits: wits,
     });
-    let op = await icpResult1.op();
-    op = await waitForOp(client, op);
+    await waitOperation(client, await icpResult1.op());
     const aid = await client.identifiers().get(name);
     await client.identifiers().addEndRole(name, 'agent', client!.agent!.pre);
     console.log(name, 'AID:', aid.prefix);


### PR DESCRIPTION
The utility function `waitOperation` has a timeout, this ensure the test fails faster if an operation does not resolve.