### PR TITLE
add integration test matrix for keria version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,20 +52,29 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test:
-    name: Run integration test
-    runs-on: ubuntu-latest
+    name: Run integration test using keria:${{ matrix.keria-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ['ubuntu-latest']
+        keria-version: ['latest', '0.1.2', '0.1.3']
+        node-version: ['20']
+    env:
+      KERIA_IMAGE_TAG: ${{ matrix.keria-version }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: install deps
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Print docker compose config
+        run: docker compose config
       - name: Start dependencies
         run: docker compose up deps --pull always
       - name: Run integration test

--- a/README.md
+++ b/README.md
@@ -75,6 +75,22 @@ signify-ts-deps-1  | Dependencies running
 signify-ts-deps-1 exited with code 0
 ```
 
+It is possible to change the keria image by using environment variables. For example, to use weboftrust/keria:0.1.3, do:
+
+```bash
+export KERIA_IMAGE_TAG=0.1.3
+docker compose pull
+docker compose up deps
+```
+
+To use another repository, you can do:
+
+```bash
+export KERIA_IMAGE=gleif/keria
+docker compose pull
+docker compose up deps
+```
+
 **Important!** The integration tests runs on the build output in `dist/` directory. Make sure to run build before running the integration tests.
 
 ```bash
@@ -100,14 +116,6 @@ TEST_ENVIRONMENT=local npx jest examples/integration-scripts/credentials.test.ts
 ```
 
 This changes the discovery urls to use `localhost` instead of the hostnames inside the docker network.
-
-### Old integration scripts
-
-To run any of the old integration scripts that has not yet been converted to an integration test. Use `ts-node-esm`
-
-```bash
-npx ts-node-esm examples/integration-scripts/challenge.ts
-```
 
 # Diagrams
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,7 +26,7 @@ services:
             - 7723:7723
 
     keria:
-        image: weboftrust/keria:latest
+        image: ${KERIA_IMAGE:-weboftrust/keria}:${KERIA_IMAGE_TAG:-latest}
         environment:
             - KERI_AGENT_CORS=1
             - KERI_URL=http://keria:3902

--- a/examples/integration-scripts/multisig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/multisig-vlei-issuance.test.ts
@@ -1261,10 +1261,9 @@ async function getOrCreateAID(
         await waitOperation(client, await result.op());
         aid = await client.identifiers().get(name);
 
-        const op = await client
+        await client
             .identifiers()
             .addEndRole(name, 'agent', client!.agent!.pre);
-        await waitOperation(client, await op.op());
         console.log(name, 'AID:', aid.prefix);
     }
     return aid;

--- a/examples/integration-scripts/multisig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/multisig-vlei-issuance.test.ts
@@ -1261,9 +1261,10 @@ async function getOrCreateAID(
         await waitOperation(client, await result.op());
         aid = await client.identifiers().get(name);
 
-        await client
+        const op = await client
             .identifiers()
             .addEndRole(name, 'agent', client!.agent!.pre);
+        await waitOperation(client, await op.op());
         console.log(name, 'AID:', aid.prefix);
     }
     return aid;


### PR DESCRIPTION
This allows us to run the integration tests using multiple keria versions to make it more clear which versions this library supports. In the future, we can add some logic to the tests that skips them if they are incompatible. 