### PR TITLE
add workflow for publishing npm package

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,11 @@ on:
   push:
     branches:
       - 'main'
+      - 'development'
   pull_request:
     branches:
       - 'main'
+      - 'development'
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,61 @@
+name: Publish NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        type: boolean
+        default: true
+        description: Dry run publish
+      dist-tag:
+        type: choice
+        options:
+          - dev
+          - latest
+        default: dev
+        description: Npm dist tag
+jobs:
+  publish:
+    name: Publish NPM
+    permissions:
+        contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Set package name from vars
+        if: ${{ vars.NPM_PACKAGE_NAME }}
+        run: |
+          cat package.json | jq -r '.name = "${{ vars.NPM_PACKAGE_NAME }}"' > package.json.tmp
+          mv package.json.tmp package.json
+
+      - name: Set version from commit
+        if: ${{ inputs.dist-tag == 'dev' }}
+        run: |
+          npm version --no-git-tag-version $(cat package.json | jq .version -r)-dev.$(git rev-parse --short HEAD)
+
+      - name: Create git tag
+        run: git tag $(cat package.json | jq .version -r)
+
+      - name: Publish dev package (Dry run)
+        if: ${{ inputs.dry-run == true }}
+        run: npm publish --tag "${{ inputs.dist-tag }}" --dry-run
+
+      - name: Publish dev package
+        if: ${{ inputs.dry-run == false }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+            npm publish --tag "${{ inputs.dist-tag }}"
+            git tag v$(cat package.json | jq .version -r)
+            git push origin  v$(cat package.json | jq .version -r)

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "start": "npm run build:esm -- --watch",


### PR DESCRIPTION
This is a suggestion of an automated workflow for publishing npm packages.

Process for publishing the development tags would be:

1. Create a PR for the next intended npm package version `x.y.z`
   - Most often this would the next minor release for new features. While we are still on v0, we also include breaking changes here. Once we hit v1, we will have a more strict process for how to bump version numbers. Perhaps something like this https://www.npmjs.com/package/semantic-release.
1. Once merged, a maintainer can publish next dev-version Actions => Publish NPM => Run workflow
   - ![image](https://github.com/WebOfTrust/signify-ts/assets/5889538/c686070f-6e24-4bd7-83dd-ed4f5bab35d0)
1. The workflow does this
   1. Set the version fo `x.y.z-dev.<commit-sha>`
   2. Publish the npm package to npm registry
   3. Creates a git tag `vx.y.z-dev.<commit-sha>`
   4. Push git tag

If this works well, we can trigger this workflow to run on push to main for a completely automated publishing flow.

Once the next release is ready you change the `npm dist tag` input to `latest`. Then the workflow does

1. Publish the npm package with version `x.y.z` to npm registry
2. Creates a git tag `x.y.z`
3. Push git tag

This can then also be easily extended to utilize https://cli.github.com/manual/gh_release_create for automatic github release creation with changelog.

# Usage

If consumers of the library want to install the lastest dev version they would do:

```
npm i --save signify-ts@dev
```

They can also explicitly install the version from a commit using

```
npm i --save signify-ts@vx.y.z-dev.<commit-sha>
```

To install the latest released version they would continue to use

```
npm i --save signify-ts@latest
```

Or simply use a version number


```
npm i --save signify-ts@x.y.z
```

As long as they use a lock file, the version that they have installed in their project will not change unless they explicitly want to upgrade.

# Discussion

In order to make this work, someone with push access to the npm package `signify-ts` needs to generate a publishing token and store in github secrets. These secrets are not accessible from forks.

This would make it easier for consumers of this package to install and test the latest versions of the package without having to reference the repository and pull all devDependencies. It would also make it easier for maintainers to publish the packages.