### PR TITLE
using jest config to configure default timeout for integration tests

### DIFF
--- a/examples/integration-scripts/jest.config.ts
+++ b/examples/integration-scripts/jest.config.ts
@@ -1,0 +1,8 @@
+import { Config } from 'jest';
+
+const config: Config = {
+    preset: 'ts-jest',
+    setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+};
+
+export default config;

--- a/examples/integration-scripts/jest.setup.ts
+++ b/examples/integration-scripts/jest.setup.ts
@@ -1,0 +1,1 @@
+jest.setTimeout(30000);

--- a/examples/integration-scripts/singlesig-ixn.test.ts
+++ b/examples/integration-scripts/singlesig-ixn.test.ts
@@ -38,7 +38,7 @@ describe('singlesig-ixn', () => {
 
         // local and remote keystate sequence match
         expect(keystate1[0].s).toEqual(keystate2[0].s);
-    }, 30000);
+    });
     test('ixn1', async () => {
         // local keystate before ixn
         const keystate0: KeyState = (
@@ -75,5 +75,5 @@ describe('singlesig-ixn', () => {
         const keystate3: KeyState = op.response;
         // local and remote keystate match
         expect(keystate3.s).toEqual(keystate1.s);
-    }, 30000);
+    });
 });

--- a/examples/integration-scripts/singlesig-rot.test.ts
+++ b/examples/integration-scripts/singlesig-rot.test.ts
@@ -40,7 +40,7 @@ describe('singlesig-rot', () => {
 
         // local and remote keystate sequence match
         expect(keystate1[0].s).toEqual(keystate2[0].s);
-    }, 30000);
+    });
     test('rot1', async () => {
         // local keystate before rot
         const keystate0: KeyState = (
@@ -86,5 +86,5 @@ describe('singlesig-rot', () => {
         expect(keystate3.s).toEqual(keystate1.s);
         expect(keystate3.k[0]).toEqual(keystate1.k[0]);
         expect(keystate3.n[0]).toEqual(keystate1.n[0]);
-    }, 30000);
+    });
 });

--- a/examples/integration-scripts/witness.test.ts
+++ b/examples/integration-scripts/witness.test.ts
@@ -89,4 +89,4 @@ test('test witness', async () => {
     assert.equal(aid1.state.b.length, 1);
     assert.equal(aid1.state.b.length, 1);
     assert.equal(aid1.state.b[0], WITNESS_AID);
-}, 30000);
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,0 @@
-export default {
-    preset: 'ts-jest',
-};

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,9 @@
+import { Config } from 'jest';
+
+const config: Config = {
+    preset: 'ts-jest',
+    testMatch: ['<rootDir>/test/**/*.test.ts'],
+    projects: ['<rootDir>', '<rootDir>/examples/integration-scripts'],
+};
+
+export default config;


### PR DESCRIPTION
As per suggestion by [psteniusubi](https://github.com/psteniusubi). But instead of adding "testTimeout" as a cli option, I think it is better to add it as a config. This should ensure it is picked up when running the tests from an IDE as well.

Note that there is actually an option for "testTimeout" that can be set in the config directly. But currently there is an issue with that (https://github.com/jestjs/jest/issues/14513) and it does not look like it will be released in jest v29. When we upgrade, we can avoid the jest.setup.ts file.