### PR TITLE
Add registry GET

### DIFF
--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -96,15 +96,11 @@ test('single signature credentials', async () => {
             .create({ name: issuerAid.name, registryName: registryName });
 
         await waitOperation(issuerClient, await regResult.op());
-        const registries = await issuerClient.registries().list(issuerAid.name);
+
         const reg = await holderClient
-          .registries()
-          .get(holderAid.name, registryName)
-        assert.equal(reg.name, registryName)
-        assert.equal(registries[0].name, reg.name)
-        const registry: { name: string; regk: string } = registries[0];
-        assert.equal(registries.length, 1);
-        assert.equal(registry.name, registryName);
+            .registries()
+            .get(holderAid.name, registryName);
+        assert.equal(reg.name, registryName);
         return reg;
     });
 
@@ -330,15 +326,10 @@ test('single signature credentials', async () => {
                 .create({ name: holderAid.name, registryName: registryName });
 
             await waitOperation(holderClient, await regResult.op());
-            const registries = await holderClient
-                .registries()
-                .list(holderAid.name);
             const reg = await holderClient
-              .registries()
-              .get(holderAid.name, registryName)
-            assert.equal(reg.name, registryName)
-            assert.equal(registries[0].name, reg.name)
-            assert(registries.length >= 1);
+                .registries()
+                .get(holderAid.name, registryName);
+            assert.equal(reg.name, registryName);
             return reg;
         }
     );

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -97,10 +97,15 @@ test('single signature credentials', async () => {
 
         await waitOperation(issuerClient, await regResult.op());
         const registries = await issuerClient.registries().list(issuerAid.name);
+        const reg = await holderClient
+          .registries()
+          .get(holderAid.name, registryName)
+        assert.equal(reg.name, registryName)
+        assert.equal(registries[0].name, reg.name)
         const registry: { name: string; regk: string } = registries[0];
         assert.equal(registries.length, 1);
         assert.equal(registry.name, registryName);
-        return registry;
+        return reg;
     });
 
     await step('issuer can get schemas', async () => {
@@ -328,8 +333,13 @@ test('single signature credentials', async () => {
             const registries = await holderClient
                 .registries()
                 .list(holderAid.name);
+            const reg = await holderClient
+              .registries()
+              .get(holderAid.name, registryName)
+            assert.equal(reg.name, registryName)
+            assert.equal(registries[0].name, reg.name)
             assert(registries.length >= 1);
-            return registries[0];
+            return reg;
         }
     );
 

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -97,9 +97,9 @@ test('single signature credentials', async () => {
 
         await waitOperation(issuerClient, await regResult.op());
 
-        const reg = await holderClient
+        const reg = await issuerClient
             .registries()
-            .get(holderAid.name, registryName);
+            .get(issuerAid.name, registryName);
         assert.equal(reg.name, registryName);
         return reg;
     });

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -7,11 +7,11 @@ import {
     d,
     Dict,
     Ident,
-    Ilks, Registry,
+    Ilks,
     Serials,
     versify,
-    Versionage
-} from "../core/core";
+    Versionage,
+} from '../core/core';
 import { Saider } from '../core/saider';
 import { Serder } from '../core/serder';
 import { Siger } from '../core/siger';
@@ -526,6 +526,16 @@ export class RegistryResult {
         const res = await this.promise;
         return await res.json();
     }
+}
+
+/**
+ * Data for a registry
+ */
+export interface Registry {
+    name: string;
+    regk: string;
+    pre: string;
+    state: any;
 }
 
 /**

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -7,11 +7,11 @@ import {
     d,
     Dict,
     Ident,
-    Ilks,
+    Ilks, Registry,
     Serials,
     versify,
-    Versionage,
-} from '../core/core';
+    Versionage
+} from "../core/core";
 import { Saider } from '../core/saider';
 import { Serder } from '../core/serder';
 import { Siger } from '../core/siger';
@@ -542,12 +542,24 @@ export class Registries {
     }
 
     /**
+     * Get a registry
+     * @param name Name or alias of the identifier
+     * @param registryName Name of the registry to get
+     */
+    async get(name: string, registryName: string): Promise<Registry> {
+        const path = `/identifiers/${name}/registries/${registryName}`;
+        const method = 'GET';
+        const res = await this.client.fetch(path, method, null);
+        return await res.json();
+    }
+
+    /**
      * List registries
      * @async
      * @param {string} name Name or alias of the identifier
      * @returns {Promise<any>} A promise to the list of registries
      */
-    async list(name: string): Promise<any> {
+    async list(name: string): Promise<Registry[]> {
         const path = `/identifiers/${name}/registries`;
         const method = 'GET';
         const res = await this.client.fetch(path, method, null);

--- a/src/keri/core/core.ts
+++ b/src/keri/core/core.ts
@@ -324,10 +324,3 @@ export function readInt(array: Uint8Array) {
     }
     return value;
 }
-
-export interface Registry {
-    name: string;
-    regk: string;
-    pre: string;
-    state: any;
-}

--- a/src/keri/core/core.ts
+++ b/src/keri/core/core.ts
@@ -324,3 +324,10 @@ export function readInt(array: Uint8Array) {
     }
     return value;
 }
+
+export interface Registry {
+    name: string;
+    regk: string;
+    pre: string;
+    state: any;
+}


### PR DESCRIPTION
KERIA supports a GET for a Registry. This will simplify checking if a registry exists or not and getting its details. Since we have `registries.list()` we may as well have `registries.get()`.