### PR TITLE
suggestion: bail on first failing integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "build:types": "tsc -p tsconfig.build.json",
     "build": "npm run build:cjs && npm run build:esm && npm run build:types",
     "test": "jest test/",
-    "test:integration": "jest examples/integration-scripts/ --runInBand",
+    "test:integration": "jest examples/integration-scripts/ --runInBand --bail",
     "lint": "npx eslint src test examples/integration-scripts examples/scripts",
     "prepare": "npm run build",
     "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",


### PR DESCRIPTION
This is just a suggestion. I think it makes sense to bail on the test run when we encounter the first failing test. This will give you quicker feedback on the build if a test is failing.

Note that this is only for the integration tests.