### PR TITLE
fix: delete contact by prefix

### DIFF
--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -74,7 +74,7 @@ export class Contacts {
      * Delete a contact
      * @async
      * @param {string} pre Prefix of the contact
-     * @returns {Promise<any>} A promise to the result of the deletion
+     * @returns {Promise<void>}
      */
     async delete(pre: string): Promise<void> {
         const path = `/contacts/` + pre;

--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -76,12 +76,11 @@ export class Contacts {
      * @param {string} pre Prefix of the contact
      * @returns {Promise<any>} A promise to the result of the deletion
      */
-    async delete(pre: string): Promise<any> {
+    async delete(pre: string): Promise<void> {
         const path = `/contacts/` + pre;
         const method = 'DELETE';
 
-        const res = await this.client.fetch(path, method, null);
-        return await res.json();
+        await this.client.fetch(path, method, null);
     }
 
     /**


### PR DESCRIPTION
The [endpoint on KERIA](https://github.com/WebOfTrust/keria/blob/a1a9b02ceda45fb83885f8ad97cc8de78cb96e45/src/keria/app/aiding.py#L1526) doesn't return a JSON response, so deleting via contact is throwing an error:
```
SyntaxError: Unexpected end of JSON input
  at JSON.parse (<anonymous>)
```

I can add integration tests to cover contacts if we think it's worthwhile but I'd need to find time.