### PR TITLE
fix: remove development from workflow triggers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - 'main'
-      - 'development'
   pull_request:
     branches:
       - 'main'
-      - 'development'
   workflow_dispatch:
 jobs:
   build:


### PR DESCRIPTION
Removing the development branch from the workflow triggers as we do not use that branch anymore.