### PR TITLE
fix npm package warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:integration": "jest examples/integration-scripts/ --runInBand --bail",
     "lint": "npx eslint src test examples/integration-scripts",
     "prepare": "npm run build",
-    "generate-docs": "node_modules/.bin/jsdoc --configure .jsdoc.json --verbose",
+    "generate-docs": "jsdoc --configure .jsdoc.json --verbose",
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."
   },


### PR DESCRIPTION
Npm would spit out these warnings when publishing. I ran `npm pkg fix` to fix it.

```
npm WARN publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm WARN publish errors corrected:
npm WARN publish scripts entry "generate-docs" was fixed to remove node_modules/.bin reference
```