### PR TITLE
Align passcode generation with `kli salt`

### DIFF
--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -4,7 +4,7 @@ import { Salter } from '../core/salter';
 import { Matter, MtrDex } from '../core/matter';
 
 export function randomPasscode(): string {
-    const raw = libsodium.randombytes_buf(16);
+    const raw = libsodium.randombytes_buf(32);
     const salter = new Salter({ raw: raw });
 
     return salter.qb64.substring(2);


### PR DESCRIPTION
Using 32 bytes rather than 16 bytes aligns SignifyTS passcode generation with KERIpy's `kli salt` command.

The generatePasscode function from SignifyTS has generated some passcodes that don't end up working for me.

```typescript
export function randomPasscode(): string {
    const raw = libsodium.randombytes_buf(16);
    const salter = new Salter({ raw: raw });

    return salter.qb64.substring(2);
}
```

From the kli salt command it is similar, though not quite the same:
```python
print(coring.Salter(raw=pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)).qb64)
```


For whatever reason the libsodium.randombytes_buf(16)  in Typescript doesn't produce the same results as pysodium.randombytes(pysodium.crypto_sign_SEEDBYTES)

I have seen problems with any random 21 character string which is why I started trying to constrain it with functions from Signify.

I found the following it in the Libsodium Github Repo [here](https://github.com/jedisct1/libsodium/blob/b564794eddda79d54374144653c1f4e05ae08a64/src/libsodium/include/sodium/crypto_sign_ed25519.h#L26). In the C code 
```c
// in libsodium/src/libsodium/include/sodium
/crypto_sign.h
#define crypto_sign_SEEDBYTES crypto_sign_ed25519_SEEDBYTES

// which references the following in
// src/libsodium/include/sodium/crypto_sign_ed25519.h
#define crypto_sign_ed25519_SEEDBYTES 32U
```

Looks like the Python impl uses 32 bytes and SignifyTS is currently using 16 bytes. 