### PR TITLE
URL enconding of AID alias name in rest calls

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -112,7 +112,7 @@ export class Identifier {
      * @returns {Promise<any>} A promise to the identifier information
      */
     async get(name: string): Promise<any> {
-        const path = `/identifiers/${name}`;
+        const path = `/identifiers/${encodeURIComponent(name)}`;
         const data = null;
         const method = 'GET';
         const res = await this.client.fetch(path, method, data);

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -183,7 +183,7 @@ export class SignifyClient {
 
         const _body = method == 'GET' ? null : JSON.stringify(data);
         if (_body !== null) {
-            headers.set('Content-Length', String(_body.length));
+            headers.set('Content-Length', String((new TextEncoder().encode(_body)).length));
         }
         if (this.authn) {
             signed_headers = this.authn.sign(


### PR DESCRIPTION
This PR fix issue #204 **Handling of special characters and white spaces in alias names** by adding a missing url encoding and the correct `content-length` calculation. 

Without changes in KERIA it will fix the spaces and some special characters such as @ and $, but not other special character such as the `ö` letter used in Swedish.
In KERIA, it seems that Falcon modifies the `req.path` when passing it to the middleware that check signatures. Need further investigation.
