### PR TITLE
Fix non-transferable prefix

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -135,10 +135,10 @@ export class Identifier {
 
         const transferable = kargs.transferable ?? true;
         const isith = kargs.isith ?? '1';
-        const nsith = kargs.nsith ?? '1';
+        let nsith = kargs.nsith ?? '1';
         let wits = kargs.wits ?? [];
         const toad = kargs.toad ?? 0;
-        const dcode = kargs.dcode ?? MtrDex.Blake3_256;
+        let dcode = kargs.dcode ?? MtrDex.Blake3_256;
         const proxy = kargs.proxy;
         const delpre = kargs.delpre;
         const data = kargs.data != undefined ? [kargs.data] : [];
@@ -152,10 +152,16 @@ export class Identifier {
         const _ndigs = kargs.ndigs;
         const bran = kargs.bran;
         const count = kargs.count;
-        const ncount = kargs.ncount;
+        let ncount = kargs.ncount;
         const tier = kargs.tier;
         const extern_type = kargs.extern_type;
         const extern = kargs.extern;
+
+        if (!transferable) {
+            ncount = 0;
+            nsith = 0;
+            dcode = MtrDex.Ed25519N;
+        }
 
         const xargs = {
             transferable: transferable,

--- a/src/keri/core/prefixer.ts
+++ b/src/keri/core/prefixer.ts
@@ -88,7 +88,7 @@ export class Prefixer extends Matter {
             throw new Error(`Error extracting public key = ${e}`);
         }
 
-        if (!(verfer.code in [MtrDex.Ed25519N])) {
+        if (verfer.code != MtrDex.Ed25519N) {
             throw new Error(`Mismatch derivation code = ${verfer.code}`);
         }
 

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -101,12 +101,10 @@ describe('Aiding', () => {
 
     it('Can create non-transferable salty identifiers', async () => {
         client.fetch.mockResolvedValue(Response.json({}));
-        await client
-            .identifiers()
-            .create('aid1', {
-                bran: '0123456789abcdefghijk',
-                transferable: false,
-            });
+        await client.identifiers().create('aid1', {
+            bran: '0123456789abcdefghijk',
+            transferable: false,
+        });
 
         const lastCall = client.getLastMockRequest();
         assert.equal(lastCall.path, '/identifiers');

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -99,6 +99,47 @@ describe('Aiding', () => {
         assert.deepEqual(lastCall.body.salty.transferable, true);
     });
 
+    it('Can create non-transferable salty identifiers', async () => {
+        client.fetch.mockResolvedValue(Response.json({}));
+        await client
+            .identifiers()
+            .create('aid1', {
+                bran: '0123456789abcdefghijk',
+                transferable: false,
+            });
+
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers');
+        assert.equal(lastCall.method, 'POST');
+        assert.equal(lastCall.body.name, 'aid1');
+        console.log(lastCall.body);
+        assert.deepEqual(lastCall.body.icp, {
+            v: 'KERI10JSON0000fd_',
+            t: 'icp',
+            d: 'EFI3s8I7M6b8iiOFJOqDfjuak9NQJtVx8N2Px_cm2lsN',
+            i: 'BPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9',
+            s: '0',
+            kt: '1',
+            k: ['BPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9'],
+            nt: '0',
+            n: [],
+            bt: '0',
+            b: [],
+            c: [],
+            a: [],
+        });
+        assert.deepEqual(lastCall.body.sigs, [
+            'AAD43ke-FKLzD_eOJuE7-G5jeqjs9iyirE-atbxd4sSvEn-0fRibOWI5jtvlE8b8Dn8_rVRa1BUCyDfmEXzy1uwA',
+        ]);
+        assert.deepEqual(lastCall.body.salty.pidx, 0);
+        assert.deepEqual(lastCall.body.salty.kidx, 0);
+        assert.deepEqual(lastCall.body.salty.stem, 'signify:aid');
+        assert.deepEqual(lastCall.body.salty.tier, 'low');
+        assert.deepEqual(lastCall.body.salty.icodes, ['A']);
+        assert.deepEqual(lastCall.body.salty.dcode, 'B');
+        assert.deepEqual(lastCall.body.salty.transferable, false);
+    });
+
     it('Can get identifiers with special characters in the name', async () => {
         client.fetch.mockResolvedValue(Response.json({}));
         await client.identifiers().get('a name with ñ!');


### PR DESCRIPTION
Non transferible AIDs were created with the prefix as the hash of the `icp` instead of the public key itself.