### PR TITLE
fix hex encoded seq num issue when sn is greater than 10

### DIFF
--- a/examples/integration-scripts/singlesig-rot-bulk.test.ts
+++ b/examples/integration-scripts/singlesig-rot-bulk.test.ts
@@ -1,0 +1,43 @@
+import { strict as assert } from 'assert';
+import signify, { SignifyClient, CesrNumber } from 'signify-ts';
+import { waitOperation } from './utils/test-util';
+import { getOrCreateClient, getOrCreateIdentifier } from './utils/test-setup';
+
+const WITNESS_AIDS = [
+    'BBilc4-L3tFUnfM_wJr4S4OJanAv_VmF_dJNN6vkf2Ha',
+    'BLskRTInXnMxWaGqcpSyMgo0nYbalW99cGZESrz3zapM',
+    'BIKKuvBwpmDVA4Ds-EpL5bt9OqPzWPja2LigFYZN2YfX',
+];
+
+test('multisig', async function run() {
+    await signify.ready();
+
+    const [client1] = await Promise.all([getOrCreateClient()]);
+
+    let [aid1] = await Promise.all([createAID(client1, 'aid1', WITNESS_AIDS)]);
+
+    aid1 = await client1.identifiers().get(aid1.name);
+    assert.equal(aid1.name, 'aid1');
+    assert.equal(aid1.state.s, '0');
+    assert.equal(Number.isInteger(aid1.state.s), false);
+    assert.equal(Number(aid1.state.s), 0);
+
+    let rotCount = 15;
+    for (let i = 1; i < rotCount; i++) {
+        let rotResult = await client1.identifiers().rotate(aid1.name);
+        await waitOperation(client1, await rotResult.op());
+
+        aid1 = await client1.identifiers().get(aid1.name);
+        let sner = new CesrNumber({}, undefined, aid1.state.s);
+        assert.equal(sner.num, i);
+        assert.equal(sner.numh, i.toString(16));
+    }
+}, 400000);
+
+async function createAID(client: SignifyClient, name: string, wits: string[]) {
+    await getOrCreateIdentifier(client, name, {
+        wits: wits,
+        toad: wits.length,
+    });
+    return await client.identifiers().get(name);
+}

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -7,6 +7,7 @@ import { MtrDex } from '../core/matter';
 import { Serder } from '../core/serder';
 import { parseRangeHeaders } from '../core/httping';
 import { KeyManager } from '../core/keeping';
+import { CesrNumber } from '../core/number';
 
 /** Arguments required to create an identfier */
 export interface CreateIdentiferArgs {
@@ -254,7 +255,7 @@ export class Identifier {
         const pre: string = hab.prefix;
 
         const state = hab.state;
-        const sn = Number(state.s);
+        const sner = new CesrNumber({}, undefined, state.s);
         const dig = state.d;
 
         data = Array.isArray(data) ? data : [data];
@@ -263,7 +264,7 @@ export class Identifier {
 
         const serder = interact({
             pre: pre,
-            sn: sn + 1,
+            sn: sner.num + 1,
             data: data,
             dig: dig,
             version: undefined,
@@ -307,7 +308,8 @@ export class Identifier {
         const state = hab.state;
         const count = state.k.length;
         const dig = state.d;
-        const ridx = Number(state.s) + 1;
+        const sner = new CesrNumber({}, undefined, state.s);
+        const ridx = sner.num + 1;
         const wits = state.b;
         let isith = state.nt;
 

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -21,6 +21,7 @@ import {
     serializeIssExnAttachment,
 } from '../core/utils';
 import { Operation } from './coring';
+import { CesrNumber } from '../core/number';
 
 /** Types of credentials */
 export class CredentialTypes {
@@ -230,10 +231,10 @@ export class Credentials {
             dt: dt,
         });
 
-        const sn = Number(hab.state.s);
+        const sner = new CesrNumber({}, undefined, hab.state.s);
         const anc = interact({
             pre: hab.prefix,
-            sn: sn + 1,
+            sn: sner.num + 1,
             data: [
                 {
                     i: iss.i,
@@ -320,7 +321,7 @@ export class Credentials {
             var estOnly = false;
         }
 
-        const sn = Number(state.s);
+        const sner = new CesrNumber({}, undefined, state.s);
         const dig = state.d;
 
         const data: any = [
@@ -339,7 +340,7 @@ export class Credentials {
         } else {
             const serder = interact({
                 pre: pre,
-                sn: sn + 1,
+                sn: sner.num + 1,
                 data: data,
                 dig: dig,
                 version: undefined,
@@ -604,7 +605,7 @@ export class Registries {
             throw new Error('establishment only not implemented');
         } else {
             const state = hab.state;
-            const sn = Number(state.s);
+            const sner = new CesrNumber({}, undefined, state.s);
             const dig = state.d;
 
             const data: any = [
@@ -617,7 +618,7 @@ export class Registries {
 
             const serder = interact({
                 pre: pre,
-                sn: sn + 1,
+                sn: sner.num + 1,
                 data: data,
                 dig: dig,
                 version: Versionage,


### PR DESCRIPTION
- fix "too large to encode" hex seq num issue when sn is greater than 10
- add singlesig-rot-bulk.test.ts to test sn greater than 10