### PR TITLE
chore: enforce the recommended linting rules for some files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -5,17 +5,29 @@
         "prettier"
     ],
     "parser": "@typescript-eslint/parser",
-    "rules": {
-        "prefer-const": "warn",
-        "no-var": "warn",
-        "no-self-assign": "warn",
-        "no-case-declarations": "warn",
-        "no-constant-condition": "warn",
-        "no-empty": "warn",
-        "@typescript-eslint/no-non-null-asserted-optional-chain": "warn",
-        "@typescript-eslint/no-explicit-any": "warn",
-        "@typescript-eslint/no-namespace": "warn",
-        "@typescript-eslint/ban-types": "warn",
-        "@typescript-eslint/no-unused-vars": "warn"
-    }
+    "overrides": [
+        {
+            // These are files with more lenient lint config because they have not been "fixed" yet
+            // Once a directory here is fixed, it should be removed from here so the strict rules applies
+            "files": [
+                "src/keri/app/**",
+                "src/keri/core/**",
+                "src/keri/end/**",
+                "examples/integration-scripts/**"
+            ],
+            "rules": {
+                "prefer-const": "warn",
+                "no-var": "warn",
+                "no-self-assign": "warn",
+                "no-case-declarations": "warn",
+                "no-constant-condition": "warn",
+                "no-empty": "warn",
+                "@typescript-eslint/no-non-null-asserted-optional-chain": "warn",
+                "@typescript-eslint/no-explicit-any": "warn",
+                "@typescript-eslint/no-namespace": "warn",
+                "@typescript-eslint/ban-types": "warn",
+                "@typescript-eslint/no-unused-vars": "warn"
+            }
+        }
+    ]
 }

