### PR TITLE
add optional nonce fields in issue credential args to multisig private credential issuance

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -81,6 +81,10 @@ export interface IssueCredentialArgs {
      * Flag to issue a credential with privacy preserving features
      */
     privacy?: boolean;
+
+    attributeNonce?: string;
+
+    rootNonce?: string;
 }
 
 export interface IssueCredentialResult {
@@ -202,7 +206,9 @@ export class Credentials {
 
         const [, subject] = Saider.saidify({
             d: '',
-            u: args.privacy ? new Salter({}).qb64 : undefined,
+            u: args.privacy
+                ? args.attributeNonce ?? new Salter({}).qb64
+                : undefined,
             i: args.recipient,
             dt: dt,
             ...args.data,
@@ -211,7 +217,7 @@ export class Credentials {
         const [, acdc] = Saider.saidify({
             v: versify(Ident.ACDC, undefined, Serials.JSON, 0),
             d: '',
-            u: args.privacy ? new Salter({}).qb64 : undefined,
+            u: args.privacy ? args.rootNonce ?? new Salter({}).qb64 : undefined,
             i: hab.prefix,
             ri: args.registryId,
             s: args.schemaId,


### PR DESCRIPTION
- add attributeNonce, rootNonce fields in IssueCredentialArgs interface  to fix multisig private credential issuance. Members joining create-credential can use these fields to set nonce form `exn` message. 