### PR TITLE
fix: export hab state types from main export

### DIFF
--- a/examples/integration-scripts/multisig-vlei-issuance.test.ts
+++ b/examples/integration-scripts/multisig-vlei-issuance.test.ts
@@ -9,6 +9,7 @@ import signify, {
     EventResult,
     randomNonce,
     Salter,
+    HabState,
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env';
 import {
@@ -17,7 +18,6 @@ import {
     waitForNotifications,
 } from './utils/test-util';
 import { getOrCreateClients, getOrCreateContact } from './utils/test-setup';
-import { HabState } from '../../src/keri/core/state';
 
 const { vleiServerUrl, witnessIds } = resolveEnvironment();
 

--- a/examples/integration-scripts/utils/test-setup.ts
+++ b/examples/integration-scripts/utils/test-setup.ts
@@ -77,7 +77,7 @@ export async function getOrCreateIdentifier(
     name: string,
     kargs: CreateIdentiferArgs | undefined = undefined
 ): Promise<[string, string]> {
-    let id: any = undefined;
+    let id: string = undefined;
     try {
         const identfier = await client.identifiers().get(name);
         // console.log("identifiers.get", identfier);

--- a/examples/integration-scripts/utils/test-setup.ts
+++ b/examples/integration-scripts/utils/test-setup.ts
@@ -77,7 +77,7 @@ export async function getOrCreateIdentifier(
     name: string,
     kargs: CreateIdentiferArgs | undefined = undefined
 ): Promise<[string, string]> {
-    let id: string = undefined;
+    let id: string;
     try {
         const identfier = await client.identifiers().get(name);
         // console.log("identifiers.get", identfier);
@@ -96,13 +96,16 @@ export async function getOrCreateIdentifier(
         // console.log("identifiers.create", op);
         id = op.response.i;
     }
-    const eid = client.agent?.pre!;
+    const eid = client.agent?.pre;
+    if (!eid) {
+        throw new Error('No agent on client');
+    }
     if (!(await hasEndRole(client, name, 'agent', eid))) {
         const result: EventResult = await client
             .identifiers()
             .addEndRole(name, 'agent', eid);
-        let op = await result.op();
-        op = await waitOperation(client, op);
+        const op = await result.op();
+        await waitOperation(client, op);
         // console.log("identifiers.addEndRole", op);
     }
     const oobi = await client.oobis().get(name, 'agent');

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -39,5 +39,6 @@ export * from './keri/core/signer';
 export * from './keri/core/tholder';
 export * from './keri/core/utils';
 export * from './keri/core/verfer';
+export * from './keri/core/state';
 
 export * from './keri/end/ending';


### PR DESCRIPTION
I have noticed it is inconvenient that the types returned from "identifiers().get()" is not exported by the package. This PR fixes that.