### PR TITLE
Fix flaky integration tests by waiting for operations

### DIFF
--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -1,7 +1,11 @@
 import { strict as assert } from 'assert';
 import signify, { Serder } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { resolveOobi, waitOperation } from './utils/test-util';
+import {
+    assert_operations,
+    resolveOobi,
+    waitOperation,
+} from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -59,9 +63,10 @@ test('challenge', async () => {
         client1,
         await icpResult1.op()
     );
-    await client1
+    let rpyResult1 = await client1
         .identifiers()
         .addEndRole('alice', 'agent', client1!.agent!.pre);
+    await waitOperation(client1, await rpyResult1.op());
     console.log("Alice's AID:", aid1.i);
 
     const icpResult2 = await client2.identifiers().create('bob', {
@@ -76,7 +81,10 @@ test('challenge', async () => {
         client2,
         await icpResult2.op()
     );
-    await client2.identifiers().addEndRole('bob', 'agent', client2!.agent!.pre);
+    let rpyResult2 = await client2
+        .identifiers()
+        .addEndRole('bob', 'agent', client2!.agent!.pre);
+    await waitOperation(client2, await rpyResult2.op());
 
     // Exchenge OOBIs
     const oobi1 = await client1.oobis().get('alice', 'agent');
@@ -121,4 +129,6 @@ test('challenge', async () => {
         (contact: { alias: string }) => contact.alias === 'bob'
     );
     expect(bobContact.challenges[0].authenticated).toEqual(true);
+
+    await assert_operations(client1, client2);
 }, 30000);

--- a/examples/integration-scripts/challenge.test.ts
+++ b/examples/integration-scripts/challenge.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import signify, { Serder } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_operations,
+    assertOperations,
     resolveOobi,
     waitOperation,
 } from './utils/test-util';
@@ -130,5 +130,5 @@ test('challenge', async () => {
     );
     expect(bobContact.challenges[0].authenticated).toEqual(true);
 
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 }, 30000);

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -3,7 +3,7 @@ import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assert_notifications,
-    assert_operations,
+    assertOperations,
     markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
@@ -79,7 +79,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-    await assert_operations(
+    await assertOperations(
         issuerClient,
         holderClient,
         verifierClient,

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_notifications,
+    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
@@ -85,7 +85,7 @@ afterAll(async () => {
         verifierClient,
         legalEntityClient
     );
-    await assert_notifications(
+    await assertNotifications(
         issuerClient,
         holderClient,
         verifierClient,

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -2,6 +2,9 @@ import { strict as assert } from 'assert';
 import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
+    assert_notifications,
+    assert_operations,
+    markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
     waitOperation,
@@ -73,6 +76,21 @@ beforeAll(async () => {
         getOrCreateContact(verifierClient, 'holder', holderAid.oobi),
         getOrCreateContact(legalEntityClient, 'holder', holderAid.oobi),
     ]);
+});
+
+afterAll(async () => {
+    await assert_operations(
+        issuerClient,
+        holderClient,
+        verifierClient,
+        legalEntityClient
+    );
+    await assert_notifications(
+        issuerClient,
+        holderClient,
+        verifierClient,
+        legalEntityClient
+    );
 });
 
 test('single signature credentials', async () => {
@@ -211,11 +229,12 @@ test('single signature credentials', async () => {
             datetime: dt,
         });
 
-        await issuerClient
+        let op = await issuerClient
             .ipex()
             .submitGrant(issuerAid.name, grant, gsigs, gend, [
                 holderAid.prefix,
             ]);
+        await waitOperation(issuerClient, op);
     });
 
     await step('holder IPEX admit', async () => {
@@ -233,11 +252,12 @@ test('single signature credentials', async () => {
                 grantNotification.a.d!,
                 createTimestamp()
             );
-        await holderClient
+        let op = await holderClient
             .ipex()
             .submitAdmit(holderAid.name, admit, sigs, aend, [issuerAid.prefix]);
+        await waitOperation(holderClient, op);
 
-        await holderClient.notifications().mark(grantNotification.i);
+        await markAndRemoveNotification(holderClient, grantNotification);
     });
 
     await step('holder has credential', async () => {
@@ -270,16 +290,13 @@ test('single signature credentials', async () => {
             issAttachment: holderCredential.issAtc,
             datetime: createTimestamp(),
         });
-        await holderClient
-            .exchanges()
-            .sendFromEvents(
-                holderAid.name,
-                'presentation',
-                grant2,
-                gsigs2,
-                gend2,
-                [verifierAid.prefix]
-            );
+
+        let op = await holderClient
+            .ipex()
+            .submitGrant(holderAid.name, grant2, gsigs2, gend2, [
+                verifierAid.prefix,
+            ]);
+        await waitOperation(holderClient, op);
     });
 
     await step('verifier receives IPEX grant', async () => {
@@ -299,13 +316,14 @@ test('single signature credentials', async () => {
                 createTimestamp()
             );
 
-        await verifierClient
+        let op = await verifierClient
             .ipex()
             .submitAdmit(verifierAid.name, admit3, sigs3, aend3, [
                 holderAid.prefix,
             ]);
+        waitOperation(verifierClient, op);
 
-        await verifierClient.notifications().mark(verifierGrantNote.i);
+        await markAndRemoveNotification(verifierClient, verifierGrantNote);
 
         const verifierCredential = await retry(async () =>
             verifierClient.credentials().get(qviCredentialId)
@@ -388,11 +406,12 @@ test('single signature credentials', async () => {
             datetime: dt,
         });
 
-        await holderClient
+        let op = await holderClient
             .ipex()
             .submitGrant(holderAid.name, grant, gsigs, gend, [
                 legalEntityAid.prefix,
             ]);
+        await waitOperation(holderClient, op);
     });
 
     await step('Legal Entity IPEX admit', async () => {
@@ -411,13 +430,14 @@ test('single signature credentials', async () => {
                 createTimestamp()
             );
 
-        await legalEntityClient
+        let op = await legalEntityClient
             .ipex()
             .submitAdmit(legalEntityAid.name, admit, sigs, aend, [
                 holderAid.prefix,
             ]);
+        await waitOperation(legalEntityClient, op);
 
-        await legalEntityClient.notifications().mark(grantNotification.i);
+        await markAndRemoveNotification(legalEntityClient, grantNotification);
     });
 
     await step('Legal Entity has chained credential', async () => {

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -260,6 +260,14 @@ test('single signature credentials', async () => {
         await markAndRemoveNotification(holderClient, grantNotification);
     });
 
+    await step('issuer IPEX grant response', async () => {
+        const issuerNotifications = await waitForNotifications(
+            issuerClient,
+            '/exn/ipex/admit'
+        );
+        await markAndRemoveNotification(issuerClient, issuerNotifications[0]);
+    });
+
     await step('holder has credential', async () => {
         const holderCredential = await retry(async () => {
             const result = await holderClient
@@ -332,6 +340,14 @@ test('single signature credentials', async () => {
         assert.equal(verifierCredential.sad.s, QVI_SCHEMA_SAID);
         assert.equal(verifierCredential.sad.i, issuerAid.prefix);
         assert.equal(verifierCredential.status.s, '0'); // 0 = issued
+    });
+
+    await step('holder IPEX present response', async () => {
+        const holderNotifications = await waitForNotifications(
+            holderClient,
+            '/exn/ipex/admit'
+        );
+        await markAndRemoveNotification(holderClient, holderNotifications[0]);
     });
 
     const holderRegistry: { regk: string } = await step(
@@ -438,6 +454,14 @@ test('single signature credentials', async () => {
         await waitOperation(legalEntityClient, op);
 
         await markAndRemoveNotification(legalEntityClient, grantNotification);
+    });
+
+    await step('LE credential IPEX grant response', async () => {
+        const notifications = await waitForNotifications(
+            holderClient,
+            '/exn/ipex/admit'
+        );
+        await markAndRemoveNotification(holderClient, notifications[0]);
     });
 
     await step('Legal Entity has chained credential', async () => {

--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -329,7 +329,7 @@ test('single signature credentials', async () => {
             .submitAdmit(verifierAid.name, admit3, sigs3, aend3, [
                 holderAid.prefix,
             ]);
-        waitOperation(verifierClient, op);
+        await waitOperation(verifierClient, op);
 
         await markAndRemoveNotification(verifierClient, verifierGrantNote);
 

--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -1,12 +1,12 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import {
-    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
     waitOperation,
+    warnNotifications,
 } from './utils/test-util';
 import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
@@ -170,7 +170,7 @@ test('delegation-multisig', async () => {
     assert.equal(aid_delegate.prefix, delegatePrefix);
 
     await assertOperations(client0, client1, client2);
-    await assertNotifications(client0, client1, client2);
+    await warnNotifications(client0, client1, client2);
 }, 30000);
 
 async function createAID(client: signify.SignifyClient, name: string) {

--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -1,11 +1,14 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import {
+    assert_notifications,
+    assert_operations,
+    markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
     waitOperation,
 } from './utils/test-util';
-import { getOrCreateClient } from './utils/test-setup';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
 test('delegation-multisig', async () => {
     await signify.ready();
@@ -85,14 +88,16 @@ test('delegation-multisig', async () => {
 
     // Second member check notifications and join the multisig
     const notifications = await waitForNotifications(client2, '/multisig/icp');
-    await Promise.all(
-        notifications.map((note) => client2.notifications().mark(note.i))
-    );
     const msgSaid = notifications[notifications.length - 1].a.d;
     assert(msgSaid !== undefined);
     console.log('Member2 received exchange message to join multisig');
 
     const res = await client2.groups().getRequest(msgSaid);
+
+    await Promise.all(
+        notifications.map((note) => markAndRemoveNotification(client2, note))
+    );
+
     const exn = res[0].exn;
     const icp = exn.e.icp;
 
@@ -145,7 +150,8 @@ test('delegation-multisig', async () => {
         s: '0',
         d: delegatePrefix,
     };
-    await client0.identifiers().interact('delegator', anchor);
+    let ixnResult = await client0.identifiers().interact('delegator', anchor);
+    await waitOperation(client0, await ixnResult.op());
     console.log('Delegator approved delegation');
 
     let op3 = await client1.keyStates().query(aid0.prefix, '1');
@@ -162,20 +168,14 @@ test('delegation-multisig', async () => {
 
     const aid_delegate = await client1.identifiers().get('multisig');
     assert.equal(aid_delegate.prefix, delegatePrefix);
+
+    await assert_operations(client0, client1, client2);
+    await assert_notifications(client0, client1, client2);
 }, 30000);
 
 async function createAID(client: signify.SignifyClient, name: string) {
-    const icpResult1 = await client.identifiers().create(name, {
-        toad: 3,
-        wits: [
-            'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
-            'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
-            'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
-        ],
-    });
-    await waitOperation(client, await icpResult1.op());
+    await getOrCreateIdentifier(client, name);
     const aid = await client.identifiers().get(name);
-    await client.identifiers().addEndRole(name, 'agent', client!.agent!.pre);
     console.log(name, 'AID:', aid.prefix);
     return aid;
 }

--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import {
     assert_notifications,
-    assert_operations,
+    assertOperations,
     markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
@@ -169,7 +169,7 @@ test('delegation-multisig', async () => {
     const aid_delegate = await client1.identifiers().get('multisig');
     assert.equal(aid_delegate.prefix, delegatePrefix);
 
-    await assert_operations(client0, client1, client2);
+    await assertOperations(client0, client1, client2);
     await assert_notifications(client0, client1, client2);
 }, 30000);
 

--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import {
-    assert_notifications,
+    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
@@ -170,7 +170,7 @@ test('delegation-multisig', async () => {
     assert.equal(aid_delegate.prefix, delegatePrefix);
 
     await assertOperations(client0, client1, client2);
-    await assert_notifications(client0, client1, client2);
+    await assertNotifications(client0, client1, client2);
 }, 30000);
 
 async function createAID(client: signify.SignifyClient, name: string) {

--- a/examples/integration-scripts/delegation.test.ts
+++ b/examples/integration-scripts/delegation.test.ts
@@ -1,7 +1,11 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { resolveOobi, waitOperation } from './utils/test-util';
+import {
+    assert_operations,
+    resolveOobi,
+    waitOperation,
+} from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -52,9 +56,10 @@ test('delegation', async () => {
     });
     await waitOperation(client1, await icpResult1.op());
     const aid1 = await client1.identifiers().get('delegator');
-    await client1
+    const rpyResult1 = await client1
         .identifiers()
         .addEndRole('delegator', 'agent', client1!.agent!.pre);
+    await waitOperation(client1, await rpyResult1.op());
     console.log("Delegator's AID:", aid1.prefix);
 
     // Client 2 resolves delegator OOBI
@@ -78,7 +83,10 @@ test('delegation', async () => {
         s: '0',
         d: delegatePrefix,
     };
-    await client1.identifiers().interact('delegator', anchor);
+    const ixnResult1 = await client1
+        .identifiers()
+        .interact('delegator', anchor);
+    await waitOperation(client1, await ixnResult1.op());
     console.log('Delegator approved delegation');
 
     let op3 = await client2.keyStates().query(aid1.prefix, '1');
@@ -89,4 +97,6 @@ test('delegation', async () => {
     const aid2 = await client2.identifiers().get('delegate');
     assert.equal(aid2.prefix, delegatePrefix);
     console.log('Delegation approved for aid:', aid2.prefix);
+
+    await assert_operations(client1, client2);
 }, 60000);

--- a/examples/integration-scripts/delegation.test.ts
+++ b/examples/integration-scripts/delegation.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_operations,
+    assertOperations,
     resolveOobi,
     waitOperation,
 } from './utils/test-util';
@@ -98,5 +98,5 @@ test('delegation', async () => {
     assert.equal(aid2.prefix, delegatePrefix);
     console.log('Delegation approved for aid:', aid2.prefix);
 
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 }, 60000);

--- a/examples/integration-scripts/externalModule.test.ts
+++ b/examples/integration-scripts/externalModule.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { BIP39Shim } from './modules/bip39_shim';
 import { resolveEnvironment } from './utils/resolve-env';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -35,6 +36,8 @@ test('bip39_shim', async () => {
         extern_type: 'bip39_shim',
         extern: { mnemonics: words },
     });
-    const op = await icpResult.op();
+    const op = await waitOperation(client1, await icpResult.op());
     assert.equal(op['done'], true);
+
+    await assert_operations(client1);
 }, 30000);

--- a/examples/integration-scripts/externalModule.test.ts
+++ b/examples/integration-scripts/externalModule.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { BIP39Shim } from './modules/bip39_shim';
 import { resolveEnvironment } from './utils/resolve-env';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -39,5 +39,5 @@ test('bip39_shim', async () => {
     const op = await waitOperation(client1, await icpResult.op());
     assert.equal(op['done'], true);
 
-    await assert_operations(client1);
+    await assertOperations(client1);
 }, 30000);

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -1,8 +1,18 @@
 import { strict as assert } from 'assert';
-import signify, { SignifyClient, IssueCredentialArgs } from 'signify-ts';
+import signify, {
+    SignifyClient,
+    IssueCredentialArgs,
+    Operation,
+} from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { waitForNotifications, waitOperation } from './utils/test-util';
-import { getOrCreateClient } from './utils/test-setup';
+import {
+    assert_notifications,
+    assert_operations,
+    markNotification,
+    waitForNotifications,
+    waitOperation,
+} from './utils/test-util';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
 const { vleiServerUrl } = resolveEnvironment();
 const WITNESS_AIDS = [
@@ -285,8 +295,8 @@ test('multisig', async function run() {
         `Member2 authorized agent role to ${eid1}, waiting for others to authorize...`
     );
     // Check for completion
-    op1 = await waitOperation(client1, op1);
-    op2 = await waitOperation(client2, op2);
+    await waitOperation(client1, op1);
+    await waitOperation(client2, op2);
     console.log(`End role authorization for agent ${eid1} completed!`);
 
     console.log(`Starting multisig end role authorization for agent ${eid2}`);
@@ -387,8 +397,8 @@ test('multisig', async function run() {
         `Member2 authorized agent role to ${eid2}, waiting for others to authorize...`
     );
     // Check for completion
-    op1 = await waitOperation(client1, op1);
-    op2 = await waitOperation(client2, op2);
+    await waitOperation(client1, op1);
+    await waitOperation(client2, op2);
     console.log(`End role authorization for agent ${eid2} completed!`);
 
     // Holder resolve multisig OOBI
@@ -396,7 +406,7 @@ test('multisig', async function run() {
     let oobiMultisig = oobisRes.oobis[0].split('/agent/')[0];
 
     op3 = await client3.oobis().resolve(oobiMultisig, 'holder');
-    op3 = await waitOperation(client3, op3);
+    await waitOperation(client3, op3);
     console.log(`Issuer resolved multisig holder OOBI`);
 
     let holderAid = await client1.identifiers().get('holder');
@@ -426,7 +436,7 @@ test('multisig', async function run() {
     let exnRes = await client1.exchanges().get(grantMsgSaid);
 
     recp = [aid2['state']].map((state) => state['i']);
-    await multisigAdmitCredential(
+    op1 = await multisigAdmitCredential(
         client1,
         'holder',
         'member1',
@@ -452,7 +462,7 @@ test('multisig', async function run() {
     console.log(`Member2 /exn/ipex/grant msg :  ` + JSON.stringify(exnRes2));
 
     let recp2 = [aid1['state']].map((state) => state['i']);
-    await multisigAdmitCredential(
+    op2 = await multisigAdmitCredential(
         client2,
         'holder',
         'member2',
@@ -463,6 +473,9 @@ test('multisig', async function run() {
     console.log(
         `Member2 admitted credential with SAID : ${exnRes.exn.e.acdc.d}`
     );
+
+    await waitOperation(client1, op1);
+    await waitOperation(client2, op2);
 
     let creds1 = await client1.credentials().list();
     console.log(`Member1 has ${creds1.length} credential`);
@@ -482,6 +495,9 @@ test('multisig', async function run() {
         `Member1 has ${creds1.length} credential : ` + JSON.stringify(creds1)
     );
     assert.equal(creds1.length, 1);
+
+    await assert_operations(client1, client2, client3);
+    await assert_notifications(client1, client2, client3);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {
@@ -489,7 +505,7 @@ async function waitAndMarkNotification(client: SignifyClient, route: string) {
 
     await Promise.all(
         notes.map(async (note) => {
-            await client.notifications().mark(note.i);
+            await markNotification(client, note);
         })
     );
 
@@ -497,13 +513,8 @@ async function waitAndMarkNotification(client: SignifyClient, route: string) {
 }
 
 async function createAID(client: SignifyClient, name: string, wits: string[]) {
-    const icpResult1 = await client.identifiers().create(name, {
-        toad: wits.length,
-        wits: wits,
-    });
-    await waitOperation(client, await icpResult1.op());
+    await getOrCreateIdentifier(client, name);
     const aid = await client.identifiers().get(name);
-    await client.identifiers().addEndRole(name, 'agent', client!.agent!.pre);
     console.log(name, 'AID:', aid.prefix);
     return aid;
 }
@@ -549,9 +560,10 @@ async function issueCredential(
             iss: result.iss,
         });
 
-        await client
+        let op = await client
             .ipex()
             .submitGrant(args.issuerName, grant, gsigs, end, [args.recipient]);
+        op = await waitOperation(client, op);
     }
 
     console.log('Grant message sent');
@@ -571,7 +583,7 @@ async function multisigAdmitCredential(
     grantSaid: string,
     issuerPrefix: string,
     recipients: string[]
-) {
+): Promise<Operation> {
     let mHab = await client.identifiers().get(memberAlias);
     let gHab = await client.identifiers().get(groupName);
 
@@ -579,7 +591,7 @@ async function multisigAdmitCredential(
         .ipex()
         .admit(groupName, '', grantSaid, TIME);
 
-    await client
+    let op = await client
         .ipex()
         .submitAdmit(groupName, admit, sigs, end, [issuerPrefix]);
 
@@ -607,4 +619,6 @@ async function multisigAdmitCredential(
             gembeds,
             recipients
         );
+
+    return op;
 }

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -7,7 +7,7 @@ import signify, {
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assert_notifications,
-    assert_operations,
+    assertOperations,
     markNotification,
     waitForNotifications,
     waitOperation,
@@ -496,7 +496,7 @@ test('multisig', async function run() {
     );
     assert.equal(creds1.length, 1);
 
-    await assert_operations(client1, client2, client3);
+    await assertOperations(client1, client2, client3);
     await assert_notifications(client1, client2, client3);
 }, 360000);
 

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -6,11 +6,11 @@ import signify, {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assertNotifications,
     assertOperations,
     markNotification,
     waitForNotifications,
     waitOperation,
+    warnNotifications,
 } from './utils/test-util';
 import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
@@ -497,7 +497,7 @@ test('multisig', async function run() {
     assert.equal(creds1.length, 1);
 
     await assertOperations(client1, client2, client3);
-    await assertNotifications(client1, client2, client3);
+    await warnNotifications(client1, client2, client3); 
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -497,7 +497,7 @@ test('multisig', async function run() {
     assert.equal(creds1.length, 1);
 
     await assertOperations(client1, client2, client3);
-    await warnNotifications(client1, client2, client3); 
+    await warnNotifications(client1, client2, client3);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -6,7 +6,7 @@ import signify, {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_notifications,
+    assertNotifications,
     assertOperations,
     markNotification,
     waitForNotifications,
@@ -497,7 +497,7 @@ test('multisig', async function run() {
     assert.equal(creds1.length, 1);
 
     await assertOperations(client1, client2, client3);
-    await assert_notifications(client1, client2, client3);
+    await assertNotifications(client1, client2, client3);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -6,7 +6,7 @@ import signify, {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_notifications,
+    assertNotifications,
     assertOperations,
     markNotification,
     waitForNotifications,
@@ -1114,7 +1114,7 @@ test('multisig', async function run() {
     console.log(`Holder holds ${creds.length} credential`);
 
     await assertOperations(client1, client2, client3, client4);
-    await assert_notifications(client1, client2, client3, client4);
+    await assertNotifications(client1, client2, client3, client4);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -6,11 +6,11 @@ import signify, {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assertNotifications,
     assertOperations,
     markNotification,
     waitForNotifications,
     waitOperation,
+    warnNotifications,
 } from './utils/test-util';
 import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
@@ -1114,7 +1114,7 @@ test('multisig', async function run() {
     console.log(`Holder holds ${creds.length} credential`);
 
     await assertOperations(client1, client2, client3, client4);
-    await assertNotifications(client1, client2, client3, client4);
+    await warnNotifications(client1, client2, client3, client4); 
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -7,7 +7,7 @@ import signify, {
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assert_notifications,
-    assert_operations,
+    assertOperations,
     markNotification,
     waitForNotifications,
     waitOperation,
@@ -1113,7 +1113,7 @@ test('multisig', async function run() {
     const creds = await client4.credentials().list();
     console.log(`Holder holds ${creds.length} credential`);
 
-    await assert_operations(client1, client2, client3, client4);
+    await assertOperations(client1, client2, client3, client4);
     await assert_notifications(client1, client2, client3, client4);
 }, 360000);
 

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -5,8 +5,14 @@ import signify, {
     IssueCredentialResult,
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { waitForNotifications, waitOperation } from './utils/test-util';
-import { getOrCreateClient } from './utils/test-setup';
+import {
+    assert_notifications,
+    assert_operations,
+    markNotification,
+    waitForNotifications,
+    waitOperation,
+} from './utils/test-util';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
 
 const { vleiServerUrl } = resolveEnvironment();
 const WITNESS_AIDS = [
@@ -963,9 +969,9 @@ test('multisig', async function run() {
         datetime: stamp,
     });
 
-    await client1
-        .exchanges()
-        .sendFromEvents('multisig', 'credential', grant, gsigs, end, [holder]);
+    op1 = await client1
+        .ipex()
+        .submitGrant('multisig', grant, gsigs, end, [holder]);
 
     mstate = m['state'];
     seal = [
@@ -1011,11 +1017,9 @@ test('multisig', async function run() {
         datetime: stamp,
     });
 
-    await client2
-        .exchanges()
-        .sendFromEvents('multisig', 'credential', grant2, gsigs2, end2, [
-            holder,
-        ]);
+    op2 = await client2
+        .ipex()
+        .submitGrant('multisig', grant2, gsigs2, end2, [holder]);
 
     sigers = gsigs2.map((sig) => new signify.Siger({ qb64: sig }));
 
@@ -1055,11 +1059,9 @@ test('multisig', async function run() {
         datetime: stamp,
     });
 
-    await client3
-        .exchanges()
-        .sendFromEvents('multisig', 'credential', grant3, gsigs3, end3, [
-            holder,
-        ]);
+    op3 = await client3
+        .ipex()
+        .submitGrant('multisig', grant3, gsigs3, end3, [holder]);
 
     sigers = gsigs3.map((sig) => new signify.Siger({ qb64: sig }));
 
@@ -1093,9 +1095,16 @@ test('multisig', async function run() {
         .ipex()
         .admit('holder', '', res.exn.d);
 
-    res = await client4
+    op4 = await client4
         .ipex()
         .submitAdmit('holder', admit, asigs, aend, [m['prefix']]);
+
+    await Promise.all([
+        waitOperation(client1, op1),
+        waitOperation(client2, op2),
+        waitOperation(client3, op3),
+        waitOperation(client4, op4),
+    ]);
 
     console.log('Holder creates and sends admit message');
 
@@ -1103,6 +1112,9 @@ test('multisig', async function run() {
     console.log('Member1 received exchange message with the admit response');
     const creds = await client4.credentials().list();
     console.log(`Holder holds ${creds.length} credential`);
+
+    await assert_operations(client1, client2, client3, client4);
+    await assert_notifications(client1, client2, client3, client4);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {
@@ -1110,7 +1122,7 @@ async function waitAndMarkNotification(client: SignifyClient, route: string) {
 
     await Promise.all(
         notes.map(async (note) => {
-            await client.notifications().mark(note.i);
+            await markNotification(client, note);
         })
     );
 
@@ -1118,15 +1130,11 @@ async function waitAndMarkNotification(client: SignifyClient, route: string) {
 }
 
 async function createAID(client: SignifyClient, name: string, wits: string[]) {
-    const icpResult1 = await client.identifiers().create(name, {
-        toad: wits.length,
+    await getOrCreateIdentifier(client, name, {
         wits: wits,
+        toad: wits.length,
     });
-    await waitOperation(client, await icpResult1.op());
-    const aid = await client.identifiers().get(name);
-    await client.identifiers().addEndRole(name, 'agent', client!.agent!.pre);
-    console.log(name, 'AID:', aid.prefix);
-    return aid;
+    return await client.identifiers().get(name);
 }
 
 async function multisigIssue(

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -1114,7 +1114,7 @@ test('multisig', async function run() {
     console.log(`Holder holds ${creds.length} credential`);
 
     await assertOperations(client1, client2, client3, client4);
-    await warnNotifications(client1, client2, client3, client4); 
+    await warnNotifications(client1, client2, client3, client4);
 }, 360000);
 
 async function waitAndMarkNotification(client: SignifyClient, route: string) {

--- a/examples/integration-scripts/randy.test.ts
+++ b/examples/integration-scripts/randy.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -68,4 +68,6 @@ test('randy', async () => {
     assert.equal(dig.qb64, icp.digers[0].qb64);
     log = await events.get(aid['prefix']);
     assert.equal(log.length, 3);
+
+    await assert_operations(client1);
 }, 30000);

--- a/examples/integration-scripts/randy.test.ts
+++ b/examples/integration-scripts/randy.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -69,5 +69,5 @@ test('randy', async () => {
     log = await events.get(aid['prefix']);
     assert.equal(log.length, 3);
 
-    await assert_operations(client1);
+    await assertOperations(client1);
 }, 30000);

--- a/examples/integration-scripts/salty.test.ts
+++ b/examples/integration-scripts/salty.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -166,7 +166,7 @@ test('salty', async () => {
     assert.equal(serder.pre, ixn.pre);
     assert.equal(serder.ked['d'], ixn.ked['d']);
 
-    await assert_operations(client1);
+    await assertOperations(client1);
 
     console.log('Salty test passed');
 }, 30000);

--- a/examples/integration-scripts/salty.test.ts
+++ b/examples/integration-scripts/salty.test.ts
@@ -1,7 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 const { url, bootUrl } = resolveEnvironment();
 
@@ -102,7 +102,8 @@ test('salty', async () => {
     assert.equal(salt.stem, 'signify:aid');
     assert.equal(aid.prefix, icp2.pre);
 
-    await client1.identifiers().create('aid3');
+    icpResult = await client1.identifiers().create('aid3');
+    await waitOperation(client1, await icpResult.op());
     aids = await client1.identifiers().list();
     assert.equal(aids.aids.length, 3);
     aid = aids.aids[0];
@@ -164,5 +165,8 @@ test('salty', async () => {
     serder = new signify.Serder(log[2]);
     assert.equal(serder.pre, ixn.pre);
     assert.equal(serder.ked['d'], ixn.ked['d']);
+
+    await assert_operations(client1);
+
     console.log('Salty test passed');
 }, 30000);

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 import { resolveEnvironment } from './utils/resolve-env';
 
 let client1: SignifyClient, client2: SignifyClient;
@@ -21,7 +21,7 @@ beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
 });
 afterAll(async () => {
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 });
 
 describe('singlesig-dip', () => {

--- a/examples/integration-scripts/singlesig-dip.test.ts
+++ b/examples/integration-scripts/singlesig-dip.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 import { resolveEnvironment } from './utils/resolve-env';
 
 let client1: SignifyClient, client2: SignifyClient;
@@ -19,6 +19,9 @@ beforeAll(async () => {
 });
 beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
+});
+afterAll(async () => {
+    await assert_operations(client1, client2);
 });
 
 describe('singlesig-dip', () => {

--- a/examples/integration-scripts/singlesig-drt.test.ts
+++ b/examples/integration-scripts/singlesig-drt.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 let delegator: SignifyClient, delegate: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -18,6 +18,9 @@ beforeAll(async () => {
 });
 beforeAll(async () => {
     contact1_id = await getOrCreateContact(delegate, 'contact1', name1_oobi);
+});
+afterAll(async () => {
+    await assert_operations(delegator, delegate);
 });
 
 describe('singlesig-drt', () => {

--- a/examples/integration-scripts/singlesig-drt.test.ts
+++ b/examples/integration-scripts/singlesig-drt.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 let delegator: SignifyClient, delegate: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -20,7 +20,7 @@ beforeAll(async () => {
     contact1_id = await getOrCreateContact(delegate, 'contact1', name1_oobi);
 });
 afterAll(async () => {
-    await assert_operations(delegator, delegate);
+    await assertOperations(delegator, delegate);
 });
 
 describe('singlesig-drt', () => {

--- a/examples/integration-scripts/singlesig-ixn.test.ts
+++ b/examples/integration-scripts/singlesig-ixn.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -18,6 +18,9 @@ beforeAll(async () => {
 });
 beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
+});
+afterAll(async () => {
+    await assert_operations(client1, client2);
 });
 
 interface KeyState {

--- a/examples/integration-scripts/singlesig-ixn.test.ts
+++ b/examples/integration-scripts/singlesig-ixn.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -20,7 +20,7 @@ beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
 });
 afterAll(async () => {
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 });
 
 interface KeyState {

--- a/examples/integration-scripts/singlesig-rot.test.ts
+++ b/examples/integration-scripts/singlesig-rot.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { waitOperation } from './utils/test-util';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -18,6 +18,9 @@ beforeAll(async () => {
 });
 beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
+});
+afterAll(async () => {
+    await assert_operations(client1, client2);
 });
 
 interface KeyState {

--- a/examples/integration-scripts/singlesig-rot.test.ts
+++ b/examples/integration-scripts/singlesig-rot.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -20,7 +20,7 @@ beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
 });
 afterAll(async () => {
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 });
 
 interface KeyState {

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -2,12 +2,12 @@ import { strict as assert } from 'assert';
 import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
     waitOperation,
+    warnNotifications,
 } from './utils/test-util';
 import { retry } from './utils/retry';
 import {
@@ -461,7 +461,7 @@ test('singlesig-vlei-issuance', async function run() {
     assert(oorCredHolder.atc !== undefined);
 
     await assertOperations(gleifClient, qviClient, leClient, roleClient);
-    await assertNotifications(gleifClient, qviClient, leClient, roleClient);
+    await warnNotifications(gleifClient, qviClient, leClient, roleClient); 
 }, 360000);
 
 async function getOrCreateRegistry(

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
-    assert_notifications,
+    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
@@ -461,7 +461,7 @@ test('singlesig-vlei-issuance', async function run() {
     assert(oorCredHolder.atc !== undefined);
 
     await assertOperations(gleifClient, qviClient, leClient, roleClient);
-    await assert_notifications(gleifClient, qviClient, leClient, roleClient);
+    await assertNotifications(gleifClient, qviClient, leClient, roleClient);
 }, 360000);
 
 async function getOrCreateRegistry(

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -3,7 +3,7 @@ import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assert_notifications,
-    assert_operations,
+    assertOperations,
     markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
@@ -460,7 +460,7 @@ test('singlesig-vlei-issuance', async function run() {
     assert.equal(oorCredHolder.status.s, '0');
     assert(oorCredHolder.atc !== undefined);
 
-    await assert_operations(gleifClient, qviClient, leClient, roleClient);
+    await assertOperations(gleifClient, qviClient, leClient, roleClient);
     await assert_notifications(gleifClient, qviClient, leClient, roleClient);
 }, 360000);
 

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -461,7 +461,7 @@ test('singlesig-vlei-issuance', async function run() {
     assert(oorCredHolder.atc !== undefined);
 
     await assertOperations(gleifClient, qviClient, leClient, roleClient);
-    await warnNotifications(gleifClient, qviClient, leClient, roleClient); 
+    await warnNotifications(gleifClient, qviClient, leClient, roleClient);
 }, 360000);
 
 async function getOrCreateRegistry(

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -2,6 +2,9 @@ import { strict as assert } from 'assert';
 import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
+    assert_notifications,
+    assert_operations,
+    markAndRemoveNotification,
     resolveOobi,
     waitForNotifications,
     waitOperation,
@@ -456,6 +459,9 @@ test('singlesig-vlei-issuance', async function run() {
     assert.equal(oorCredHolder.sad.e.auth.n, oorAuthCred.sad.d);
     assert.equal(oorCredHolder.status.s, '0');
     assert(oorCredHolder.atc !== undefined);
+
+    await assert_operations(gleifClient, qviClient, leClient, roleClient);
+    await assert_notifications(gleifClient, qviClient, leClient, roleClient);
 }, 360000);
 
 async function getOrCreateRegistry(
@@ -551,9 +557,10 @@ async function sendGrantMessage(
         datetime: createTimestamp(),
     });
 
-    await senderClient
+    let op = await senderClient
         .ipex()
         .submitGrant(senderAid.name, grant, gsigs, gend, [recipientAid.prefix]);
+    op = await waitOperation(senderClient, op);
 }
 
 async function sendAdmitMessage(
@@ -572,9 +579,10 @@ async function sendAdmitMessage(
         .ipex()
         .admit(senderAid.name, '', grantNotification.a.d!, createTimestamp());
 
-    await senderClient
+    let op = await senderClient
         .ipex()
         .submitAdmit(senderAid.name, admit, sigs, aend, [recipientAid.prefix]);
+    op = await waitOperation(senderClient, op);
 
-    await senderClient.notifications().mark(grantNotification.i);
+    await markAndRemoveNotification(senderClient, grantNotification);
 }

--- a/examples/integration-scripts/test-setup-clients.test.ts
+++ b/examples/integration-scripts/test-setup-clients.test.ts
@@ -4,7 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
-import { assert_operations } from './utils/test-util';
+import { assertOperations } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -24,7 +24,7 @@ beforeAll(async () => {
     contact2_id = await getOrCreateContact(client1, 'contact2', name2_oobi);
 });
 afterAll(async () => {
-    await assert_operations(client1, client2);
+    await assertOperations(client1, client2);
 });
 
 describe('test-setup-clients', () => {

--- a/examples/integration-scripts/test-setup-clients.test.ts
+++ b/examples/integration-scripts/test-setup-clients.test.ts
@@ -4,6 +4,7 @@ import {
     getOrCreateContact,
     getOrCreateIdentifier,
 } from './utils/test-setup';
+import { assert_operations } from './utils/test-util';
 
 let client1: SignifyClient, client2: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -21,6 +22,9 @@ beforeAll(async () => {
 beforeAll(async () => {
     contact1_id = await getOrCreateContact(client2, 'contact1', name1_oobi);
     contact2_id = await getOrCreateContact(client1, 'contact2', name2_oobi);
+});
+afterAll(async () => {
+    await assert_operations(client1, client2);
 });
 
 describe('test-setup-clients', () => {

--- a/examples/integration-scripts/test-setup-single-client.test.ts
+++ b/examples/integration-scripts/test-setup-single-client.test.ts
@@ -1,6 +1,7 @@
 import { SignifyClient } from 'signify-ts';
 import { getOrCreateClients, getOrCreateIdentifier } from './utils/test-setup';
 import { resolveEnvironment } from './utils/resolve-env';
+import { assert_operations, waitOperation } from './utils/test-util';
 
 let client: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -11,6 +12,9 @@ beforeAll(async () => {
 });
 beforeAll(async () => {
     [name1_id, name1_oobi] = await getOrCreateIdentifier(client, 'name1');
+});
+afterAll(async () => {
+    await assert_operations(client);
 });
 
 describe('test-setup-single-client', () => {

--- a/examples/integration-scripts/test-setup-single-client.test.ts
+++ b/examples/integration-scripts/test-setup-single-client.test.ts
@@ -1,7 +1,7 @@
 import { SignifyClient } from 'signify-ts';
 import { getOrCreateClients, getOrCreateIdentifier } from './utils/test-setup';
 import { resolveEnvironment } from './utils/resolve-env';
-import { assert_operations, waitOperation } from './utils/test-util';
+import { assertOperations, waitOperation } from './utils/test-util';
 
 let client: SignifyClient;
 let name1_id: string, name1_oobi: string;
@@ -14,7 +14,7 @@ beforeAll(async () => {
     [name1_id, name1_oobi] = await getOrCreateIdentifier(client, 'name1');
 });
 afterAll(async () => {
-    await assert_operations(client);
+    await assertOperations(client);
 });
 
 describe('test-setup-single-client', () => {

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -8,23 +8,108 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Poll for operation to become completed
+ * Assert that all operations were waited for
+ */
+export async function assert_operations(
+    ...clients: SignifyClient[]
+): Promise<void> {
+    for (let client of clients) {
+        let operations = await client.operations().list();
+        for (let op of operations) {
+            if (true) {
+                expect(op).toBeUndefined();
+            } else {
+                console.warn('operation', op);
+            }
+        }
+    }
+}
+
+/**
+ * Assert that all notifications were handled
+ */
+export async function assert_notifications(
+    ...clients: SignifyClient[]
+): Promise<void> {
+    for (let client of clients) {
+        let res = await client.notifications().list();
+        for (let note of res.notes.filter((i: any) => i.r === false)) {
+            if (false) {
+                expect(note).toBeUndefined();
+            } else {
+                console.warn('notification', note);
+            }
+        }
+    }
+}
+
+/**
+ * Get status of operation.
+ * If parameter recurse is set then also checks status of dependent operations.
+ */
+async function getOperation<T>(
+    client: SignifyClient,
+    name: string,
+    recurse?: boolean
+): Promise<Operation<T>> {
+    const result = await client.operations().get<T>(name);
+    if (recurse === true) {
+        let i: Operation | undefined = result;
+        while (result.done && i?.metadata?.depends !== undefined) {
+            let depends: Operation = await client
+                .operations()
+                .get(i.metadata.depends.name);
+            result.done = result.done && depends.done;
+            i.metadata.depends = depends;
+            i = depends.metadata?.depends;
+        }
+    }
+    return result;
+}
+
+/**
+ * Poll for operation to become completed.
+ * Removes completed operation
  */
 export async function waitOperation<T = any>(
     client: SignifyClient,
-    op: Operation<T>,
+    op: Operation<T> | string,
     options: RetryOptions = {}
 ): Promise<Operation<T>> {
-    return retry(async () => {
-        op = await client.operations().get(op.name);
-
-        if (op.done !== true) {
-            throw new Error(`Operation ${op.name} not done`);
+    const ctrl = new AbortController();
+    options.signal?.addEventListener('abort', (e: Event) => {
+        const s = e.target as AbortSignal;
+        ctrl.abort(s.reason);
+    });
+    let name: string;
+    if (typeof op === 'string') {
+        name = op;
+    } else if (typeof op === 'object' && 'name' in op) {
+        name = op.name;
+    } else {
+        throw new Error();
+    }
+    const result: Operation<T> = await retry(async () => {
+        let t: Operation<T>;
+        try {
+            t = await getOperation<T>(client, name, true);
+        } catch (e) {
+            ctrl.abort(e);
+            throw e;
         }
-
-        console.log('DONE', op.name);
-        return op;
+        if (t.done !== true) {
+            throw new Error(`Operation ${name} not done`);
+        }
+        console.log('DONE', name);
+        return t;
     }, options);
+    let i: Operation | undefined = result;
+    while (i !== undefined) {
+        // console.log('DELETE', i.name);
+        await client.operations().delete(i.name);
+        i = i.metadata?.depends;
+    }
+    return result;
 }
 
 export async function resolveOobi(
@@ -63,4 +148,28 @@ export async function waitForNotifications(
 
         return notes;
     }, options);
+}
+
+/**
+ * Mark notification as read.
+ */
+export async function markNotification(
+    client: SignifyClient,
+    note: Notification
+): Promise<void> {
+    await client.notifications().mark(note.i);
+}
+
+/**
+ * Mark and remove notification.
+ */
+export async function markAndRemoveNotification(
+    client: SignifyClient,
+    note: Notification
+): Promise<void> {
+    try {
+        await client.notifications().mark(note.i);
+    } finally {
+        await client.notifications().delete(note.i);
+    }
 }

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -8,7 +8,9 @@ export function sleep(ms: number): Promise<void> {
 }
 
 /**
- * Assert that all operations were waited for
+ * Assert that all operations were waited for.
+ * <p>This is a postcondition check to make sure all long-running operations have been waited for
+ * @see waitOperation
  */
 export async function assertOperations(
     ...clients: SignifyClient[]
@@ -20,21 +22,39 @@ export async function assertOperations(
 }
 
 /**
- * Assert that all notifications were handled
+ * Assert that all notifications were handled.
+ * <p>This is a postcondition check to make sure all notifications have been handled
+ * @see markNotification
+ * @see markAndRemoveNotification
  */
 export async function assertNotifications(
     ...clients: SignifyClient[]
 ): Promise<void> {
     for (let client of clients) {
         let res = await client.notifications().list();
-        for (let note of res.notes.filter((i: any) => i.r === false)) {
-            if (false) {
-                expect(note).toBeUndefined();
-            } else {
-                console.warn('notification', note);
-            }
+        let notes = res.notes.filter((i: any) => i.r === false);
+        expect(notes).toHaveLength(0);
+    }
+}
+
+/**
+ * Logs a warning for each un-handled notification.
+ * <p>Replace warnNotifications with assertNotifications when test handles all notifications
+ * @see assertNotifications
+ */
+export async function warnNotifications(
+    ...clients: SignifyClient[]
+): Promise<void> {
+    let count = 0;
+    for (let client of clients) {
+        let res = await client.notifications().list();
+        let notes = res.notes.filter((i: any) => i.r === false);
+        if (notes.length > 0) {
+            count += notes.length;
+            console.warn("notifications", notes);
         }
     }
+    expect(count).toBeGreaterThan(0); // replace warnNotifications with assertNotifications
 }
 
 /**

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -15,13 +15,7 @@ export async function assertOperations(
 ): Promise<void> {
     for (let client of clients) {
         let operations = await client.operations().list();
-        for (let op of operations) {
-            if (true) {
-                expect(op).toBeUndefined();
-            } else {
-                console.warn('operation', op);
-            }
-        }
+        expect(operations).toHaveLength(0);
     }
 }
 

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -51,7 +51,7 @@ export async function warnNotifications(
         let notes = res.notes.filter((i: any) => i.r === false);
         if (notes.length > 0) {
             count += notes.length;
-            console.warn("notifications", notes);
+            console.warn('notifications', notes);
         }
     }
     expect(count).toBeGreaterThan(0); // replace warnNotifications with assertNotifications

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -10,7 +10,7 @@ export function sleep(ms: number): Promise<void> {
 /**
  * Assert that all operations were waited for
  */
-export async function assert_operations(
+export async function assertOperations(
     ...clients: SignifyClient[]
 ): Promise<void> {
     for (let client of clients) {

--- a/examples/integration-scripts/utils/test-util.ts
+++ b/examples/integration-scripts/utils/test-util.ts
@@ -28,7 +28,7 @@ export async function assertOperations(
 /**
  * Assert that all notifications were handled
  */
-export async function assert_notifications(
+export async function assertNotifications(
     ...clients: SignifyClient[]
 ): Promise<void> {
     for (let client of clients) {

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -381,7 +381,7 @@ export class Identifier {
         role: string,
         eid?: string,
         stamp?: string
-    ): Promise<any> {
+    ): Promise<EventResult> {
         const hab = await this.get(name);
         const pre = hab.prefix;
 

--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -61,9 +61,14 @@ export class Oobis {
 }
 
 export interface Operation<T = unknown> {
-    done: boolean;
     name: string;
-    response: T;
+    metadata?: {
+        depends?: Operation;
+        [property: string]: any;
+    };
+    done?: boolean;
+    error?: any;
+    response?: T;
 }
 
 /**
@@ -93,6 +98,34 @@ export class Operations {
         const method = 'GET';
         const res = await this.client.fetch(path, method, data);
         return await res.json();
+    }
+    /**
+     * List operations
+     * @async
+     * @param {string} type Select operations by type
+     * @returns {Promise<Operation[]>} A list of operations
+     */
+    async list(type?: string): Promise<Operation<any>[]> {
+        const params = new URLSearchParams();
+        if (type !== undefined) {
+            params.append('type', type);
+        }
+        const path = `/operations?${params.toString()}`;
+        const data = null;
+        const method = 'GET';
+        const res = await this.client.fetch(path, method, data);
+        return await res.json();
+    }
+    /**
+     * Delete operation
+     * @async
+     * @param {string} name Name of the operation
+     */
+    async delete(name: string): Promise<void> {
+        const path = `/operations/${name}`;
+        const data = null;
+        const method = 'DELETE';
+        const res = await this.client.fetch(path, method, data);
     }
 }
 

--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -125,7 +125,7 @@ export class Operations {
         const path = `/operations/${name}`;
         const data = null;
         const method = 'DELETE';
-        const res = await this.client.fetch(path, method, data);
+        await this.client.fetch(path, method, data);
     }
 }
 

--- a/src/keri/app/notifying.ts
+++ b/src/keri/app/notifying.ts
@@ -61,10 +61,9 @@ export class Notifications {
      * @param {string} said SAID of the notification
      * @returns {Promise<any>} A promise to the result of the deletion
      */
-    async delete(said: string): Promise<any> {
+    async delete(said: string): Promise<void> {
         const path = `/notifications/` + said;
         const method = 'DELETE';
         const res = await this.client.fetch(path, method, null);
-        return await res.json();
     }
 }

--- a/src/keri/app/notifying.ts
+++ b/src/keri/app/notifying.ts
@@ -64,6 +64,6 @@ export class Notifications {
     async delete(said: string): Promise<void> {
         const path = `/notifications/` + said;
         const method = 'DELETE';
-        const res = await this.client.fetch(path, method, null);
+        await this.client.fetch(path, method, null);
     }
 }

--- a/test/app/coring.test.ts
+++ b/test/app/coring.test.ts
@@ -214,9 +214,24 @@ describe('Coring', () => {
         const ops = client.operations();
 
         await ops.get('operationName');
-        const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(lastCall[0]!, url + '/operations/operationName');
         assert.equal(lastCall[1]!.method, 'GET');
+
+        await ops.list();
+        lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(lastCall[0]!, url + '/operations?');
+        assert.equal(lastCall[1]!.method, 'GET');
+
+        await ops.list('witness');
+        lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(lastCall[0]!, url + '/operations?type=witness');
+        assert.equal(lastCall[1]!.method, 'GET');
+
+        await ops.delete('operationName');
+        lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(lastCall[0]!, url + '/operations/operationName');
+        assert.equal(lastCall[1]!.method, 'DELETE');
     });
 
     it('Events and states', async () => {


### PR DESCRIPTION
Fixing issues reported in https://github.com/WebOfTrust/signify-ts/issues/201

Implements client side fix for https://github.com/WebOfTrust/keria/issues/147 when checking status of operations that have dependencies