### PR TITLE
chore: upgrade math.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signify-ts",
-  "version": "0.1.1",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signify-ts",
-      "version": "0.1.1",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"
@@ -16,7 +16,7 @@
         "buffer": "^6.0.3",
         "ecdsa-secp256r1": "^1.3.3",
         "libsodium-wrappers-sumo": "^0.7.9",
-        "mathjs": "^11.8.2",
+        "mathjs": "^12.4.0",
         "structured-headers": "^0.5.0",
         "urlsafe-base64": "^1.0.0"
       },
@@ -664,9 +664,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
-      "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -6388,11 +6388,11 @@
       }
     },
     "node_modules/mathjs": {
-      "version": "11.11.0",
-      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.0.tgz",
-      "integrity": "sha512-i1Ao/tv1mlNd09XlOMOUu3KMySX3S0jhHNfDPzh0sCnPf1i62x6RjxhLwZ9ytmVSs0OdhF3moI4O84VSEjmUFw==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-12.4.0.tgz",
+      "integrity": "sha512-4Moy0RNjwMSajEkGGxNUyMMC/CZAcl87WBopvNsJWB4E4EFebpTedr+0/rhqmnOSTH3Wu/3WfiWiw6mqiaHxVw==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.23.9",
         "complex.js": "^2.1.1",
         "decimal.js": "^10.4.3",
         "escape-latex": "^1.2.0",
@@ -6400,13 +6400,13 @@
         "javascript-natural-sort": "^0.7.1",
         "seedrandom": "^3.0.5",
         "tiny-emitter": "^2.1.0",
-        "typed-function": "^4.1.0"
+        "typed-function": "^4.1.1"
       },
       "bin": {
         "mathjs": "bin/cli.js"
       },
       "engines": {
-        "node": ">= 14"
+        "node": ">= 18"
       }
     },
     "node_modules/md5.js": {
@@ -7647,9 +7647,9 @@
       }
     },
     "node_modules/typed-function": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.0.tgz",
-      "integrity": "sha512-DGwUl6cioBW5gw2L+6SMupGwH/kZOqivy17E4nsh1JI9fKF87orMmlQx3KISQPmg3sfnOUGlwVkroosvgddrlg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/typed-function/-/typed-function-4.1.1.tgz",
+      "integrity": "sha512-Pq1DVubcvibmm8bYcMowjVnnMwPVMeh0DIdA8ad8NZY2sJgapANJmiigSUwlt+EgXxpfIv8MWrQXTIzkfYZLYQ==",
       "engines": {
         "node": ">= 14"
       }

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "buffer": "^6.0.3",
     "ecdsa-secp256r1": "^1.3.3",
     "libsodium-wrappers-sumo": "^0.7.9",
-    "mathjs": "^11.8.2",
+    "mathjs": "^12.4.0",
     "structured-headers": "^0.5.0",
     "urlsafe-base64": "^1.0.0"
   },


### PR DESCRIPTION
Read about changes here: https://github.com/josdejong/mathjs/issues/3032

In particular it resolves an issue regarding module exports https://github.com/josdejong/mathjs/issues/2919 that complicates our tsconfig setup a little bit.