### PR TITLE
fix: do not include src files in npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   "types": "./dist/index.d.ts",
   "type": "module",
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "scripts": {
     "start": "npm run build:esm -- --watch",


### PR DESCRIPTION
The "src" directory is not supposed to be included in the published npm package. I also verified that this works when installing from a git repository.

Broken out from #260 as this change is unrelated and should land regardless in my opinion.