### PR TITLE
update credential rules type to support value as string

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -65,7 +65,7 @@ export interface IssueCredentialArgs {
     /**
      * Credential rules
      */
-    rules?: Record<string, unknown>;
+    rules?: string | Record<string, unknown>;
 
     /**
      * Credential sources


### PR DESCRIPTION
- update credential rules type to support value as string for usecases when schema rules can be just SAID of the rules block object. For example rules block of [LE vLEI schema](https://github.com/WebOfTrust/vLEI/blob/dev/schema/acdc/legal-entity-vLEI-credential.json#L121)