### PR TITLE
Show Python container logs locally

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,9 @@
 services:
     vlei-server:
         image: gleif/vlei
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONIOENCODING=UTF-8
         command:
             - vLEI-server
             - -s
@@ -27,6 +30,8 @@ services:
         environment:
             - KERI_AGENT_CORS=1
             - KERI_URL=http://keria:3902
+            - PYTHONUNBUFFERED=1
+            - PYTHONIOENCODING=UTF-8
         volumes:
             - ./config/keria.json:/keria/config/keri/cf/keria.json
         entrypoint: keria
@@ -51,6 +56,9 @@ services:
 
     witness-demo:
         image: weboftrust/keri-witness-demo:1.1.0
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONIOENCODING=UTF-8
         healthcheck:
             test: ['CMD', 'curl', '-f', 'http://localhost:5642/oobi']
             interval: 2s


### PR DESCRIPTION
By default in non-interactive mode, when not run as an interactive script, Python doesn't flush the log buffer to stdout or stderr. This means you need to set PYTHONUNBUFFERED=1 to ensure that the output is not buffered, which means it is immediately flushed to stdout or stderr.

In containers this is needed as it makes viewing logs in real-time reliable and consistent.