### PR TITLE
fix: remove window.Buffer assignment

### DIFF
--- a/src/buffer-polyfill.ts
+++ b/src/buffer-polyfill.ts
@@ -1,5 +1,0 @@
-import { Buffer } from 'buffer';
-
-try {
-    window.Buffer = Buffer;
-} catch (e) {}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-import './buffer-polyfill';
 import * as exp from './exports';
 export * from './exports';
 export default exp;

--- a/src/keri/core/bexter.ts
+++ b/src/keri/core/bexter.ts
@@ -1,6 +1,7 @@
 import { BexDex, Matter, MatterArgs, MtrDex } from './matter';
 import { EmptyMaterialError } from './kering';
 import Base64 from 'urlsafe-base64';
+import { Buffer } from 'buffer';
 
 const B64REX = '^[A-Za-z0-9\\-_]*$';
 export const Reb64 = new RegExp(B64REX);

--- a/src/keri/core/diger.ts
+++ b/src/keri/core/diger.ts
@@ -1,5 +1,5 @@
 import { blake3 } from '@noble/hashes/blake3';
-
+import { Buffer } from 'buffer';
 import { Matter, MatterArgs, MtrDex } from './matter';
 
 /**

--- a/src/keri/core/prefixer.ts
+++ b/src/keri/core/prefixer.ts
@@ -3,7 +3,7 @@ import { EmptyMaterialError } from './kering';
 import { Dict, Ilks } from './core';
 import { sizeify } from './serder';
 import { Verfer } from './verfer';
-
+import { Buffer } from 'buffer';
 import { blake3 } from '@noble/hashes/blake3';
 
 const Dummy: string = '#';

--- a/src/keri/core/saider.ts
+++ b/src/keri/core/saider.ts
@@ -2,7 +2,7 @@ import { DigiDex, Matter, MatterArgs, MtrDex } from './matter';
 import { deversify, Dict, Serials } from './core';
 import { EmptyMaterialError } from './kering';
 import { dumps, sizeify } from './serder';
-
+import { Buffer } from 'buffer';
 import { blake3 } from '@noble/hashes/blake3';
 
 const Dummy = '#';


### PR DESCRIPTION
Previously, we've had a polyfill setting `window.Buffer = import("buffer").Buffer`. However, window is not available in all environments (e.g. service workers). This causes background browser extension workers to either fail or require an extra polyfill.

This PR fixes that by removing the polyfill and importing the module where it is needed instead.

There should be a way to ensure that the typescript build or eslint check fails if we are using APIs that are not available in both browser and node.js environment, but I haven't been able to figure it out yet.