### PR TITLE
Multisig inception utils for testing

### DIFF
--- a/examples/integration-scripts/delegation-multisig.test.ts
+++ b/examples/integration-scripts/delegation-multisig.test.ts
@@ -1,6 +1,7 @@
 import { strict as assert } from 'assert';
 import signify from 'signify-ts';
 import {
+    assertNotifications,
     assertOperations,
     markAndRemoveNotification,
     resolveOobi,
@@ -9,6 +10,10 @@ import {
     warnNotifications,
 } from './utils/test-util';
 import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
+import {
+    acceptMultisigIncept,
+    startMultisigIncept,
+} from './utils/multisig-utils';
 
 test('delegation-multisig', async () => {
     await signify.ready();
@@ -42,102 +47,33 @@ test('delegation-multisig', async () => {
     console.log('Member1 and Member2 resolved 2 OOBIs');
 
     // First member start the creation of a multisig identifier
-    const rstates = [aid1['state'], aid2['state']];
-    const states = rstates;
-    const icpResult1 = await client1.identifiers().create('multisig', {
-        algo: signify.Algos.group,
-        mhab: aid1,
+    const op1 = await startMultisigIncept(client1, {
+        groupName: 'multisig',
+        localMemberName: aid1.name,
+        participants: [aid1.prefix, aid2.prefix],
         isith: 2,
         nsith: 2,
         toad: 2,
+        delpre: aid0.prefix,
         wits: [
             'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
             'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
             'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
         ],
-        states: states,
-        rstates: rstates,
-        delpre: aid0.prefix,
     });
-    const op1 = await icpResult1.op();
-    let serder = icpResult1.serder;
-
-    let sigs = icpResult1.sigs;
-    let sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
-    let ims = signify.d(signify.messagize(serder, sigers));
-    let atc = ims.substring(serder.size);
-    let embeds = {
-        icp: [serder, atc],
-    };
-
-    let smids = states.map((state) => state['i']);
-    let recp = [aid2['state']].map((state) => state['i']);
-
-    await client1
-        .exchanges()
-        .send(
-            'member1',
-            'multisig',
-            aid1,
-            '/multisig/icp',
-            { gid: serder.pre, smids: smids, rmids: smids },
-            embeds,
-            recp
-        );
     console.log('Member1 initiated multisig, waiting for others to join...');
 
     // Second member check notifications and join the multisig
-    const notifications = await waitForNotifications(client2, '/multisig/icp');
-    const msgSaid = notifications[notifications.length - 1].a.d;
-    assert(msgSaid !== undefined);
-    console.log('Member2 received exchange message to join multisig');
-
-    const res = await client2.groups().getRequest(msgSaid);
-
-    await Promise.all(
-        notifications.map((note) => markAndRemoveNotification(client2, note))
-    );
-
-    const exn = res[0].exn;
-    const icp = exn.e.icp;
-
-    const icpResult2 = await client2.identifiers().create('multisig', {
-        algo: signify.Algos.group,
-        mhab: aid2,
-        isith: icp.kt,
-        nsith: icp.nt,
-        toad: parseInt(icp.bt),
-        wits: icp.b,
-        states: states,
-        rstates: rstates,
-        delpre: aid0.prefix,
+    const [notification] = await waitForNotifications(client2, '/multisig/icp');
+    await markAndRemoveNotification(client2, notification);
+    assert(notification.a.d);
+    const op2 = await acceptMultisigIncept(client2, {
+        localMemberName: aid2.name,
+        groupName: 'multisig',
+        msgSaid: notification.a.d,
     });
-    const op2 = await icpResult2.op();
-    serder = icpResult2.serder;
-    sigs = icpResult2.sigs;
-    sigers = sigs.map((sig) => new signify.Siger({ qb64: sig }));
 
-    ims = signify.d(signify.messagize(serder, sigers));
-    atc = ims.substring(serder.size);
-    embeds = {
-        icp: [serder, atc],
-    };
-
-    smids = exn.a.smids;
-    recp = [aid1['state']].map((state) => state['i']);
-
-    await client2
-        .exchanges()
-        .send(
-            'member2',
-            'multisig',
-            aid2,
-            '/multisig/icp',
-            { gid: serder.pre, smids: smids, rmids: smids },
-            embeds,
-            recp
-        );
-    console.log('Member2 joined multisig, waiting for others...');
+    console.log('Member2 joined multisig, waiting for delegator...');
 
     const delegatePrefix = op1.name.split('.')[1];
     assert.equal(op2.name.split('.')[1], delegatePrefix);
@@ -150,12 +86,12 @@ test('delegation-multisig', async () => {
         s: '0',
         d: delegatePrefix,
     };
-    let ixnResult = await client0.identifiers().interact('delegator', anchor);
+    const ixnResult = await client0.identifiers().interact('delegator', anchor);
     await waitOperation(client0, await ixnResult.op());
     console.log('Delegator approved delegation');
 
-    let op3 = await client1.keyStates().query(aid0.prefix, '1');
-    let op4 = await client2.keyStates().query(aid0.prefix, '1');
+    const op3 = await client1.keyStates().query(aid0.prefix, '1');
+    const op4 = await client2.keyStates().query(aid0.prefix, '1');
 
     // Check for completion
     await Promise.all([
@@ -170,7 +106,7 @@ test('delegation-multisig', async () => {
     assert.equal(aid_delegate.prefix, delegatePrefix);
 
     await assertOperations(client0, client1, client2);
-    await warnNotifications(client0, client1, client2);
+    await assertNotifications(client0, client1, client2);
 }, 30000);
 
 async function createAID(client: signify.SignifyClient, name: string) {

--- a/examples/integration-scripts/multisig-inception.test.ts
+++ b/examples/integration-scripts/multisig-inception.test.ts
@@ -1,0 +1,133 @@
+import signify from 'signify-ts';
+import {
+    resolveOobi,
+    waitForNotifications,
+    waitOperation,
+} from './utils/test-util';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
+import {
+    acceptMultisigIncept,
+    startMultisigIncept,
+} from './utils/multisig-utils';
+import assert from 'assert';
+import { step } from './utils/test-step';
+
+test('multisig inception', async () => {
+    await signify.ready();
+    const [client1, client2] = await Promise.all([
+        getOrCreateClient(),
+        getOrCreateClient(),
+    ]);
+
+    const [[aid1], [aid2]] = await Promise.all([
+        getOrCreateIdentifier(client1, 'member1'),
+        getOrCreateIdentifier(client2, 'member2'),
+    ]);
+
+    await step('Resolve oobis', async () => {
+        const oobi1 = await client1.oobis().get('member1', 'agent');
+        const oobi2 = await client2.oobis().get('member2', 'agent');
+
+        await Promise.all([
+            resolveOobi(client1, oobi2.oobis[0], 'member2'),
+            resolveOobi(client2, oobi1.oobis[0], 'member1'),
+        ]);
+    });
+
+    await step('Create multisig group', async () => {
+        const groupName = 'multisig';
+        const op1 = await startMultisigIncept(client1, {
+            groupName,
+            localMemberName: 'member1',
+            participants: [aid1, aid2],
+            toad: 2,
+            isith: 2,
+            nsith: 2,
+            wits: [
+                'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
+                'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
+                'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
+            ],
+        });
+        console.log(
+            'Member1 initiated multisig, waiting for others to join...'
+        );
+
+        // Second member check notifications and join the multisig
+        const notifications = await waitForNotifications(
+            client2,
+            '/multisig/icp'
+        );
+        await Promise.all(
+            notifications.map((note) => client2.notifications().mark(note.i))
+        );
+        const msgSaid = notifications[notifications.length - 1].a.d;
+        assert(msgSaid, 'msgSaid not defined');
+        const op2 = await acceptMultisigIncept(client2, {
+            localMemberName: 'member2',
+            groupName,
+            msgSaid,
+        });
+        console.log('Member2 joined multisig, waiting for others...');
+
+        // Check for completion
+        await Promise.all([
+            waitOperation(client1, op1),
+            waitOperation(client2, op2),
+        ]);
+        console.log('Multisig created!');
+
+        const multisig1 = await client1.identifiers().get(groupName);
+        const multisig2 = await client2.identifiers().get(groupName);
+        assert.strictEqual(multisig1.prefix, multisig2.prefix);
+        const members = await client1.identifiers().members(groupName);
+        assert.strictEqual(members.signing.length, 2);
+        assert.strictEqual(members.rotation.length, 2);
+        assert.strictEqual(members.signing[0].aid, aid1);
+        assert.strictEqual(members.signing[1].aid, aid2);
+        assert.strictEqual(members.rotation[0].aid, aid1);
+        assert.strictEqual(members.rotation[1].aid, aid2);
+    });
+
+    await step('Test creating another group', async () => {
+        const groupName = 'multisig2';
+        const op1 = await startMultisigIncept(client1, {
+            groupName,
+            localMemberName: 'member1',
+            participants: [aid1, aid2],
+            toad: 0,
+            isith: 2,
+            nsith: 2,
+            wits: [],
+        });
+        console.log(
+            'Member1 initiated multisig, waiting for others to join...'
+        );
+
+        // Second member check notifications and join the multisig
+        const notifications = await waitForNotifications(
+            client2,
+            '/multisig/icp'
+        );
+        await Promise.all(
+            notifications.map((note) => client2.notifications().mark(note.i))
+        );
+        const msgSaid = notifications[notifications.length - 1].a.d;
+        assert(msgSaid, 'msgSaid not defined');
+        const op2 = await acceptMultisigIncept(client2, {
+            localMemberName: 'member2',
+            groupName,
+            msgSaid,
+        });
+
+        await Promise.all([
+            waitOperation(client1, op1),
+            waitOperation(client2, op2),
+        ]);
+
+        // TODO: https://github.com/WebOfTrust/keria/issues/189
+        // const members = await client1.identifiers().members(groupName);
+        // assert.strictEqual(members.signing.length, 2);
+        // assert.strictEqual(members.rotating.length, 2);
+    });
+}, 30000);

--- a/examples/integration-scripts/utils/multisig-utils.ts
+++ b/examples/integration-scripts/utils/multisig-utils.ts
@@ -1,0 +1,127 @@
+import { Algos, Siger, SignifyClient, d, messagize } from 'signify-ts';
+
+export interface AcceptMultisigInceptArgs {
+    groupName: string;
+    localMemberName: string;
+    msgSaid: string;
+}
+
+export async function acceptMultisigIncept(
+    client2: SignifyClient,
+    { groupName, localMemberName, msgSaid }: AcceptMultisigInceptArgs
+) {
+    const memberHab = await client2.identifiers().get(localMemberName);
+
+    const res = await client2.groups().getRequest(msgSaid);
+    const exn = res[0].exn;
+    const icp = exn.e.icp;
+    const smids = exn.a.smids;
+    const rmids = exn.a.rmids;
+    const states = await getStates(client2, smids);
+    const rstates = await getStates(client2, rmids);
+
+    const icpResult2 = await client2.identifiers().create(groupName, {
+        algo: Algos.group,
+        mhab: memberHab,
+        isith: icp.kt,
+        nsith: icp.nt,
+        toad: parseInt(icp.bt),
+        wits: icp.b,
+        states: states,
+        rstates: rstates,
+        delpre: icp.di,
+    });
+    const op2 = await icpResult2.op();
+    const serder = icpResult2.serder;
+    const sigs = icpResult2.sigs;
+    const sigers = sigs.map((sig) => new Siger({ qb64: sig }));
+
+    const ims = d(messagize(serder, sigers));
+    const atc = ims.substring(serder.size);
+    const embeds = {
+        icp: [serder, atc],
+    };
+
+    const recipients = smids.filter((id: string) => memberHab.prefix !== id);
+
+    await client2
+        .exchanges()
+        .send(
+            localMemberName,
+            'multisig',
+            memberHab,
+            '/multisig/icp',
+            { gid: serder.pre, smids: smids, rmids: smids },
+            embeds,
+            recipients
+        );
+
+    return op2;
+}
+
+export interface StartMultisigInceptArgs {
+    groupName: string;
+    localMemberName: string;
+    participants: string[];
+    isith?: number | string | string[];
+    nsith?: number | string | string[];
+    toad?: number;
+    wits?: string[];
+    delpre?: string;
+}
+
+export async function startMultisigIncept(
+    client: SignifyClient,
+    {
+        groupName,
+        localMemberName,
+        participants,
+        ...args
+    }: StartMultisigInceptArgs
+) {
+    const aid1 = await client.identifiers().get(localMemberName);
+    const participantStates = await getStates(client, participants);
+    const icpResult1 = await client.identifiers().create(groupName, {
+        algo: Algos.group,
+        mhab: aid1,
+        isith: args.isith,
+        nsith: args.nsith,
+        toad: args.toad,
+        wits: args.wits,
+        delpre: args.delpre,
+        states: participantStates,
+        rstates: participantStates,
+    });
+    const op1 = await icpResult1.op();
+    const serder = icpResult1.serder;
+
+    const sigs = icpResult1.sigs;
+    const sigers = sigs.map((sig) => new Siger({ qb64: sig }));
+    const ims = d(messagize(serder, sigers));
+    const atc = ims.substring(serder.size);
+    const embeds = {
+        icp: [serder, atc],
+    };
+
+    const smids = participantStates.map((state) => state['i']);
+
+    await client
+        .exchanges()
+        .send(
+            'member1',
+            'multisig',
+            aid1,
+            '/multisig/icp',
+            { gid: serder.pre, smids: smids, rmids: smids },
+            embeds,
+            participants
+        );
+    return op1;
+}
+
+async function getStates(client: SignifyClient, prefixes: string[]) {
+    const participantStates = await Promise.all(
+        prefixes.map((p) => client.keyStates().get(p))
+    );
+    return participantStates.map((s) => s[0]);
+}


### PR DESCRIPTION
When I was creating the reproduction script for https://github.com/WebOfTrust/keria/issues/189 I extract a couple of utility functions for multisig inceptions. I thought it might be useful to include them in the multisig tests to make it a bit easier to comprehend the tests.

In the future, I believe the "accept" type of function for multisig operations would be useful to include in the exposed library.