### PR TITLE
fix challenge.test.ts

### DIFF
--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -92,8 +92,9 @@ test('challenge', async () => {
 
     // List Client 1 contacts
     let contacts1 = await client1.contacts().list();
-    expect(contacts1[0].alias).toEqual('bob');
-    expect(contacts1[0].challenges).toHaveLength(0);
+    let bobContact = findContact(contacts1, 'bob');
+    expect(bobContact.alias).toEqual('bob');
+    expect(bobContact.challenges).toHaveLength(0);
 
     // Bob responds to Alice challenge
     await client2.challenges().respond('bob', aid1.i, challenge1_small.words);
@@ -119,5 +120,16 @@ test('challenge', async () => {
 
     // Check Bob's challenge in conctats
     contacts1 = await client1.contacts().list();
-    expect(contacts1[0].challenges[0].authenticated).toEqual(true);
+    bobContact = findContact(contacts1, 'bob');
+    expect(bobContact.challenges[0].authenticated).toEqual(true);
 }, 30000);
+
+function findContact(contactsList: any, name: any) {
+    let contact: any;
+    for (const index in contactsList) {
+        if (contactsList[index].alias == name) {
+            contact = contactsList[index];
+        }
+    }
+    return contact;
+}

--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -92,7 +92,9 @@ test('challenge', async () => {
 
     // List Client 1 contacts
     let contacts1 = await client1.contacts().list();
-    let bobContact = findContact(contacts1, 'bob');
+    let bobContact = contacts1.find(
+        (contact: { alias: string }) => contact.alias === 'bob'
+    );
     expect(bobContact.alias).toEqual('bob');
     expect(bobContact.challenges).toHaveLength(0);
 
@@ -120,16 +122,8 @@ test('challenge', async () => {
 
     // Check Bob's challenge in conctats
     contacts1 = await client1.contacts().list();
-    bobContact = findContact(contacts1, 'bob');
+    bobContact = contacts1.find(
+        (contact: { alias: string }) => contact.alias === 'bob'
+    );
     expect(bobContact.challenges[0].authenticated).toEqual(true);
 }, 30000);
-
-function findContact(contactsList: any, name: any) {
-    let contact: any;
-    for (const index in contactsList) {
-        if (contactsList[index].alias == name) {
-            contact = contactsList[index];
-        }
-    }
-    return contact;
-}


### PR DESCRIPTION
When I ran `challenge.test.ts` locally using 
```
TEST_ENVIRONMENT=local npx jest examples/integration-scripts/challenge.test.ts
```

I encountered the following error 
```
 FAIL  examples/integration-scripts/challenge.test.ts (9.743 s)
  ✕ challenge (8165 ms)

  ● challenge

    expect(received).toEqual(expected) // deep equality

    Expected: "bob"
    Received: "Wan"

      93 |     // List Client 1 contacts
      94 |     let contacts1 = await client1.contacts().list();
    > 95 |     expect(contacts1[0].alias).toEqual('bob');
         |                                ^
      96 |     expect(contacts1[0].challenges).toHaveLength(0);
      97 |
      98 |     // Bob responds to Alice challenge

      at Object.<anonymous> (challenge.test.ts:95:32)
```

`contacts1[0]` points to a witness instead of `bob`. I assume that this test passed the automatic test, so I guess the order of elements in `contacts`  is somehow different in the automatic test. Hence, I added a function `findContact()` and a variable `bobContact = findContact(contacts1, 'bob')` to avoid this error.