--- a/test/app/clienting.test.ts
+++ b/test/app/clienting.test.ts
@@ -360,18 +360,18 @@ describe('SignifyClient', () => {
             'EGFi9pCcRaLK8dPh5S7JP9Em62fBMiR1l4gW1ZazuuAO'
         );
 
-        let heads = new Headers();
+        const heads = new Headers();
         heads.set('Content-Type', 'application/json');
-        let treqInit = {
+        const treqInit = {
             headers: heads,
             method: 'POST',
             body: JSON.stringify({ foo: true }),
         };
-        let turl = 'http://example.com/test';
-        let treq = await client.createSignedRequest('aid1', turl, treqInit);
-        let tres = await fetch(treq);
+        const turl = 'http://example.com/test';
+        const treq = await client.createSignedRequest('aid1', turl, treqInit);
+        await fetch(treq);
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
-        let resReq = lastCall[0] as Request;
+        const resReq = lastCall[0] as Request;
         assert.equal(resReq.url, 'http://example.com/test');
         assert.equal(resReq.method, 'POST');
         lastBody = await resReq.json();
@@ -398,7 +398,7 @@ describe('SignifyClient', () => {
             true
         );
 
-        let aid = await client.identifiers().get('aid1');
+        const aid = await client.identifiers().get('aid1');
         const keeper = client.manager!.get(aid);
         const signer = keeper.signers[0];
         const created = lastHeaders

--- a/test/app/credentialing.test.ts
+++ b/test/app/credentialing.test.ts
@@ -548,7 +548,7 @@ describe('Ipex', () => {
         const ipex = client.ipex();
 
         const holder = 'ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k';
-        const [_, acdc] = Saider.saidify(mockCredential.sad);
+        const [, acdc] = Saider.saidify(mockCredential.sad);
 
         // Create iss
         const vs = versify(Ident.KERI, undefined, Serials.JSON, 0);
@@ -562,7 +562,7 @@ describe('Ipex', () => {
             dt: mockCredential.sad.a.dt,
         };
 
-        const [issSaider, iss] = Saider.saidify(_iss);
+        const [, iss] = Saider.saidify(_iss);
         const iserder = new Serder(iss);
         const anc = interact({
             pre: mockCredential.sad.i,
@@ -848,7 +848,7 @@ describe('Ipex', () => {
         const ipex = client.ipex();
 
         const holder = 'ELjSFdrTdCebJlmvbFNX9-TLhR2PO0_60al1kQp5_e6k';
-        const [_, acdc] = Saider.saidify(mockCredential.sad);
+        const [, acdc] = Saider.saidify(mockCredential.sad);
 
         const [offer, offerSigs, offerEnd] = await ipex.offer({
             senderName: 'multisig',
@@ -898,7 +898,7 @@ describe('Ipex', () => {
         await ipex.submitOffer('multisig', offer, offerSigs, offerEnd, [
             holder,
         ]);
-        let lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        const lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         assert.equal(
             lastCall[0],
             'http://127.0.0.1:3901/identifiers/multisig/ipex/offer'

--- a/test/app/delegating.test.ts
+++ b/test/app/delegating.test.ts
@@ -158,7 +158,7 @@ describe('delegate', () => {
             },
         };
         assert.equal(
-            lastCall[1]!.body?.toString()!,
+            lastCall[1]?.body?.toString(),
             JSON.stringify(expectedBody)
         );
     });

--- a/test/app/exchanging.test.ts
+++ b/test/app/exchanging.test.ts
@@ -2,7 +2,6 @@ import { strict as assert } from 'assert';
 import {
     b,
     d,
-    Dict,
     Diger,
     exchange,
     Ilks,
@@ -234,7 +233,7 @@ describe('exchange', () => {
             b: [],
             c: [],
             a: [],
-        } as Dict<any>;
+        };
 
         const serder = new Serder(ked0);
         const siger = skp0.sign(b(serder.raw), 0);
@@ -251,13 +250,13 @@ describe('exchange', () => {
             s: '0',
             bt: toad.toString(16),
             b: [],
-        } as Dict<any>;
+        };
         const vcp = new Serder(ked1);
 
         const embeds = {
             icp: [serder, siger.qb64],
             vcp: [vcp, undefined],
-        } as Dict<any>;
+        };
 
         [exn, end] = exchange(
             '/multisig/vcp',
@@ -373,7 +372,7 @@ describe('exchange', () => {
             b: [],
             c: [],
             a: [],
-        } as Dict<any>;
+        };
 
         const serder = new Serder(ked0);
 

--- a/test/core/counter.test.ts
+++ b/test/core/counter.test.ts
@@ -16,7 +16,7 @@ describe('int to b64 and back', () => {
         });
 
         // verify all Codes have hs > 0 and ss > 0 and fs = hs + ss and not fs % 4
-        Counter.Sizes.forEach((val, _) => {
+        Counter.Sizes.forEach((val) => {
             assert.equal(
                 val.hs > 0 &&
                     val.ss > 0 &&

--- a/test/core/eventing.test.ts
+++ b/test/core/eventing.test.ts
@@ -7,7 +7,6 @@ import { Saider } from '../../src/keri/core/saider';
 import { Diger } from '../../src/keri/core/diger';
 import { b, d, Ilks } from '../../src/keri/core/core';
 import { Siger } from '../../src/keri/core/siger';
-import { randomBytes } from 'crypto';
 
 describe('key event function', () => {
     it('incept should create inception events', async () => {

--- a/test/core/prefixer.test.ts
+++ b/test/core/prefixer.test.ts
@@ -1,6 +1,5 @@
 import libsodium from 'libsodium-wrappers-sumo';
 import {
-    Dict,
     Ident,
     Ilks,
     Serials,
@@ -50,7 +49,7 @@ describe('Prefixer', () => {
             wt: toad.toString(16), // hex string no leading zeros lowercase
             w: wits, // list of qb64 may be empty
             c: cnfg, // list of config ordered mappings may be empty
-        } as Dict<any>;
+        };
 
         prefixer = new Prefixer({ code: MtrDex.Blake3_256 }, ked);
         assert.equal(

--- a/test/core/saider.test.ts
+++ b/test/core/saider.test.ts
@@ -1,10 +1,4 @@
-import {
-    Dict,
-    Ident,
-    Serials,
-    versify,
-    Versionage,
-} from '../../src/keri/core/core';
+import { Ident, Serials, versify, Versionage } from '../../src/keri/core/core';
 import { strict as assert } from 'assert';
 import { MtrDex } from '../../src/keri/core/matter';
 import libsodium from 'libsodium-wrappers-sumo';
@@ -30,8 +24,8 @@ describe('Saider', () => {
                 i: 'EB0_D51cTh_q6uOQ-byFiv5oNXZ-cxdqCqBAa4JmBLtb',
                 name: 'John Jones',
                 role: 'Founder',
-            } as Dict<any>,
-        } as Dict<any>;
+            },
+        };
         const saider = new Saider({}, sad4); // default version string code, kind, and label
         assert.equal(saider.code, code);
         assert.equal(

--- a/test/core/serder.test.ts
+++ b/test/core/serder.test.ts
@@ -1,10 +1,4 @@
-import {
-    deversify,
-    Dict,
-    Ilks,
-    Serials,
-    Version,
-} from '../../src/keri/core/core';
+import { deversify, Ilks, Serials, Version } from '../../src/keri/core/core';
 import { strict as assert } from 'assert';
 import { Salter, Tier } from '../../src/keri/core/salter';
 import { MtrDex } from '../../src/keri/core/matter';
@@ -72,7 +66,7 @@ describe('Serder', () => {
             b: [],
             c: [],
             a: [],
-        } as Dict<any>;
+        };
 
         const serder = new Serder(ked0);
         assert.equal(
@@ -92,9 +86,12 @@ describe('Serder', () => {
         aid0 = new Prefixer({ code: MtrDex.Blake3_256 }, ked0);
         assert.equal(aid0.qb64, 'ECHOi6qRaswNpvytpCtpvEh2cB2aLAwVHBLFinno3YVW');
 
-        const ked1 = ked0;
-        ked1.a = { n: 'Lenksjö' };
-        const serder1 = new Serder(ked1);
+        const serder1 = new Serder({
+            ...ked0,
+            a: {
+                n: 'Lenksjö',
+            },
+        });
         assert.equal(serder1.ked.v, 'KERI10JSON000139_');
     });
 });


### PR DESCRIPTION
I thought we should make an effort to remove the relaxed linting rules. This is an initial effort to work towards enforcing the recommended linting rules for all files.

The changes to the lint config explicitly specifies the files that should have relaxed rules. The idea is that this list should eventually be removed once the entire codebase conforms to the rules.

In this PR I have only fixed some low hanging fruit in the test directory. If people think it is a good idea to enforce the rules I can do it for the rest. I would do it in my spare time so it might take a few weeks to do the overhaul.

In the long term, I think we will benefit greatly by getting rid of all the `any` types in the code base. Strict types will make it much easier to catch type errors and also improve the discoverability of the library.