### PR TITLE
Fix salty and randy constructors transferable flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7572,12 +7572,12 @@
       ]
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {

--- a/src/keri/core/keeping.ts
+++ b/src/keri/core/keeping.ts
@@ -245,7 +245,7 @@ export class SaltyKeeper implements Keeper {
     ) {
         // # Salter is the entered passcode and used for enc/dec of salts for each AID
         this.salter = salter;
-        const signer = this.salter.signer(undefined, (transferable = false));
+        const signer = this.salter.signer(code, transferable, undefined, tier);
 
         this.aeid = signer.verfer.qb64;
 
@@ -490,7 +490,7 @@ export class RandyKeeper implements Keeper {
         this.count = count;
         this.ncount = ncount;
 
-        const signer = this.salter.signer(undefined, (transferable = false));
+        const signer = this.salter.signer(code, transferable);
         this.aeid = signer.verfer.qb64;
 
         this.encrypter = new Encrypter({}, b(this.aeid));

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -110,7 +110,6 @@ describe('Aiding', () => {
         assert.equal(lastCall.path, '/identifiers');
         assert.equal(lastCall.method, 'POST');
         assert.equal(lastCall.body.name, 'aid1');
-        console.log(lastCall.body);
         assert.deepEqual(lastCall.body.icp, {
             v: 'KERI10JSON0000fd_',
             t: 'icp',

--- a/test/app/clienting.test.ts
+++ b/test/app/clienting.test.ts
@@ -393,7 +393,7 @@ describe('SignifyClient', () => {
             lastHeaders
                 .get(HEADER_SIG_INPUT)
                 ?.endsWith(
-                    ';keyid="BPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9";alg="ed25519"'
+                    ';keyid="DPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9";alg="ed25519"'
                 ),
             true
         );
@@ -407,7 +407,7 @@ describe('SignifyClient', () => {
             .split(';keyid=')[0];
         const data = `"@method": POST\n"@path": /test\n"signify-resource": ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK\n"signify-timestamp": ${lastHeaders.get(
             HEADER_SIG_TIME
-        )}\n"@signature-params: (@method @path signify-resource signify-timestamp);created=${created};keyid=BPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9;alg=ed25519"`;
+        )}\n"@signature-params: (@method @path signify-resource signify-timestamp);created=${created};keyid=DPmhSfdhCPxr3EqjxzEtF8TVy0YX7ATo0Uc8oo2cnmY9;alg=ed25519"`;
 
         if (data) {
             const raw = new TextEncoder().encode(data);

--- a/test/app/delegating.test.ts
+++ b/test/app/delegating.test.ts
@@ -154,7 +154,7 @@ describe('delegate', () => {
                 icodes: ['A'],
                 ncodes: ['A'],
                 dcode: 'E',
-                transferable: false,
+                transferable: true,
             },
         };
         assert.equal(


### PR DESCRIPTION
This is a fix in the constructors of the class Randy and Salty that were not passing the `transferable` flag correctly to the signer. 