### PR TITLE
fix: send exn to actual recipient only

### DIFF
--- a/examples/integration-scripts/multisig-holder.test.ts
+++ b/examples/integration-scripts/multisig-holder.test.ts
@@ -162,7 +162,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     let recp = [aid2['state']].map((state) => state['i']);
-    let res = await client1
+    await client1
         .exchanges()
         .send(
             'member1',
@@ -182,7 +182,7 @@ test('multisig', async function run() {
     console.log(
         'Member2 received exchange message to join the end role authorization'
     );
-    res = await client2.groups().getRequest(msgSaid);
+    let res = await client2.groups().getRequest(msgSaid);
     let exn = res[0].exn;
     // stamp, eid and role are provided in the exn message
     let rpystamp = exn.e.rpy.dt;
@@ -215,7 +215,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid1['state']].map((state) => state['i']);
-    res = await client2
+    await client2
         .exchanges()
         .send(
             'member2',
@@ -262,7 +262,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid2['state']].map((state) => state['i']);
-    res = await client1
+    await client1
         .exchanges()
         .send(
             'member1',
@@ -316,7 +316,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid1['state']].map((state) => state['i']);
-    res = await client2
+    await client2
         .exchanges()
         .send(
             'member2',

--- a/examples/integration-scripts/multisig.test.ts
+++ b/examples/integration-scripts/multisig.test.ts
@@ -334,7 +334,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
-    res = await client1
+    await client1
         .exchanges()
         .send(
             'member1',
@@ -382,7 +382,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid1['state'], aid3['state']].map((state) => state['i']);
-    res = await client2
+    await client2
         .exchanges()
         .send(
             'member2',
@@ -429,7 +429,7 @@ test('multisig', async function run() {
         rpy: [rpy, atc],
     };
     recp = [aid1['state'], aid2['state']].map((state) => state['i']);
-    res = await client3
+    await client3
         .exchanges()
         .send(
             'member3',
@@ -770,7 +770,7 @@ test('multisig', async function run() {
     };
 
     recp = [aid2['state'], aid3['state']].map((state) => state['i']);
-    res = await client1
+    await client1
         .exchanges()
         .send(
             'member1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -7572,12 +7572,12 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -149,7 +149,7 @@ export class Challenges {
             {},
             [recipient]
         );
-        return resp;
+        return resp[0];  // Only one recipient
     }
 
     /**

--- a/src/keri/app/contacting.ts
+++ b/src/keri/app/contacting.ts
@@ -149,7 +149,7 @@ export class Challenges {
             {},
             [recipient]
         );
-        return resp[0];  // Only one recipient
+        return resp[0]; // Only one recipient
     }
 
     /**

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -93,7 +93,7 @@ export class Exchanges {
                 exn,
                 sigs,
                 atc,
-                recipients
+                [recipient]
             );
         }
     }

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -79,7 +79,8 @@ export class Exchanges {
         embeds: Dict<any>,
         recipients: string[]
     ): Promise<any[]> {
-        return recipients.map(async (recipient) => {
+        const responses: any[] = [];
+        for (const recipient of recipients) {
             const [exn, sigs, atc] = await this.createExchangeMessage(
                 sender,
                 route,
@@ -87,10 +88,11 @@ export class Exchanges {
                 embeds,
                 recipient
             );
-            return this.sendFromEvents(name, topic, exn, sigs, atc, [
+            responses.push(await this.sendFromEvents(name, topic, exn, sigs, atc, [
                 recipient,
-            ]);
-        });
+            ]));
+        };
+        return responses;
     }
 
     /**

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -78,8 +78,8 @@ export class Exchanges {
         payload: Dict<any>,
         embeds: Dict<any>,
         recipients: string[]
-    ): Promise<any> {
-        for (const recipient of recipients) {
+    ): Promise<any[]> {
+        return recipients.map(async (recipient) => {
             const [exn, sigs, atc] = await this.createExchangeMessage(
                 sender,
                 route,
@@ -87,10 +87,10 @@ export class Exchanges {
                 embeds,
                 recipient
             );
-            return await this.sendFromEvents(name, topic, exn, sigs, atc, [
+            return this.sendFromEvents(name, topic, exn, sigs, atc, [
                 recipient,
             ]);
-        }
+        });
     }
 
     /**

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -88,10 +88,12 @@ export class Exchanges {
                 embeds,
                 recipient
             );
-            responses.push(await this.sendFromEvents(name, topic, exn, sigs, atc, [
-                recipient,
-            ]));
-        };
+            responses.push(
+                await this.sendFromEvents(name, topic, exn, sigs, atc, [
+                    recipient,
+                ])
+            );
+        }
         return responses;
     }
 

--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -87,14 +87,9 @@ export class Exchanges {
                 embeds,
                 recipient
             );
-            return await this.sendFromEvents(
-                name,
-                topic,
-                exn,
-                sigs,
-                atc,
-                [recipient]
-            );
+            return await this.sendFromEvents(name, topic, exn, sigs, atc, [
+                recipient,
+            ]);
         }
     }
 


### PR DESCRIPTION
exn messages have a specific recipient (`rp` field).

Right now for multi-sig:
- creates first exn message with `rp` field of first member
- this message is sent to all members
- returns early (bug in itself)

This change will just send the specific message to the specific member, and not return early.