### PR TITLE
Update keyState call to use hex string instead of int for sequence number.

### DIFF
--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -142,7 +142,7 @@ test('delegation-multisig', async () => {
     // Client 0 approves delegation
     const anchor = {
         i: delegatePrefix,
-        s: 0,
+        s: '0',
         d: delegatePrefix,
     };
     await client0.identifiers().interact('delegator', anchor);

--- a/examples/integration-scripts/delegation.test.ts
+++ b/examples/integration-scripts/delegation.test.ts
@@ -75,7 +75,7 @@ test('delegation', async () => {
     // Client 1 approves deletation
     const anchor = {
         i: delegatePrefix,
-        s: 0,
+        s: '0',
         d: delegatePrefix,
     };
     await client1.identifiers().interact('delegator', anchor);

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -592,29 +592,29 @@ test('multisig', async function run() {
     console.log('Member3 rotated keys');
 
     // Update new key states
-    op1 = await client1.keyStates().query(aid2.prefix, 1);
+    op1 = await client1.keyStates().query(aid2.prefix, "1");
     op1 = await waitOperation(client1, op1);
     const aid2State = op1['response'];
-    op1 = await client1.keyStates().query(aid3.prefix, 1);
+    op1 = await client1.keyStates().query(aid3.prefix, "1");
     op1 = await waitOperation(client1, op1);
     const aid3State = op1['response'];
 
-    op2 = await client2.keyStates().query(aid3.prefix, 1);
+    op2 = await client2.keyStates().query(aid3.prefix, "1");
     op2 = await waitOperation(client2, op2);
-    op2 = await client2.keyStates().query(aid1.prefix, 1);
+    op2 = await client2.keyStates().query(aid1.prefix, "1");
     op2 = await waitOperation(client2, op2);
     const aid1State = op2['response'];
 
-    op3 = await client3.keyStates().query(aid1.prefix, 1);
+    op3 = await client3.keyStates().query(aid1.prefix, "1");
     op3 = await waitOperation(client3, op3);
-    op3 = await client3.keyStates().query(aid2.prefix, 1);
+    op3 = await client3.keyStates().query(aid2.prefix, "1");
     op3 = await waitOperation(client3, op3);
 
-    op4 = await client4.keyStates().query(aid1.prefix, 1);
+    op4 = await client4.keyStates().query(aid1.prefix, "1");
     op4 = await waitOperation(client4, op4);
-    op4 = await client4.keyStates().query(aid2.prefix, 1);
+    op4 = await client4.keyStates().query(aid2.prefix, "1");
     op4 = await waitOperation(client4, op4);
-    op4 = await client4.keyStates().query(aid3.prefix, 1);
+    op4 = await client4.keyStates().query(aid3.prefix, "1");
     op4 = await waitOperation(client4, op4);
 
     rstates = [aid1State, aid2State, aid3State];
@@ -945,13 +945,13 @@ test('multisig', async function run() {
     const m = await client1.identifiers().get('multisig');
 
     // Update states
-    op1 = await client1.keyStates().query(m.prefix, 4);
+    op1 = await client1.keyStates().query(m.prefix, "4");
     op1 = await waitOperation(client1, op1);
-    op2 = await client2.keyStates().query(m.prefix, 4);
+    op2 = await client2.keyStates().query(m.prefix, "4");
     op2 = await waitOperation(client2, op2);
-    op3 = await client3.keyStates().query(m.prefix, 4);
+    op3 = await client3.keyStates().query(m.prefix, "4");
     op3 = await waitOperation(client3, op3);
-    op4 = await client4.keyStates().query(m.prefix, 4);
+    op4 = await client4.keyStates().query(m.prefix, "4");
     op4 = await waitOperation(client4, op4);
 
     // IPEX grant message

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -592,29 +592,29 @@ test('multisig', async function run() {
     console.log('Member3 rotated keys');
 
     // Update new key states
-    op1 = await client1.keyStates().query(aid2.prefix, "1");
+    op1 = await client1.keyStates().query(aid2.prefix, '1');
     op1 = await waitOperation(client1, op1);
     const aid2State = op1['response'];
-    op1 = await client1.keyStates().query(aid3.prefix, "1");
+    op1 = await client1.keyStates().query(aid3.prefix, '1');
     op1 = await waitOperation(client1, op1);
     const aid3State = op1['response'];
 
-    op2 = await client2.keyStates().query(aid3.prefix, "1");
+    op2 = await client2.keyStates().query(aid3.prefix, '1');
     op2 = await waitOperation(client2, op2);
-    op2 = await client2.keyStates().query(aid1.prefix, "1");
+    op2 = await client2.keyStates().query(aid1.prefix, '1');
     op2 = await waitOperation(client2, op2);
     const aid1State = op2['response'];
 
-    op3 = await client3.keyStates().query(aid1.prefix, "1");
+    op3 = await client3.keyStates().query(aid1.prefix, '1');
     op3 = await waitOperation(client3, op3);
-    op3 = await client3.keyStates().query(aid2.prefix, "1");
+    op3 = await client3.keyStates().query(aid2.prefix, '1');
     op3 = await waitOperation(client3, op3);
 
-    op4 = await client4.keyStates().query(aid1.prefix, "1");
+    op4 = await client4.keyStates().query(aid1.prefix, '1');
     op4 = await waitOperation(client4, op4);
-    op4 = await client4.keyStates().query(aid2.prefix, "1");
+    op4 = await client4.keyStates().query(aid2.prefix, '1');
     op4 = await waitOperation(client4, op4);
-    op4 = await client4.keyStates().query(aid3.prefix, "1");
+    op4 = await client4.keyStates().query(aid3.prefix, '1');
     op4 = await waitOperation(client4, op4);
 
     rstates = [aid1State, aid2State, aid3State];
@@ -945,13 +945,13 @@ test('multisig', async function run() {
     const m = await client1.identifiers().get('multisig');
 
     // Update states
-    op1 = await client1.keyStates().query(m.prefix, "4");
+    op1 = await client1.keyStates().query(m.prefix, '4');
     op1 = await waitOperation(client1, op1);
-    op2 = await client2.keyStates().query(m.prefix, "4");
+    op2 = await client2.keyStates().query(m.prefix, '4');
     op2 = await waitOperation(client2, op2);
-    op3 = await client3.keyStates().query(m.prefix, "4");
+    op3 = await client3.keyStates().query(m.prefix, '4');
     op3 = await waitOperation(client3, op3);
-    op4 = await client4.keyStates().query(m.prefix, "4");
+    op4 = await client4.keyStates().query(m.prefix, '4');
     op4 = await waitOperation(client4, op4);
 
     // IPEX grant message

--- a/examples/integration-scripts/singlesig-ixn.test.ts
+++ b/examples/integration-scripts/singlesig-ixn.test.ts
@@ -70,7 +70,7 @@ describe('singlesig-ixn', () => {
         // refresh remote keystate
         let op = await client2
             .keyStates()
-            .query(contact1_id, parseInt(keystate1.s), undefined);
+            .query(contact1_id, keystate1.s, undefined);
         op = await waitOperation(client2, op);
         const keystate3: KeyState = op.response;
         // local and remote keystate match

--- a/examples/integration-scripts/singlesig-rot.test.ts
+++ b/examples/integration-scripts/singlesig-rot.test.ts
@@ -79,7 +79,7 @@ describe('singlesig-rot', () => {
         // refresh remote keystate
         let op = await client2
             .keyStates()
-            .query(contact1_id, parseInt(keystate1.s), undefined);
+            .query(contact1_id, keystate1.s, undefined);
         op = await waitOperation(client2, op);
         const keystate3: KeyState = op.response;
         // local and remote keystate match

--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -173,7 +173,7 @@ export class KeyStates {
      * @param {string} [anchor] Optional anchor SAID
      * @returns {Promise<any>} A promise to the long-running operation
      */
-    async query(pre: string, sn?: number, anchor?: string): Promise<any> {
+    async query(pre: string, sn?: string, anchor?: string): Promise<any> {
         const path = `/queries`;
         const data: any = {
             pre: pre,

--- a/test/app/coring.test.ts
+++ b/test/app/coring.test.ts
@@ -261,7 +261,7 @@ describe('Coring', () => {
 
         await keyStates.query(
             'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX',
-            "1",
+            '1',
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
@@ -272,7 +272,7 @@ describe('Coring', () => {
             lastBody.pre,
             'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX'
         );
-        assert.equal(lastBody.sn, "1");
+        assert.equal(lastBody.sn, '1');
         assert.equal(
             lastBody.anchor,
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'

--- a/test/app/coring.test.ts
+++ b/test/app/coring.test.ts
@@ -261,7 +261,7 @@ describe('Coring', () => {
 
         await keyStates.query(
             'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX',
-            1,
+            "1",
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
@@ -272,7 +272,7 @@ describe('Coring', () => {
             lastBody.pre,
             'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX'
         );
-        assert.equal(lastBody.sn, 1);
+        assert.equal(lastBody.sn, "1");
         assert.equal(
             lastBody.anchor,
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'


### PR DESCRIPTION
This PR fixes keyState queries by using hex string for sequence number parameter instead of int.