### PR TITLE
fix flaky integration test

### DIFF
--- a/examples/integration-scripts/multisig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/multisig-vlei-issuance.test.ts
@@ -1261,9 +1261,10 @@ async function getOrCreateAID(
         await waitOperation(client, await result.op());
         aid = await client.identifiers().get(name);
 
-        await client
+        const op = await client
             .identifiers()
             .addEndRole(name, 'agent', client!.agent!.pre);
+        await waitOperation(client, await op.op());
         console.log(name, 'AID:', aid.prefix);
     }
     return aid;


### PR DESCRIPTION
The multisig vlei test did not await the end role operations, so it failed occasionally when the operations where not finished before the OOBI step.