### PR TITLE
Fix size from bytes instead of string. Need for serder with special characters

### DIFF
--- a/src/keri/core/serder.ts
+++ b/src/keri/core/serder.ts
@@ -153,7 +153,7 @@ export function sizeify(
     }
 
     let raw = dumps(ked, kind);
-    const size = raw.length;
+    const size = new TextEncoder().encode(raw).length;
 
     ked['v'] = versify(ident, version, kind, size);
 

--- a/test/core/serder.test.ts
+++ b/test/core/serder.test.ts
@@ -93,8 +93,8 @@ describe('Serder', () => {
         assert.equal(aid0.qb64, 'ECHOi6qRaswNpvytpCtpvEh2cB2aLAwVHBLFinno3YVW');
 
         const ked1 = ked0;
-        ked1.a = {n: "Lenksjö"}
+        ked1.a = { n: 'Lenksjö' };
         const serder1 = new Serder(ked1);
-        assert.equal(serder1.ked.v,"KERI10JSON000139_");
+        assert.equal(serder1.ked.v, 'KERI10JSON000139_');
     });
 });

--- a/test/core/serder.test.ts
+++ b/test/core/serder.test.ts
@@ -91,5 +91,10 @@ describe('Serder', () => {
 
         aid0 = new Prefixer({ code: MtrDex.Blake3_256 }, ked0);
         assert.equal(aid0.qb64, 'ECHOi6qRaswNpvytpCtpvEh2cB2aLAwVHBLFinno3YVW');
+
+        const ked1 = ked0;
+        ked1.a = {n: "Lenksjö"}
+        const serder1 = new Serder(ked1);
+        assert.equal(serder1.ked.v,"KERI10JSON000139_");
     });
 });


### PR DESCRIPTION
This PR fix KERIA issue https://github.com/WebOfTrust/keria/issues/201

The `sizeify` method in `Serder` class was computing the size base in the stringifyed json,  but it should be from the bytes, so the version string was created with the wrong size preventing to pass the validation in `keripy`