### PR TITLE
Update challenge and credential endpoints to remove unneeded path parameters

### DIFF
--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -104,7 +104,7 @@ test('challenge', async () => {
         client1,
         await client1
             .challenges()
-            .verify('alice', aid2.i, challenge1_small.words)
+            .verify(aid2.i, challenge1_small.words)
     );
     console.log('Alice verified challenge response');
 
@@ -114,7 +114,7 @@ test('challenge', async () => {
     };
     const exn = new Serder(verifyResponse.exn);
 
-    await client1.challenges().responded('alice', aid2.i, exn.ked.d);
+    await client1.challenges().responded(aid2.i, exn.ked.d);
     console.log('Alice marked challenge response as accepted');
 
     // Check Bob's challenge in conctats

--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -102,9 +102,7 @@ test('challenge', async () => {
     // Alice verifies Bob's response
     const verifyOperation = await waitOperation(
         client1,
-        await client1
-            .challenges()
-            .verify(aid2.i, challenge1_small.words)
+        await client1.challenges().verify(aid2.i, challenge1_small.words)
     );
     console.log('Alice verified challenge response');
 

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -422,9 +422,7 @@ test('single signature credentials', async () => {
 
     await step('Legal Entity has chained credential', async () => {
         const legalEntityCredential = await retry(async () =>
-            legalEntityClient
-                .credentials()
-                .get(leCredentialId)
+            legalEntityClient.credentials().get(leCredentialId)
         );
 
         assert.equal(legalEntityCredential.sad.s, LE_SCHEMA_SAID);

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -188,7 +188,7 @@ test('single signature credentials', async () => {
     await step('issuer get credential by id', async () => {
         const issuerCredential = await issuerClient
             .credentials()
-            .get(issuerAid.name, qviCredentialId);
+            .get(qviCredentialId);
         assert.equal(issuerCredential.sad.s, QVI_SCHEMA_SAID);
         assert.equal(issuerCredential.sad.i, issuerAid.prefix);
         assert.equal(issuerCredential.status.s, '0');
@@ -198,7 +198,7 @@ test('single signature credentials', async () => {
         const dt = createTimestamp();
         const issuerCredential = await issuerClient
             .credentials()
-            .get(issuerAid.name, qviCredentialId);
+            .get(qviCredentialId);
         assert(issuerCredential !== undefined);
 
         const [grant, gsigs, gend] = await issuerClient.ipex().grant({
@@ -244,7 +244,7 @@ test('single signature credentials', async () => {
         const holderCredential = await retry(async () => {
             const result = await holderClient
                 .credentials()
-                .get(holderAid.name, qviCredentialId);
+                .get(qviCredentialId);
             assert(result !== undefined);
             return result;
         });
@@ -257,7 +257,7 @@ test('single signature credentials', async () => {
     await step('holder IPEX present', async () => {
         const holderCredential = await holderClient
             .credentials()
-            .get(holderAid.name, qviCredentialId);
+            .get(qviCredentialId);
 
         const [grant2, gsigs2, gend2] = await holderClient.ipex().grant({
             senderName: holderAid.name,
@@ -308,7 +308,7 @@ test('single signature credentials', async () => {
         await verifierClient.notifications().mark(verifierGrantNote.i);
 
         const verifierCredential = await retry(async () =>
-            verifierClient.credentials().get(verifierAid.name, qviCredentialId)
+            verifierClient.credentials().get(qviCredentialId)
         );
 
         assert.equal(verifierCredential.sad.s, QVI_SCHEMA_SAID);
@@ -338,7 +338,7 @@ test('single signature credentials', async () => {
         async () => {
             const qviCredential = await holderClient
                 .credentials()
-                .get(holderAid.name, qviCredentialId);
+                .get(qviCredentialId);
 
             const result = await holderClient.credentials().issue({
                 issuerName: holderAid.name,
@@ -375,7 +375,7 @@ test('single signature credentials', async () => {
         const dt = createTimestamp();
         const leCredential = await holderClient
             .credentials()
-            .get(holderAid.name, leCredentialId);
+            .get(leCredentialId);
         assert(leCredential !== undefined);
 
         const [grant, gsigs, gend] = await holderClient.ipex().grant({
@@ -424,7 +424,7 @@ test('single signature credentials', async () => {
         const legalEntityCredential = await retry(async () =>
             legalEntityClient
                 .credentials()
-                .get(legalEntityAid.name, leCredentialId)
+                .get(leCredentialId)
         );
 
         assert.equal(legalEntityCredential.sad.s, LE_SCHEMA_SAID);
@@ -443,7 +443,7 @@ test('single signature credentials', async () => {
         await waitOperation(issuerClient, revokeOperation);
         const issuerCredential = await issuerClient
             .credentials()
-            .get(issuerAid.name, qviCredentialId);
+            .get(qviCredentialId);
 
         assert.equal(issuerCredential.status.s, '1');
     });

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -99,22 +99,22 @@ test('multisig', async function run() {
     await client3.challenges().respond('member3', aid1.prefix, words);
     console.log('Member3 responded challenge with signed words');
 
-    op1 = await client1.challenges().verify('member1', aid2.prefix, words);
+    op1 = await client1.challenges().verify(aid2.prefix, words);
     op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member2');
     let exnwords = new Serder(op1.response.exn);
     op1 = await client1
         .challenges()
-        .responded('member1', aid2.prefix, exnwords.ked.d);
+        .responded(aid2.prefix, exnwords.ked.d);
     console.log('Member1 marked challenge response as accepted');
 
-    op1 = await client1.challenges().verify('member1', aid3.prefix, words);
+    op1 = await client1.challenges().verify(aid3.prefix, words);
     op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member3');
     exnwords = new Serder(op1.response.exn);
     op1 = await client1
         .challenges()
-        .responded('member1', aid3.prefix, exnwords.ked.d);
+        .responded(aid3.prefix, exnwords.ked.d);
     console.log('Member1 marked challenge response as accepted');
 
     // First member start the creation of a multisig identifier

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -103,18 +103,14 @@ test('multisig', async function run() {
     op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member2');
     let exnwords = new Serder(op1.response.exn);
-    op1 = await client1
-        .challenges()
-        .responded(aid2.prefix, exnwords.ked.d);
+    op1 = await client1.challenges().responded(aid2.prefix, exnwords.ked.d);
     console.log('Member1 marked challenge response as accepted');
 
     op1 = await client1.challenges().verify(aid3.prefix, words);
     op1 = await waitOperation(client1, op1);
     console.log('Member1 verified challenge response from member3');
     exnwords = new Serder(op1.response.exn);
-    op1 = await client1
-        .challenges()
-        .responded(aid3.prefix, exnwords.ked.d);
+    op1 = await client1.challenges().responded(aid3.prefix, exnwords.ked.d);
     console.log('Member1 marked challenge response as accepted');
 
     // First member start the creation of a multisig identifier

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -515,7 +515,7 @@ async function getOrIssueCredential(
     await waitOperation(issuerClient, issResult.op);
     const credential = await issuerClient
         .credentials()
-        .get(issuerAid.name, issResult.acdc.ked.d);
+        .get(issResult.acdc.ked.d);
 
     return credential;
 }

--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -159,10 +159,7 @@ export class Challenges {
      * @param {Array<string>} words List of challenge words to check for
      * @returns A promise to the long running operation
      */
-    async verify(
-        source: string,
-        words: string[]
-    ): Promise<Operation<unknown>> {
+    async verify(source: string, words: string[]): Promise<Operation<unknown>> {
         const path = `/challenges_verify/${source}`;
         const method = 'POST';
         const data = {
@@ -179,10 +176,7 @@ export class Challenges {
      * @param {string} said qb64 AID of exn message representing the signed response
      * @returns {Promise<Response>} A promise to the result
      */
-    async responded(
-        source: string,
-        said: string
-    ): Promise<Response> {
+    async responded(source: string, said: string): Promise<Response> {
         const path = `/challenges_verify/${source}`;
         const method = 'PUT';
         const data = {

--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -155,17 +155,15 @@ export class Challenges {
 
     /**
      * Ask Agent to verify a given sender signed the provided words
-     * @param {string} name Name or alias of the identifier
      * @param {string} source Prefix of the identifier that was challenged
      * @param {Array<string>} words List of challenge words to check for
      * @returns A promise to the long running operation
      */
     async verify(
-        name: string,
         source: string,
         words: string[]
     ): Promise<Operation<unknown>> {
-        const path = `/challenges/${name}/verify/${source}`;
+        const path = `/challenges_verify/${source}`;
         const method = 'POST';
         const data = {
             words: words,
@@ -177,17 +175,15 @@ export class Challenges {
 
     /**
      * Mark challenge response as signed and accepted
-     * @param {string} name Name or alias of the identifier
      * @param {string} source Prefix of the identifier that was challenged
      * @param {string} said qb64 AID of exn message representing the signed response
      * @returns {Promise<Response>} A promise to the result
      */
     async responded(
-        name: string,
         source: string,
         said: string
     ): Promise<Response> {
-        const path = `/challenges/${name}/verify/${source}`;
+        const path = `/challenges_verify/${source}`;
         const method = 'PUT';
         const data = {
             said: said,

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -160,17 +160,15 @@ export class Credentials {
     /**
      * Get a credential
      * @async
-     * @param {string} name - Name or alias of the identifier
      * @param {string} said - SAID of the credential
      * @param {boolean} [includeCESR=false] - Optional flag export the credential in CESR format
      * @returns {Promise<any>} A promise to the credential
      */
     async get(
-        name: string,
         said: string,
         includeCESR: boolean = false
     ): Promise<any> {
-        const path = `/identifiers/${name}/credentials/${said}`;
+        const path = `/credentials/${said}`;
         const method = 'GET';
         const headers = includeCESR
             ? new Headers({ Accept: 'application/json+cesr' })
@@ -286,7 +284,7 @@ export class Credentials {
         const vs = versify(Ident.KERI, undefined, Serials.JSON, 0);
         const dt = new Date().toISOString().replace('Z', '000+00:00');
 
-        const cred = await this.get(name, said);
+        const cred = await this.get(said);
 
         // Create rev
         const _rev = {
@@ -373,7 +371,7 @@ export class Credentials {
         const hab = await this.client.identifiers().get(name);
         const pre: string = hab.prefix;
 
-        const cred = await this.get(name, said);
+        const cred = await this.get(said);
         const data = {
             i: cred.sad.i,
             s: cred.sad.s,

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -164,10 +164,7 @@ export class Credentials {
      * @param {boolean} [includeCESR=false] - Optional flag export the credential in CESR format
      * @returns {Promise<any>} A promise to the credential
      */
-    async get(
-        said: string,
-        includeCESR: boolean = false
-    ): Promise<any> {
+    async get(said: string, includeCESR: boolean = false): Promise<any> {
         const path = `/credentials/${said}`;
         const method = 'GET';
         const headers = includeCESR

--- a/test/app/contacting.test.ts
+++ b/test/app/contacting.test.ts
@@ -272,7 +272,6 @@ describe('Contacting', () => {
         assert.equal(lastBody.sigs[0].length, 88);
 
         await challenges.verify(
-            'aid1',
             'EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p',
             words
         );
@@ -280,14 +279,13 @@ describe('Contacting', () => {
         assert.equal(
             lastCall[0]!,
             url +
-                '/challenges/aid1/verify/EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p'
+                '/challenges_verify/EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p'
         );
         assert.equal(lastCall[1]!.method, 'POST');
         lastBody = JSON.parse(lastCall[1]!.body!.toString());
         assert.deepEqual(lastBody.words, words);
 
         await challenges.responded(
-            'aid1',
             'EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p',
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
@@ -295,7 +293,7 @@ describe('Contacting', () => {
         assert.equal(
             lastCall[0]!,
             url +
-                '/challenges/aid1/verify/EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p'
+                '/challenges_verify/EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p'
         );
         assert.equal(lastCall[1]!.method, 'PUT');
         lastBody = JSON.parse(lastCall[1]!.body!.toString());

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -202,8 +202,7 @@ describe('Credentialing', () => {
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0]!,
-            url +
-                '/credentials/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+            url + '/credentials/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
         assert.equal(lastCall[1]!.method, 'GET');
 

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -157,7 +157,7 @@ fetchMock.mockResponse((req) => {
             req.method,
             requrl.pathname.split('?')[0]
         );
-        const body = req.url.startsWith(url + '/identifiers/aid1/credentials')
+        const body = req.url.startsWith(url + '/credentials')
             ? mockCredential
             : mockGetAID;
 
@@ -196,7 +196,6 @@ describe('Credentialing', () => {
         assert.deepEqual(lastBody, kargs);
 
         await credentials.get(
-            'aid1',
             'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao',
             true
         );
@@ -204,7 +203,7 @@ describe('Credentialing', () => {
         assert.equal(
             lastCall[0]!,
             url +
-                '/identifiers/aid1/credentials/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
+                '/credentials/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao'
         );
         assert.equal(lastCall[1]!.method, 'GET');
 


### PR DESCRIPTION
This PR matches the KERIA change to remove `/identifiers/{name}` from challenge and credential endpoints