### PR TITLE
Add type information to keeping module

### DIFF
--- a/examples/integration-scripts/modules/bip39_shim.ts
+++ b/examples/integration-scripts/modules/bip39_shim.ts
@@ -1,7 +1,7 @@
 import { mnemonicToSeedSync, generateMnemonic } from 'bip39';
-import { Diger, Signer, MtrDex } from 'signify-ts';
+import { Diger, Signer, MtrDex, Keeper, KeeperResult, Algos } from 'signify-ts';
 
-export class BIP39Shim {
+export class BIP39Shim implements Keeper {
     private icount: number;
     private ncount: number;
     private dcode: string | undefined;
@@ -10,6 +10,8 @@ export class BIP39Shim {
     private transferable: boolean;
     private stem: string;
     private mnemonics: string = '';
+    algo: Algos = Algos.extern;
+    signers: Signer[] = [];
 
     constructor(pidx: number, kargs: any) {
         this.icount = kargs.icount ?? 1;
@@ -47,7 +49,7 @@ export class BIP39Shim {
         return keys;
     }
 
-    incept(transferable: boolean) {
+    async incept(transferable: boolean): Promise<KeeperResult> {
         const signers = this.keys(this.icount, this.kidx, transferable);
         const verfers = signers.map((signer) => signer.verfer.qb64);
 
@@ -63,7 +65,12 @@ export class BIP39Shim {
         return [verfers, digers];
     }
 
-    rotate(ncount: number, transferable: boolean) {
+    async rotate(
+        // TODO: This signature is incompatible with Keeper
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        count: any, //number,
+        transferable: boolean
+    ): Promise<KeeperResult> {
         const signers = this.keys(
             this.ncount,
             this.kidx + this.icount,
@@ -73,7 +80,9 @@ export class BIP39Shim {
 
         this.kidx = this.kidx + this.icount;
         this.icount = this.ncount;
-        this.ncount = ncount;
+
+        // TODO: Due to incompatible signature.
+        this.ncount = count as number;
 
         const nsigners = this.keys(
             this.ncount,
@@ -88,7 +97,7 @@ export class BIP39Shim {
         return [verfers, digers];
     }
 
-    sign(
+    async sign(
         ser: Uint8Array,
         indexed = true,
         indices: number[] | undefined = undefined,
@@ -133,7 +142,7 @@ export class BIP39Shim {
             return sigers.map((siger) => siger.qb64);
         } else {
             const cigars = [];
-            for (const [_, signer] of signers.entries()) {
+            for (const [, signer] of signers.entries()) {
                 cigars.push(signer.sign(ser));
             }
             return cigars.map((cigar) => cigar.qb64);

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -7,6 +7,7 @@ import { MtrDex } from '../core/matter';
 import { Serder } from '../core/serder';
 import { parseRangeHeaders } from '../core/httping';
 import { KeyManager } from '../core/keeping';
+import { HabState } from '../core/state';
 
 /** Arguments required to create an identfier */
 export interface CreateIdentiferArgs {
@@ -25,9 +26,9 @@ export interface CreateIdentiferArgs {
     rstates?: any[];
     prxs?: any[];
     nxts?: any[];
-    mhab?: any;
-    keys?: any[];
-    ndigs?: any[];
+    mhab?: HabState;
+    keys?: string[];
+    ndigs?: string[];
     bran?: string;
     count?: number;
     ncount?: number;
@@ -111,7 +112,7 @@ export class Identifier {
      * @param {string} name Name or alias of the identifier
      * @returns {Promise<any>} A promise to the identifier information
      */
-    async get(name: string): Promise<any> {
+    async get(name: string): Promise<HabState> {
         const path = `/identifiers/${encodeURIComponent(name)}`;
         const data = null;
         const method = 'GET';

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -1,5 +1,4 @@
 import { SignifyClient } from './clienting';
-import { Salter } from '../core/salter';
 import { interact, messagize } from '../core/eventing';
 import { vdr } from '../core/vdring';
 import {
@@ -21,6 +20,7 @@ import {
     serializeIssExnAttachment,
 } from '../core/utils';
 import { Operation } from './coring';
+import { HabState } from '../core/state';
 
 /** Types of credentials */
 export class CredentialTypes {
@@ -408,7 +408,7 @@ export class Credentials {
 
         const keeper = this.client!.manager!.get(hab);
 
-        const sig = keeper.sign(b(exn.raw), true);
+        const sig = await keeper.sign(b(exn.raw), true);
 
         const siger = new Siger({ qb64: sig[0] });
         const seal = ['SealLast', { i: pre }];
@@ -634,7 +634,7 @@ export class Registries {
     }
 
     createFromEvents(
-        hab: Dict<any>,
+        hab: HabState,
         name: string,
         registryName: string,
         vcp: Dict<any>,
@@ -743,7 +743,7 @@ export class Ipex {
 
         let atc = args.ancAttachment;
         if (atc === undefined) {
-            const keeper = this.client.manager?.get(hab);
+            const keeper = this.client.manager!.get(hab);
             const sigs = await keeper.sign(b(args.anc.raw));
             const sigers = sigs.map((sig: string) => new Siger({ qb64: sig }));
             const ims = d(messagize(args.anc, sigers));

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -5,6 +5,7 @@ import { nowUTC } from '../core/utils';
 import { Pather } from '../core/pather';
 import { Counter, CtrDex } from '../core/counter';
 import { Saider } from '../core/saider';
+import { HabState } from '../core/state';
 
 /**
  * Exchanges
@@ -33,7 +34,7 @@ export class Exchanges {
      * @param dig
      */
     async createExchangeMessage(
-        sender: Dict<any>,
+        sender: HabState,
         route: string,
         payload: Dict<any>,
         embeds: Dict<any>,
@@ -72,7 +73,7 @@ export class Exchanges {
     async send(
         name: string,
         topic: string,
-        sender: Dict<any>,
+        sender: HabState,
         route: string,
         payload: Dict<any>,
         embeds: Dict<any>,

--- a/src/keri/core/keeping.ts
+++ b/src/keri/core/keeping.ts
@@ -13,7 +13,7 @@ import { HabState, State } from './state';
 
 /** External module definition */
 export interface ExternalModuleType {
-    new (pidx: number, args: unknown): Keeper;
+    new (pidx: number, args: KeeperParams): Keeper;
 }
 
 export interface ExternalModule {
@@ -143,7 +143,6 @@ export class KeyManager {
     }
 
     get(aid: HabState): Keeper {
-        const pre = new Prefixer({ qb64: aid['prefix'] });
         if (aid[Algos.salty]) {
             const kargs = aid[Algos.salty];
             return new SaltyKeeper(
@@ -164,6 +163,7 @@ export class KeyManager {
                 kargs['sxlt']
             );
         } else if (aid[Algos.randy]) {
+            const pre = new Prefixer({ qb64: aid['prefix'] });
             const kargs = aid[Algos.randy]!;
             return new RandyKeeper(
                 this.salter,

--- a/src/keri/core/keeping.ts
+++ b/src/keri/core/keeping.ts
@@ -9,28 +9,79 @@ import { Cipher } from './cipher';
 import { Diger } from './diger';
 import { Prefixer } from './prefixer';
 import { Signer } from './signer';
-import { Siger } from './siger';
-import { Cigar } from './cigar';
-
-export {};
+import { HabState, State } from './state';
 
 /** External module definition */
+export interface ExternalModuleType {
+    new (pidx: number, args: unknown): Keeper;
+}
+
 export interface ExternalModule {
     type: string;
     name: string;
-    module: any;
+    module: ExternalModuleType;
+}
+
+export type KeeperResult = [string[], string[]];
+export type SignResult = string[];
+
+export interface KeeperParams {
+    [key: string]: unknown;
+}
+
+export interface SaltyParams extends KeeperParams {
+    pidx: number;
+    kidx: number;
+    tier: Tier;
+    transferable: boolean;
+    stem: string | undefined;
+    icodes: string[] | undefined;
+    ncodes: string[] | undefined;
+    dcode: string | undefined;
+    sxlt: string | undefined;
+}
+
+export interface RandyParams extends KeeperParams {
+    nxts?: string[];
+    prxs?: string[];
+    transferable: boolean;
+}
+
+export interface GroupParams extends KeeperParams {
+    mhab: HabState;
+}
+
+export interface Keeper<T extends KeeperParams = KeeperParams> {
+    algo: Algos;
+    signers: Signer[];
+    params(): T;
+    incept(transferable: boolean): Promise<KeeperResult>;
+    rotate(
+        ncodes: string[],
+        transferable: boolean,
+        states?: State[],
+        rstates?: State[]
+    ): Promise<KeeperResult>;
+    sign(
+        ser: Uint8Array,
+        indexed?: boolean,
+        indices?: number[],
+        ondices?: number[]
+    ): Promise<SignResult>;
 }
 
 export class KeyManager {
-    private salter?: Salter;
-    private modules?: any;
+    private modules: Record<string, ExternalModuleType> = {};
 
-    constructor(salter: Salter, externalModules: ExternalModule[] = []) {
+    constructor(
+        private salter: Salter,
+        externalModules: ExternalModule[] = []
+    ) {
         this.salter = salter;
-        this.modules = [];
-        externalModules.forEach((mod) => {
+
+        for (const mod of externalModules) {
             this.modules[mod.type] = mod.module;
-        });
+        }
     }
 
     new(algo: Algos, pidx: number, kargs: any) {
@@ -76,67 +127,69 @@ export class KeyManager {
                     kargs['keys'],
                     kargs['ndigs']
                 );
-            case Algos.extern:
-                const typ = kargs.extern_type;
-                if (typ in this.modules) {
-                    const mod = new this.modules[typ](pidx, kargs);
-                    return mod;
-                } else {
-                    throw new Error(`unsupported external module type ${typ}`);
+            case Algos.extern: {
+                const ModuleConstructor = this.modules[kargs.extern_type];
+                if (!ModuleConstructor) {
+                    throw new Error(
+                        `unsupported external module type ${kargs.extern_type}`
+                    );
                 }
+
+                return new ModuleConstructor(pidx, kargs);
+            }
             default:
                 throw new Error('Unknown algo');
         }
     }
 
-    get(aid: any) {
+    get(aid: HabState): Keeper {
         const pre = new Prefixer({ qb64: aid['prefix'] });
-        if (Algos.salty in aid) {
+        if (aid[Algos.salty]) {
             const kargs = aid[Algos.salty];
             return new SaltyKeeper(
-                this.salter!,
+                this.salter,
                 kargs['pidx'],
                 kargs['kidx'],
                 kargs['tier'],
                 kargs['transferable'],
                 kargs['stem'],
-                kargs['code'],
-                kargs['count'],
+                undefined,
+                undefined,
                 kargs['icodes'],
-                kargs['ncode'],
-                kargs['ncount'],
+                undefined,
+                undefined,
                 kargs['ncodes'],
                 kargs['dcode'],
-                kargs['bran'],
+                undefined,
                 kargs['sxlt']
             );
-        } else if (Algos.randy in aid) {
-            const kargs = aid[Algos.randy];
+        } else if (aid[Algos.randy]) {
+            const kargs = aid[Algos.randy]!;
             return new RandyKeeper(
-                this.salter!,
-                kargs['code'],
-                kargs['count'],
-                kargs['icodes'],
+                this.salter,
+                undefined,
+                undefined,
+                undefined,
                 pre.transferable,
-                kargs['ncode'],
-                kargs['ncount'],
-                kargs['ncodes'],
-                kargs['dcode'],
+                undefined,
+                undefined,
+                [],
+                undefined,
                 kargs['prxs'],
                 kargs['nxts']
             );
-        } else if (Algos.group in aid) {
+        } else if (aid[Algos.group]) {
             const kargs = aid[Algos.group];
             return new GroupKeeper(
                 this,
                 kargs['mhab'],
-                kargs['states'],
-                kargs['rstates'],
+                undefined,
+                undefined,
                 kargs['keys'],
                 kargs['ndigs']
             );
-        } else if (Algos.extern in aid) {
-            const kargs = aid[Algos.randy];
+        } else if (aid[Algos.extern]) {
+            const kargs = aid[Algos.extern];
             const typ = kargs.extern_type;
             if (typ in this.modules) {
                 const mod = new this.modules[typ](kargs['pidx'], kargs);
@@ -150,7 +203,7 @@ export class KeyManager {
     }
 }
 
-export class SaltyKeeper {
+export class SaltyKeeper implements Keeper {
     private aeid: string;
     private encrypter: Encrypter;
     private decrypter: Decrypter;
@@ -179,7 +232,7 @@ export class SaltyKeeper {
         kidx: number = 0,
         tier = Tier.low,
         transferable = false,
-        stem = undefined,
+        stem: string | undefined = undefined,
         code = MtrDex.Ed25519_Seed,
         count = 1,
         icodes: string[] | undefined = undefined,
@@ -188,7 +241,7 @@ export class SaltyKeeper {
         ncodes: string[] | undefined = undefined,
         dcode = MtrDex.Blake3_256,
         bran: string | undefined = undefined,
-        sxlt = undefined
+        sxlt: string | undefined = undefined
     ) {
         // # Salter is the entered passcode and used for enc/dec of salts for each AID
         this.salter = salter;
@@ -228,7 +281,7 @@ export class SaltyKeeper {
             const ciph = new Cipher({ qb64: this.sxlt });
             this.creator = new SaltyCreator(
                 this.decrypter.decrypt(null, ciph).qb64,
-                (tier = tier),
+                tier,
                 this.stem
             );
         }
@@ -245,9 +298,7 @@ export class SaltyKeeper {
         ).signers;
     }
 
-    params() {
-        // Get AID parameters to store externally
-
+    params(): SaltyParams {
         return {
             sxlt: this.sxlt,
             pidx: this.pidx,
@@ -261,16 +312,7 @@ export class SaltyKeeper {
         };
     }
 
-    incept(transferable: boolean) {
-        // Create verfers and digers for inception event for AID represented by this Keeper
-
-        // Args:
-        //     transferable (bool): True if the AID for this keeper can establish new keys
-
-        // Returns:
-        //     verfers(list): qualified base64 of signing public keys
-        //     digers(list): qualified base64 of hash of rotation public keys
-
+    async incept(transferable: boolean): Promise<KeeperResult> {
         this.transferable = transferable;
         this.kidx = 0;
 
@@ -304,17 +346,10 @@ export class SaltyKeeper {
         return [verfers, digers];
     }
 
-    rotate(ncodes: string[], transferable: boolean, ..._: any[]) {
-        // Rotate and return verfers and digers for next rotation event for AID represented by this Keeper
-
-        // Args:
-        //     ncodes (list):
-        //     transferable (bool): derivation codes for rotation key creation
-
-        // Returns:
-        //     verfers(list): qualified base64 of signing public keys
-        //     digers(list): qualified base64 of hash of rotation public keys
-
+    async rotate(
+        ncodes: string[],
+        transferable: boolean
+    ): Promise<[string[], string[]]> {
         this.ncodes = ncodes;
         this.transferable = transferable;
         const signers = this.creator.create(
@@ -348,12 +383,12 @@ export class SaltyKeeper {
         return [verfers, digers];
     }
 
-    sign(
+    async sign(
         ser: Uint8Array,
         indexed = true,
         indices: number[] | undefined = undefined,
         ondices: number[] | undefined = undefined
-    ) {
+    ): Promise<SignResult> {
         const signers = this.creator.create(
             this.icodes,
             this.ncount,
@@ -402,7 +437,7 @@ export class SaltyKeeper {
             return sigers.map((siger) => siger.qb64);
         } else {
             const cigars = [];
-            for (const [_, signer] of signers.signers.entries()) {
+            for (const [, signer] of signers.signers.entries()) {
                 cigars.push(signer.sign(ser));
             }
             return cigars.map((cigar) => cigar.qb64);
@@ -410,7 +445,7 @@ export class SaltyKeeper {
     }
 }
 
-export class RandyKeeper {
+export class RandyKeeper implements Keeper {
     private salter: Salter;
     private code: string;
     private count: number;
@@ -480,7 +515,7 @@ export class RandyKeeper {
         );
     }
 
-    params() {
+    params(): RandyParams {
         return {
             nxts: this.nxts,
             prxs: this.prxs,
@@ -488,7 +523,7 @@ export class RandyKeeper {
         };
     }
 
-    incept(transferable: boolean) {
+    async incept(transferable: boolean): Promise<KeeperResult> {
         this.transferable = transferable;
 
         const signers = this.creator.create(
@@ -522,7 +557,10 @@ export class RandyKeeper {
         return [verfers, digers];
     }
 
-    rotate(ncodes: string[], transferable: boolean, ..._: any[]) {
+    async rotate(
+        ncodes: string[],
+        transferable: boolean
+    ): Promise<KeeperResult> {
         this.ncodes = ncodes;
         this.transferable = transferable;
         this.prxs = this.nxts;
@@ -554,12 +592,12 @@ export class RandyKeeper {
         return [verfers, digers];
     }
 
-    sign(
+    async sign(
         ser: Uint8Array,
         indexed = true,
         indices: number[] | undefined = undefined,
         ondices: number[] | undefined = undefined
-    ) {
+    ): Promise<SignResult> {
         const signers = this.prxs!.map((prx) =>
             this.decrypter.decrypt(
                 new Cipher({ qb64: prx }).qb64b,
@@ -605,28 +643,29 @@ export class RandyKeeper {
             return sigers.map((siger) => siger.qb64);
         } else {
             const cigars = [];
-            for (const [_, signer] of signers.entries()) {
+            for (const [, signer] of signers.entries()) {
                 cigars.push(signer.sign(ser));
             }
             return cigars.map((cigar) => cigar.qb64);
         }
     }
 }
-export class GroupKeeper {
+
+export class GroupKeeper implements Keeper {
     private manager: KeyManager;
-    private mhab: any;
-    private gkeys: string[] | undefined;
-    private gdigs: string[] | undefined;
+    private mhab: HabState;
+    private gkeys: string[] = [];
+    private gdigs: string[] = [];
     public algo: Algos = Algos.group;
     public signers: Signer[];
 
     constructor(
         manager: KeyManager,
-        mhab = undefined,
-        states: any[] | undefined = undefined,
-        rstates: any[] | undefined = undefined,
-        keys: any[] | undefined = undefined,
-        ndigs: any[] | undefined = undefined
+        mhab: HabState,
+        states: State[] | undefined = undefined,
+        rstates: State[] | undefined = undefined,
+        keys: string[] = [],
+        ndigs: string[] = []
     ) {
         this.manager = manager;
         if (states != undefined) {
@@ -637,33 +676,32 @@ export class GroupKeeper {
             ndigs = rstates.map((state) => state['n'][0]);
         }
 
-        this.gkeys = keys;
-        this.gdigs = ndigs;
+        this.gkeys = states?.map((state) => state['k'][0]) ?? keys;
+        this.gdigs = rstates?.map((state) => state['n'][0]) ?? ndigs;
         this.mhab = mhab;
         this.signers = [];
     }
-    incept(..._: any) {
+
+    async incept(): Promise<KeeperResult> {
         return [this.gkeys, this.gdigs];
     }
 
-    rotate(
+    async rotate(
         _ncodes: string[],
         _transferable: boolean,
-        states: any[],
-        rstates: any[],
-        ..._: any
-    ) {
+        states: State[],
+        rstates: State[]
+    ): Promise<KeeperResult> {
         this.gkeys = states.map((state) => state['k'][0]);
         this.gdigs = rstates.map((state) => state['n'][0]);
         return [this.gkeys, this.gdigs];
     }
 
-    async sign(
-        ser: Uint8Array,
-        indexed: boolean = true,
-        _indices: number[] | undefined = undefined,
-        _ondices: number[] | undefined = undefined
-    ): Promise<Siger[] | Cigar[]> {
+    async sign(ser: Uint8Array, indexed: boolean = true): Promise<SignResult> {
+        if (!this.mhab.state) {
+            throw new Error(`No state in mhab`);
+        }
+
         const key = this.mhab['state']['k'][0];
         const ndig = this.mhab['state']['n'][0];
 

--- a/src/keri/core/state.ts
+++ b/src/keri/core/state.ts
@@ -1,0 +1,68 @@
+import { Algos } from './manager';
+import { Tier } from './salter';
+
+export interface State {
+    vn: [number, number];
+    i: string;
+    s: string;
+    p?: string;
+    d: string;
+    f: string;
+    dt: string;
+    et: string;
+    kt: string | string[];
+    k: string[];
+    nt: string | string[];
+    n: string[];
+    bt: string;
+    b: string[];
+    c: string[];
+    ee: EstablishmentState;
+    di?: string;
+}
+
+export interface EstablishmentState {
+    d: string;
+    s: string;
+}
+
+export interface SaltyState {
+    sxlt: string;
+    pidx: number;
+    kidx: number;
+    stem: string;
+    tier: Tier;
+    dcode: string;
+    icodes: string[];
+    ncodes: string[];
+    transferable: boolean;
+}
+
+export interface RandyState {
+    prxs: string[];
+    nxts: string[];
+}
+
+export interface GroupState {
+    mhab: HabState;
+    keys: string[];
+    ndigs: string[];
+}
+
+export interface ExternState {
+    extern_type: string;
+    pidx: number;
+    [key: string]: unknown;
+}
+
+export interface HabState {
+    name: string;
+    prefix: string;
+    transferable: boolean;
+    state: State;
+    windexes: unknown[];
+    [Algos.salty]?: SaltyState;
+    [Algos.randy]?: RandyState;
+    [Algos.group]?: GroupState;
+    [Algos.extern]?: ExternState;
+}

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -366,7 +366,7 @@ describe('Aiding', () => {
                 rstates: [member1.state, member2.state],
             };
 
-            await client.identifiers().rotate(group.alias, args);
+            await client.identifiers().rotate(group.name, args);
             const request = client.getLastMockRequest();
             const body = request.body;
             expect(body).toMatchObject({
@@ -395,7 +395,7 @@ describe('Aiding', () => {
 
             client.fetch.mockResolvedValueOnce(Response.json(group));
             client.fetch.mockResolvedValueOnce(Response.json({}));
-            await client.identifiers().rotate(group.alias, {
+            await client.identifiers().rotate(group.name, {
                 nsith: '1',
                 states: [member1.state, member2.state],
                 rstates: [member1.state, member2.state],

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -7,7 +7,6 @@ import libsodium from 'libsodium-wrappers-sumo';
 import fetchMock from 'jest-fetch-mock';
 import 'whatwg-fetch';
 import {
-    b,
     d,
     Ident,
     Ilks,
@@ -25,24 +24,75 @@ fetchMock.enableMocks();
 const url = 'http://127.0.0.1:3901';
 const boot_url = 'http://127.0.0.1:3903';
 
-const mockConnect =
-    '{"agent":{"vn":[1,0],"i":"EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei",' +
-    '"s":"0","p":"","d":"EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei","f":"0",' +
-    '"dt":"2023-08-19T21:04:57.948863+00:00","et":"dip","kt":"1",' +
-    '"k":["DMZh_y-H5C3cSbZZST-fqnsmdNTReZxIh0t2xSTOJQ8a"],"nt":"1",' +
-    '"n":["EM9M2EQNCBK0MyAhVYBvR98Q0tefpvHgE-lHLs82XgqC"],"bt":"0","b":[],' +
-    '"c":[],"ee":{"s":"0","d":"EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei","br":[],"ba":[]},' +
-    '"di":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose"},"controller":{"state":{"vn":[1,0],' +
-    '"i":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose","s":"0","p":"",' +
-    '"d":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose","f":"0","dt":"2023-08-19T21:04:57.959047+00:00",' +
-    '"et":"icp","kt":"1","k":["DAbWjobbaLqRB94KiAutAHb_qzPpOHm3LURA_ksxetVc"],"nt":"1",' +
-    '"n":["EIFG_uqfr1yN560LoHYHfvPAhxQ5sN6xZZT_E3h7d2tL"],"bt":"0","b":[],"c":[],"ee":{"s":"0",' +
-    '"d":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose","br":[],"ba":[]},"di":""},' +
-    '"ee":{"v":"KERI10JSON00012b_","t":"icp","d":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose",' +
-    '"i":"ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose","s":"0","kt":"1",' +
-    '"k":["DAbWjobbaLqRB94KiAutAHb_qzPpOHm3LURA_ksxetVc"],"nt":"1",' +
-    '"n":["EIFG_uqfr1yN560LoHYHfvPAhxQ5sN6xZZT_E3h7d2tL"],"bt":"0","b":[],"c":[],"a":[]}},"ridx":0,' +
-    '"pidx":0}';
+const mockConnect = {
+    agent: {
+        vn: [1, 0],
+        i: 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei',
+        s: '0',
+        p: '',
+        d: 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei',
+        f: '0',
+        dt: '2023-08-19T21:04:57.948863+00:00',
+        et: 'dip',
+        kt: '1',
+        k: ['DMZh_y-H5C3cSbZZST-fqnsmdNTReZxIh0t2xSTOJQ8a'],
+        nt: '1',
+        n: ['EM9M2EQNCBK0MyAhVYBvR98Q0tefpvHgE-lHLs82XgqC'],
+        bt: '0',
+        b: [],
+        c: [],
+        ee: {
+            s: '0',
+            d: 'EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei',
+            br: [],
+            ba: [],
+        },
+        di: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+    },
+    controller: {
+        state: {
+            vn: [1, 0],
+            i: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+            s: '0',
+            p: '',
+            d: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+            f: '0',
+            dt: '2023-08-19T21:04:57.959047+00:00',
+            et: 'icp',
+            kt: '1',
+            k: ['DAbWjobbaLqRB94KiAutAHb_qzPpOHm3LURA_ksxetVc'],
+            nt: '1',
+            n: ['EIFG_uqfr1yN560LoHYHfvPAhxQ5sN6xZZT_E3h7d2tL'],
+            bt: '0',
+            b: [],
+            c: [],
+            ee: {
+                s: '0',
+                d: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+                br: [],
+                ba: [],
+            },
+            di: '',
+        },
+        ee: {
+            v: 'KERI10JSON00012b_',
+            t: 'icp',
+            d: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+            i: 'ELI7pg979AdhmvrjDeam2eAO2SR5niCgnjAJXJHtJose',
+            s: '0',
+            kt: '1',
+            k: ['DAbWjobbaLqRB94KiAutAHb_qzPpOHm3LURA_ksxetVc'],
+            nt: '1',
+            n: ['EIFG_uqfr1yN560LoHYHfvPAhxQ5sN6xZZT_E3h7d2tL'],
+            bt: '0',
+            b: [],
+            c: [],
+            a: [],
+        },
+    },
+    ridx: 0,
+    pidx: 0,
+};
 const mockGetAID = {
     name: 'aid1',
     prefix: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
@@ -125,7 +175,10 @@ const mockCredential = {
 
 fetchMock.mockResponse((req) => {
     if (req.url.startsWith(url + '/agent')) {
-        return Promise.resolve({ body: mockConnect, init: { status: 202 } });
+        return Promise.resolve({
+            body: JSON.stringify(mockConnect),
+            init: { status: 202 },
+        });
     } else if (req.url == boot_url + '/boot') {
         return Promise.resolve({ body: '', init: { status: 202 } });
     } else {
@@ -330,7 +383,7 @@ describe('Ipex', () => {
         const ipex = client.ipex();
 
         const holder = 'ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k';
-        const [acdcSaider, acdc] = Saider.saidify(mockCredential.sad);
+        const [, acdc] = Saider.saidify(mockCredential.sad);
 
         // Create iss
         const vs = versify(Ident.KERI, undefined, Serials.JSON, 0);
@@ -344,7 +397,7 @@ describe('Ipex', () => {
             dt: mockCredential.sad.a.dt,
         };
 
-        const [issSaider, iss] = Saider.saidify(_iss);
+        const [, iss] = Saider.saidify(_iss);
         const iserder = new Serder(iss);
         const anc = interact({
             pre: mockCredential.sad.i,

--- a/test/app/registry.test.ts
+++ b/test/app/registry.test.ts
@@ -5,6 +5,7 @@ import 'whatwg-fetch';
 import { Registries } from '../../src/keri/app/credentialing';
 import { Identifier, KeyManager, SaltyKeeper } from '../../src';
 import { strict as assert } from 'assert';
+import { HabState, State } from '../../src/keri/core/state';
 
 describe('registry', () => {
     it('should create a registry', async () => {
@@ -14,12 +15,15 @@ describe('registry', () => {
         const mockedKeyManager = mock(KeyManager);
         const mockedKeeper = mock(SaltyKeeper);
 
-        const hab = { prefix: 'hab prefix', state: { s: 0, d: 'a digest' } };
+        const hab = {
+            prefix: 'hab prefix',
+            state: { s: '0', d: 'a digest' } as State,
+        } as HabState;
 
         when(mockedClient.manager).thenReturn(instance(mockedKeyManager));
         when(mockedKeyManager.get(hab)).thenReturn(instance(mockedKeeper));
 
-        when(mockedKeeper.sign(anyOfClass(Uint8Array))).thenReturn([
+        when(mockedKeeper.sign(anyOfClass(Uint8Array))).thenResolve([
             'a signature',
         ]);
 
@@ -62,8 +66,11 @@ describe('registry', () => {
 
         const hab = {
             prefix: 'hab prefix',
-            state: { s: 0, d: 'a digest', c: ['EO'] },
-        };
+            state: { s: 0, d: 'a digest', c: ['EO'] } as unknown as State,
+            name: 'a name',
+            transferable: true,
+            windexes: [],
+        } as HabState;
 
         when(mockedIdentifiers.get('a name')).thenResolve(hab);
         when(mockedClient.identifiers()).thenReturn(

--- a/test/app/test-utils.ts
+++ b/test/app/test-utils.ts
@@ -9,12 +9,13 @@ import {
     Versionage,
     incept,
 } from '../../src';
+import { EstablishmentState, HabState, State } from '../../src/keri/core/state';
 
 export async function createMockIdentifierState(
     name: string,
     bran: string,
     kargs: CreateIdentiferArgs = {}
-) {
+): Promise<HabState> {
     const controller = new Controller(bran, Tier.low);
     const manager = new KeyManager(controller.salter);
     const algo = kargs.algo == undefined ? Algos.salty : kargs.algo;
@@ -89,12 +90,14 @@ export async function createMockIdentifierState(
         name: name,
         prefix: serder.pre,
         [algo]: keeper.params(),
+        transferable,
+        windexes: [],
         state: {
             vn: [serder.version.major, serder.version.minor],
             s: serder.ked.s,
             d: serder.ked.d,
             i: serder.pre,
-            ee: serder.ked,
+            ee: serder.ked as EstablishmentState,
             kt: serder.ked.kt,
             k: serder.ked.k,
             nt: serder.ked.nt,
@@ -102,8 +105,11 @@ export async function createMockIdentifierState(
             bt: serder.ked.bt,
             b: serder.ked.b,
             p: serder.ked.p ?? '',
+            f: '',
+            dt: new Date().toISOString().replace('Z', '000+00:00'),
+            et: '',
             c: [],
             di: serder.ked.di ?? '',
-        },
+        } as State,
     };
 }

--- a/test/core/manager.test.ts
+++ b/test/core/manager.test.ts
@@ -19,6 +19,9 @@ import { Diger } from '../../src/keri/core/diger';
 import { Siger } from '../../src/keri/core/siger';
 import { b } from '../../src/keri/core/core';
 import { Cigar } from '../../src/keri/core/cigar';
+import { Keeper, KeeperParams, KeyManager } from '../../src';
+import { State } from '../../src/keri/core/state';
+import { randomUUID } from 'crypto';
 
 describe('RandyCreator', () => {
     it('should create sets of random signers', async () => {
@@ -694,5 +697,109 @@ describe('Manager', () => {
             psigs[0],
             'AACRPqO6vdXm1oSSa82rmVVHikf7NdN4JXjOWEk30Ub5JHChL0bW6DzJfA-7VlgLm_B1XR0Z61FweP87bBQpVawI'
         );
+    });
+
+    describe('External Module ', () => {
+        class MockModule implements jest.Mocked<Keeper> {
+            #params: Record<string, unknown>;
+
+            constructor(
+                public pidx: number,
+                params: KeeperParams
+            ) {
+                this.#params = params;
+            }
+
+            signers: Signer[] = [];
+            sign = jest.fn();
+            algo: Algos = Algos.extern;
+            incept = jest.fn();
+            rotate = jest.fn();
+            params = jest.fn(() => this.#params);
+        }
+
+        it('Should support creating external keeper module', async () => {
+            const passcode = '0123456789abcdefghijk';
+            const salter = new Salter({ raw: b(passcode) });
+
+            const manager = new KeyManager(salter, [
+                { module: MockModule, name: 'mock', type: 'mock' },
+            ]);
+
+            const param = randomUUID();
+            const keeper = manager.new(Algos.extern, 0, {
+                extern_type: 'mock',
+                param,
+            });
+
+            assert(keeper instanceof MockModule);
+            expect(keeper.params()).toMatchObject({ param });
+        });
+
+        it('Should throw if external keeper module is not addede', async () => {
+            const passcode = '0123456789abcdefghijk';
+            const salter = new Salter({ raw: b(passcode) });
+
+            const manager = new KeyManager(salter, []);
+
+            const param = randomUUID();
+            expect(() =>
+                manager.new(Algos.extern, 0, {
+                    extern_type: 'mock',
+                    param,
+                })
+            ).toThrow('unsupported external module type mock');
+        });
+
+        it('Should support getting external keeper module', async () => {
+            const passcode = '0123456789abcdefghijk';
+            const salter = new Salter({ raw: b(passcode) });
+
+            const manager = new KeyManager(salter, [
+                { module: MockModule, name: 'mock', type: 'mock' },
+            ]);
+
+            const param = randomUUID();
+
+            const keeper = manager.get({
+                name: randomUUID(),
+                prefix: '',
+                state: {} as unknown as State,
+                windexes: [],
+                extern: {
+                    extern_type: 'mock',
+                    pidx: 3,
+                    param,
+                },
+                transferable: true,
+            });
+
+            assert(keeper instanceof MockModule);
+            expect(keeper.params()).toMatchObject({ param, pidx: 3 });
+        });
+
+        it('Should throw when trying to get external keeper that is not registered', async () => {
+            const passcode = '0123456789abcdefghijk';
+            const salter = new Salter({ raw: b(passcode) });
+
+            const manager = new KeyManager(salter, []);
+
+            const param = randomUUID();
+
+            expect(() =>
+                manager.get({
+                    name: randomUUID(),
+                    prefix: '',
+                    state: {} as unknown as State,
+                    windexes: [],
+                    extern: {
+                        extern_type: 'mock',
+                        pidx: 3,
+                        param,
+                    },
+                    transferable: true,
+                })
+            ).toThrow('unsupported external module type mock');
+        });
     });
 });


### PR DESCRIPTION
This PR adds type information to keeping.ts module.

When working with signify-ts, I find that this module is the source for a lot of missing type information that makes the library difficult to work with, so I tried to add as much as possible to make the library easier to use and safer to refactor.

I could not find a good place to put the interfaces for the "HabState" types, so they are in a file called "state.ts" at the moment. Please give feedback on the solution and type information.