### PR TITLE
fix sn to int parsing to use base 16

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -254,7 +254,7 @@ export class Identifier {
         const pre: string = hab.prefix;
 
         const state = hab.state;
-        const sn = Number(state.s);
+        const sn = parseInt(state.s, 16);
         const dig = state.d;
 
         data = Array.isArray(data) ? data : [data];
@@ -307,7 +307,7 @@ export class Identifier {
         const state = hab.state;
         const count = state.k.length;
         const dig = state.d;
-        const ridx = Number(state.s) + 1;
+        const ridx = parseInt(state.s, 16) + 1;
         const wits = state.b;
         let isith = state.nt;
 

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -259,8 +259,6 @@ export class Identifier {
 
         data = Array.isArray(data) ? data : [data];
 
-        data = Array.isArray(data) ? data : [data];
-
         const serder = interact({
             pre: pre,
             sn: sn + 1,

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -224,7 +224,7 @@ export class Credentials {
             dt: dt,
         });
 
-        const sn = Number(hab.state.s);
+        const sn = parseInt(hab.state.s, 16);
         const anc = interact({
             pre: hab.prefix,
             sn: sn + 1,
@@ -308,7 +308,7 @@ export class Credentials {
             var estOnly = false;
         }
 
-        const sn = Number(state.s);
+        const sn = parseInt(state.s, 16);
         const dig = state.d;
 
         const data: any = [
@@ -583,7 +583,7 @@ export class Registries {
             throw new Error('establishment only not implemented');
         } else {
             const state = hab.state;
-            const sn = Number(state.s);
+            const sn = parseInt(state.s, 16);
             const dig = state.d;
 
             const data: any = [

--- a/src/keri/core/number.ts
+++ b/src/keri/core/number.ts
@@ -40,7 +40,7 @@ export class CesrNumber extends Matter {
             // make huge version of code
             code = code = NumDex.Huge;
         } else {
-            throw new Error('Invalid num = {num}, too large to encode.');
+            throw new Error(`Invalid num = ${num}, too large to encode.`);
         }
 
         raw = intToBytes(_num, Matter._rawSize(code));

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -191,6 +191,30 @@ describe('Aiding', () => {
         assert.deepEqual(lastCall.body.salty.transferable, true);
     });
 
+    it('Can rotate salty identifier with sn > 10', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(
+            Response.json({
+                ...aid1,
+                state: {
+                    ...aid1.state,
+                    s: 'a',
+                },
+            })
+        );
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+
+        await client.identifiers().rotate('aid1');
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers/aid1');
+        assert.equal(lastCall.method, 'PUT');
+        expect(lastCall.body.rot).toMatchObject({
+            v: 'KERI10JSON000160_',
+            t: 'rot',
+            s: 'b',
+        });
+    });
+
     it('Can create interact event', async () => {
         const data = [
             {
@@ -217,18 +241,45 @@ describe('Aiding', () => {
             i: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
             s: '1',
             p: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
-            a: [
-                {
-                    i: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
-                    s: 0,
-                    d: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
-                },
-            ],
+            a: data,
         });
 
         assert.deepEqual(lastCall.body.sigs, [
             'AADEzKk-5LT6vH-PWFb_1i1A8FW-KGHORtTOCZrKF4gtWkCr9vN1z_mDSVKRc6MKktpdeB3Ub1fWCGpnS50hRgoJ',
         ]);
+    });
+
+    it('Can create interact event when sequence number > 10', async () => {
+        const data = [
+            {
+                i: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
+                s: 0,
+                d: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
+            },
+        ];
+
+        const aid1 = await createMockIdentifierState('aid1', bran);
+        client.fetch.mockResolvedValueOnce(
+            Response.json({
+                ...aid1,
+                state: {
+                    ...aid1.state,
+                    s: 'a',
+                },
+            })
+        );
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+
+        await client.identifiers().interact('aid1', data);
+
+        const lastCall = client.getLastMockRequest();
+
+        expect(lastCall.path).toEqual('/identifiers/aid1?type=ixn');
+        expect(lastCall.method).toEqual('PUT');
+        expect(lastCall.body.ixn).toMatchObject({
+            s: 'b',
+            a: data,
+        });
     });
 
     it('Can add end role', async () => {


### PR DESCRIPTION
The sequence number is expected to be a hex string without the preceeding `0x`. So for example sequence number 10 is simply `a`. This causes issues with previous implementation because `Number("a") => NaN` this fixes the issue by specifying the base when parsing.

Another potential fix could have been to add a `0x` prefix server side... But that probably has more implications that I am not aware of.

It would be good to add some unit tests with that verifies the behavour with a sequence number > 10.

There is a related issue where I wrote about this a few months ago: https://github.com/WebOfTrust/signify-ts/issues/138. Though I think the issue is broader than this particular fix. I simply searched the codebase for usage of the `Number` constructor and replaced them where it looked like it needed replacing.