### PR TITLE
update keria test matrix to only use latest for now

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        keria-version: ['latest', '0.1.2', '0.1.3']
+        keria-version: ['latest']
         node-version: ['20']
     env:
       KERIA_IMAGE_TAG: ${{ matrix.keria-version }}


### PR DESCRIPTION
As mentioned by Phil in #248, it does not make much sense right now to keep running tests against old versions of keria.