### PR TITLE
add check for revoked credential for holder

### DIFF
--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -447,4 +447,17 @@ test('single signature credentials', async () => {
 
         assert.equal(issuerCredential.status.s, '1');
     });
+
+    await step('Holder has revoked QVI credential', async () => {
+        await retry(
+            async () => {
+                const holderCredential = await holderClient
+                    .credentials()
+                    .get(holderAid.name, qviCredentialId);
+
+                assert.equal(holderCredential.status.s, '1');
+            },
+            { timeout: 3000 }
+        );
+    });
 }, 90000);


### PR DESCRIPTION
First attempt to add coverage to resolve #187 

Created as draft because it does not work at the moment. What are the intended steps here? Another IPEX grant + admit after revocation?