### PR TITLE
fix: cannot set salts for credential creation (suggestion)

### DIFF
--- a/examples/integration-scripts/credentials.test.ts
+++ b/examples/integration-scripts/credentials.test.ts
@@ -143,13 +143,16 @@ test('single signature credentials', async () => {
             LEI: '5493001KJTIIGC8Y1R17',
         };
 
-        const issResult = await issuerClient.credentials().issue({
-            issuerName: issuerAid.name,
-            registryId: registry.regk,
-            schemaId: QVI_SCHEMA_SAID,
-            recipient: holderAid.prefix,
-            data: vcdata,
-        });
+        const issResult = await issuerClient
+            .credentials()
+            .issue(issuerAid.name, {
+                ri: registry.regk,
+                s: QVI_SCHEMA_SAID,
+                a: {
+                    i: holderAid.prefix,
+                    ...vcdata,
+                },
+            });
 
         await waitOperation(issuerClient, issResult.op);
         return issResult.acdc.ked.d as string;
@@ -374,31 +377,32 @@ test('single signature credentials', async () => {
                 .credentials()
                 .get(qviCredentialId);
 
-            const result = await holderClient.credentials().issue({
-                issuerName: holderAid.name,
-                recipient: legalEntityAid.prefix,
-                registryId: holderRegistry.regk,
-                schemaId: LE_SCHEMA_SAID,
-                data: {
-                    LEI: '5493001KJTIIGC8Y1R17',
-                },
-                rules: Saider.saidify({
-                    d: '',
-                    usageDisclaimer: {
-                        l: 'Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled.',
+            const result = await holderClient
+                .credentials()
+                .issue(holderAid.name, {
+                    a: {
+                        i: legalEntityAid.prefix,
+                        LEI: '5493001KJTIIGC8Y1R17',
                     },
-                    issuanceDisclaimer: {
-                        l: 'All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework.',
-                    },
-                })[1],
-                source: Saider.saidify({
-                    d: '',
-                    qvi: {
-                        n: qviCredential.sad.d,
-                        s: qviCredential.sad.s,
-                    },
-                })[1],
-            });
+                    ri: holderRegistry.regk,
+                    s: LE_SCHEMA_SAID,
+                    r: Saider.saidify({
+                        d: '',
+                        usageDisclaimer: {
+                            l: 'Usage of a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, does not assert that the Legal Entity is trustworthy, honest, reputable in its business dealings, safe to do business with, or compliant with any laws or that an implied or expressly intended purpose will be fulfilled.',
+                        },
+                        issuanceDisclaimer: {
+                            l: 'All information in a valid, unexpired, and non-revoked vLEI Credential, as defined in the associated Ecosystem Governance Framework, is accurate as of the date the validation process was complete. The vLEI Credential has been issued to the legal entity or person named in the vLEI Credential as the subject; and the qualified vLEI Issuer exercised reasonable care to perform the validation process set forth in the vLEI Ecosystem Governance Framework.',
+                        },
+                    })[1],
+                    e: Saider.saidify({
+                        d: '',
+                        qvi: {
+                            n: qviCredential.sad.d,
+                            s: qviCredential.sad.s,
+                        },
+                    })[1],
+                });
 
             await waitOperation(holderClient, result.op);
             return result.acdc.ked.d;

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -1,10 +1,5 @@
 import { strict as assert } from 'assert';
-import signify, {
-    SignifyClient,
-    IssueCredentialArgs,
-    Operation,
-    CredentialData,
-} from 'signify-ts';
+import signify, { SignifyClient, Operation, CredentialData } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assertOperations,

--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -3,6 +3,7 @@ import signify, {
     SignifyClient,
     IssueCredentialArgs,
     Operation,
+    CredentialData,
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
@@ -354,12 +355,11 @@ test('multisig', async function run() {
 
     console.log(`Issuer starting credential issuance to holder...`);
     const registires = await client3.registries().list('issuer');
-    await issueCredential(client3, {
-        issuerName: 'issuer',
-        registryId: registires[0].regk,
-        schemaId: SCHEMA_SAID,
-        recipient: holderAid['prefix'],
-        data: {
+    await issueCredential(client3, 'issuer', {
+        ri: registires[0].regk,
+        s: SCHEMA_SAID,
+        a: {
+            i: holderAid['prefix'],
             LEI: '5493001KJTIIGC8Y1R17',
         },
     });
@@ -476,23 +476,24 @@ async function createRegistry(
 
 async function issueCredential(
     client: SignifyClient,
-    args: IssueCredentialArgs
+    name: string,
+    data: CredentialData
 ) {
-    const result = await client.credentials().issue(args);
+    const result = await client.credentials().issue(name, data);
 
     await waitOperation(client, result.op);
 
     const creds = await client.credentials().list();
     assert.equal(creds.length, 1);
-    assert.equal(creds[0].sad.s, args.schemaId);
+    assert.equal(creds[0].sad.s, data.s);
     assert.equal(creds[0].status.s, '0');
 
     const dt = createTimestamp();
 
-    if (args.recipient) {
+    if (data.a.i) {
         const [grant, gsigs, end] = await client.ipex().grant({
-            senderName: args.issuerName,
-            recipient: args.recipient,
+            senderName: name,
+            recipient: data.a.i,
             datetime: dt,
             acdc: result.acdc,
             anc: result.anc,
@@ -501,7 +502,7 @@ async function issueCredential(
 
         let op = await client
             .ipex()
-            .submitGrant(args.issuerName, grant, gsigs, end, [args.recipient]);
+            .submitGrant(name, grant, gsigs, end, [data.a.i]);
         op = await waitOperation(client, op);
     }
 

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -797,7 +797,6 @@ test('multisig', async function run() {
     });
     op2 = await vcpRes2.op();
     serder = vcpRes2.regser;
-    const regk2 = serder.pre;
     anc = vcpRes2.serder;
     sigs = vcpRes2.sigs;
 
@@ -840,7 +839,6 @@ test('multisig', async function run() {
     });
     op3 = await vcpRes3.op();
     serder = vcpRes3.regser;
-    const regk3 = serder.pre;
     anc = vcpRes3.serder;
     sigs = vcpRes3.sigs;
 
@@ -881,13 +879,14 @@ test('multisig', async function run() {
     const holder = aid4.prefix;
 
     const TIME = new Date().toISOString().replace('Z', '000+00:00');
-    const credRes = await client1.credentials().issue({
-        issuerName: 'multisig',
-        registryId: regk,
-        schemaId: SCHEMA_SAID,
-        data: vcdata,
-        recipient: holder,
-        datetime: TIME,
+    const credRes = await client1.credentials().issue('multisig', {
+        ri: regk,
+        s: SCHEMA_SAID,
+        a: {
+            i: holder,
+            dt: TIME,
+            ...vcdata,
+        },
     });
     op1 = credRes.op;
     await multisigIssue(client1, 'member1', 'multisig', credRes);
@@ -905,15 +904,7 @@ test('multisig', async function run() {
     exn = res[0].exn;
 
     const credentialSaid = exn.e.acdc.d;
-
-    const credRes2 = await client2.credentials().issue({
-        issuerName: 'multisig',
-        registryId: regk2,
-        schemaId: SCHEMA_SAID,
-        data: vcdata,
-        datetime: exn.e.acdc.a.dt,
-        recipient: holder,
-    });
+    const credRes2 = await client2.credentials().issue('multisig', exn.e.acdc);
 
     op2 = credRes2.op;
     await multisigIssue(client2, 'member2', 'multisig', credRes2);
@@ -927,14 +918,7 @@ test('multisig', async function run() {
     res = await client3.groups().getRequest(msgSaid);
     exn = res[0].exn;
 
-    const credRes3 = await client3.credentials().issue({
-        issuerName: 'multisig',
-        registryId: regk3,
-        schemaId: SCHEMA_SAID,
-        recipient: holder,
-        data: vcdata,
-        datetime: exn.e.acdc.a.dt,
-    });
+    const credRes3 = await client3.credentials().issue('multisig', exn.e.acdc);
 
     op3 = credRes3.op;
     await multisigIssue(client3, 'member3', 'multisig', credRes3);

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -490,7 +490,8 @@ async function getOrIssueCredential(
     credData: any,
     schema: string,
     rules?: any,
-    source?: any
+    source?: any,
+    privacy = false
 ): Promise<any> {
     const credentialList = await issuerClient.credentials().list();
 
@@ -509,10 +510,10 @@ async function getOrIssueCredential(
     const issResult = await issuerClient.credentials().issue(issuerAid.name, {
         ri: issuerRegistry.regk,
         s: schema,
-        u: new Salter({}).qb64,
+        u: privacy ? new Salter({}).qb64 : undefined,
         a: {
             i: recipientAid.prefix,
-            u: new Salter({}).qb64,
+            u: privacy ? new Salter({}).qb64 : undefined,
             ...credData,
         },
         r: rules,

--- a/examples/integration-scripts/singlesig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/singlesig-vlei-issuance.test.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from 'assert';
-import { Saider, Serder, SignifyClient } from 'signify-ts';
+import { Saider, Salter, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
     assertOperations,
@@ -490,8 +490,7 @@ async function getOrIssueCredential(
     credData: any,
     schema: string,
     rules?: any,
-    source?: any,
-    privacy: boolean = false
+    source?: any
 ): Promise<any> {
     const credentialList = await issuerClient.credentials().list();
 
@@ -507,15 +506,17 @@ async function getOrIssueCredential(
         if (credential) return credential;
     }
 
-    const issResult = await issuerClient.credentials().issue({
-        issuerName: issuerAid.name,
-        registryId: issuerRegistry.regk,
-        schemaId: schema,
-        recipient: recipientAid.prefix,
-        data: credData,
-        rules: rules,
-        source: source,
-        privacy: privacy,
+    const issResult = await issuerClient.credentials().issue(issuerAid.name, {
+        ri: issuerRegistry.regk,
+        s: schema,
+        u: new Salter({}).qb64,
+        a: {
+            i: recipientAid.prefix,
+            u: new Salter({}).qb64,
+            ...credData,
+        },
+        r: rules,
+        e: source,
     });
 
     await waitOperation(issuerClient, issResult.op);

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -37,8 +37,17 @@ export interface CredentialFilter {
 }
 
 export interface CredentialSubject {
+    /**
+     * Issuee, or holder of the credential.
+     */
     i?: string;
+    /**
+     * Timestamp of issuance.
+     */
     dt?: string;
+    /**
+     * Privacy salt
+     */
     u?: string;
     [key: string]: unknown;
 }
@@ -46,12 +55,33 @@ export interface CredentialSubject {
 export interface CredentialData {
     v?: string;
     d?: string;
+    /**
+     * Privacy salt
+     */
     u?: string;
+    /**
+     * Issuer of the credential.
+     */
     i?: string;
+    /**
+     * Registry id.
+     */
     ri?: string;
+    /**
+     * Schema id
+     */
     s?: string;
+    /**
+     * Credential subject data
+     */
     a: CredentialSubject;
+    /**
+     * Credential source section
+     */
     e?: { [key: string]: unknown };
+    /**
+     * Credential rules section
+     */
     r?: { [key: string]: unknown };
 }
 

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -223,7 +223,7 @@ export class Credentials {
             i: acdc.d,
             s: '0',
             ri: args.ri,
-            dt: args.a.dt ?? new Date().toISOString().replace('Z', '000+00:00'),
+            dt: subject.dt,
         });
 
         const sn = parseInt(hab.state.s, 16);

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -209,15 +209,10 @@ describe('Credentialing', () => {
         const registry = 'EP10ooRj0DJF0HWZePEYMLPl-arMV-MAoTKK-o3DXbgX';
         const schema = 'EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao';
         const isuee = 'EG2XjQN-3jPN5rcR4spLjaJyM4zA6Lgg-Hd5vSMymu5p';
-        await credentials.issue({
-            issuerName: 'aid1',
-            registryId: registry,
-            schemaId: schema,
-            recipient: isuee,
-            data: { LEI: '1234' },
-            source: {},
-            rules: {},
-            privacy: false,
+        await credentials.issue('aid1', {
+            ri: registry,
+            s: schema,
+            a: { i: isuee, LEI: '1234' },
         });
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         lastBody = JSON.parse(lastCall[1]!.body!.toString());


### PR DESCRIPTION
This is my suggestion on how to solve #221 .

I know this is a breaking change, but I don't think we need the additional interface for IssueCredentialArgs. I think it just adds confusion with the additional mapping of properties. Same for the other operations such as create identifier, rotate etc.