### PR TITLE
chore: implement typings in ending module

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,6 @@
             "files": [
                 "src/keri/app/**",
                 "src/keri/core/**",
-                "src/keri/end/**",
                 "examples/integration-scripts/**"
             ],
             "rules": {

--- a/src/keri/core/authing.ts
+++ b/src/keri/core/authing.ts
@@ -77,8 +77,9 @@ export class Authenticater {
             items.push(`"@signature-params: ${params}"`);
             const ser = items.join('\n');
             const signage = designature(signature!);
-            const cig = signage[0].markers.get(input.name);
-            if (!this._verfer.verify(cig.raw, ser)) {
+            const markers = signage[0].markers as Map<string, Siger | Cigar>;
+            const cig = markers.get(input.name);
+            if (!cig || !this._verfer.verify(cig.raw, ser)) {
                 throw new Error(`Signature for ${input.keyid} invalid.`);
             }
         });

--- a/test/core/authing.test.ts
+++ b/test/core/authing.test.ts
@@ -20,11 +20,19 @@ describe('Authenticater.verify', () => {
             ['Content-Type', 'application/json'],
             [
                 'Signature',
-                'indexed="?0";signify="0BDLh8QCytVBx1YMam4Vt8s4b9HAW1dwfE4yU5H_w1V6gUvPBoVGWQlIMdC16T3WFWHDHCbMcuceQzrr6n9OULsK"',
+                [
+                    'indexed="?0"',
+                    'signify="0BDLh8QCytVBx1YMam4Vt8s4b9HAW1dwfE4yU5H_w1V6gUvPBoVGWQlIMdC16T3WFWHDHCbMcuceQzrr6n9OULsK"',
+                ].join(';'),
             ],
             [
                 'Signature-Input',
-                'signify=("signify-resource" "@method" "@path" "signify-timestamp");created=1684715820;keyid="EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei";alg="ed25519"',
+                [
+                    'signify=("signify-resource" "@method" "@path" "signify-timestamp")',
+                    'created=1684715820',
+                    'keyid="EEXekkGu9IAzav6pZVJhkLnjtjM5v3AcyA-pdKUcaGei"',
+                    'alg="ed25519"',
+                ].join(';'),
             ],
             [
                 'Signify-Resource',
@@ -52,7 +60,7 @@ describe('Authenticater.sign', () => {
         const aaid = 'DDK2N5_fVCWIEO9d8JLhk7hKrkft6MbtkUhaHQsmABHY';
         const verfer = new Verfer({ qb64: aaid });
 
-        let headers = new Headers([
+        const headers = new Headers([
             ['Content-Type', 'application/json'],
             ['Content-Length', '256'],
             ['Connection', 'close'],
@@ -67,17 +75,23 @@ describe('Authenticater.sign', () => {
         );
 
         const authn = new Authenticater(signer, verfer);
-        headers = authn.sign(headers, 'POST', '/boot');
+        const result = authn.sign(headers, 'POST', '/boot');
 
-        assert.equal(headers.has('Signature-Input'), true);
-        assert.equal(headers.has('Signature'), true);
-        assert.equal(
-            headers.get('Signature-Input'),
-            'signify=("@method" "@path" "signify-resource" "signify-timestamp");created=1609459200;keyid="DN54yRad_BTqgZYUSi_NthRBQrxSnqQdJXWI5UHcGOQt";alg="ed25519"'
-        );
-        assert.equal(
-            headers.get('Signature'),
-            'indexed="?0";signify="0BChvN_BWAf-mgEuTnWfNnktgHdWOuOh9cWc4o0GFWuZOwra3DyJT5dJ_6BX7AANDOTnIlAKh5Sg_9qGQXHjj5oJ"'
-        );
+        assert.equal(result.has('Signature-Input'), true);
+        assert.equal(result.has('Signature'), true);
+
+        const expectedSignatureInput = [
+            'signify=("@method" "@path" "signify-resource" "signify-timestamp")',
+            'created=1609459200',
+            'keyid="DN54yRad_BTqgZYUSi_NthRBQrxSnqQdJXWI5UHcGOQt"',
+            'alg="ed25519"',
+        ].join(';');
+        assert.equal(result.get('Signature-Input'), expectedSignatureInput);
+
+        const expectedSignature = [
+            'indexed="?0"',
+            'signify="0BChvN_BWAf-mgEuTnWfNnktgHdWOuOh9cWc4o0GFWuZOwra3DyJT5dJ_6BX7AANDOTnIlAKh5Sg_9qGQXHjj5oJ"',
+        ].join(';');
+        assert.equal(result.get('Signature'), expectedSignature);
     });
 });

--- a/test/end/ending.test.ts
+++ b/test/end/ending.test.ts
@@ -6,151 +6,251 @@ import { MtrDex } from '../../src/keri/core/matter';
 import { designature, Signage, signature } from '../../src/keri/end/ending';
 import { Siger } from '../../src/keri/core/siger';
 import { Cigar } from '../../src/keri/core/cigar';
+import { Signer } from '../../src/keri/core/signer';
 
-describe('ending_signature_designature', () => {
-    it('should create and parse signature headers', async () => {
-        await libsodium.ready;
+function createSigner(name: string): Signer {
+    const temp = true;
 
-        const name = 'Hilga';
-        const temp = true;
+    const salter = new Salter({ raw: b('0123456789abcdef') });
+    const signer0 = salter.signer(
+        MtrDex.Ed25519_Seed,
+        true,
+        name,
+        Tier.low,
+        temp
+    );
 
-        const salter = new Salter({ raw: b('0123456789abcdef') });
-        const signer0 = salter.signer(
-            MtrDex.Ed25519_Seed,
-            true,
-            `${name}00`,
-            Tier.low,
-            temp
-        );
-        const signer1 = salter.signer(
-            MtrDex.Ed25519_Seed,
-            true,
-            `${name}01`,
-            Tier.low,
-            temp
-        );
-        const signer2 = salter.signer(
-            MtrDex.Ed25519_Seed,
-            true,
-            `${name}02`,
-            Tier.low,
-            temp
-        );
-        const signers = [signer0, signer1, signer2];
+    return signer0;
+}
 
-        const text = b(
-            '{"seid":"BA89hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68","name":"wit0","dts":"2021-01-01T00' +
-                ':00:00.000000+00:00","scheme":"http","host":"localhost","port":8080,"path":"/witness"}'
-        );
+let sigers: Siger[];
+let cigars: Cigar[];
+let text: Uint8Array;
+let pre: string;
+let digest: string;
 
-        const sigers = Array.from(signers, (signer, idx) =>
-            signer.sign(text, idx)
-        );
-        const pre = 'EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-'; // Hab.pre from KERIpy test
-        const digest = pre;
+beforeAll(async () => {
+    await libsodium.ready;
 
-        let signage = new Signage(sigers);
-        let header = signature([signage]);
+    const name = 'Hilga';
+    const signer0 = createSigner(`${name}00`);
+    const signer1 = createSigner(`${name}01`);
+    const signer2 = createSigner(`${name}02`);
+    const signers = [signer0, signer1, signer2];
+    text = b(
+        JSON.stringify({
+            seid: 'BA89hKezugU2LFKiFVbitoHAxXqJh6HQ8Rn9tH7fxd68',
+            name: 'wit0',
+            dts: '2021-01-01T00:00:00.000000+00:00',
+            scheme: 'http',
+            host: 'localhost',
+            port: 8080,
+            path: '/witness',
+        })
+    );
+    sigers = signers.map((signer, idx) => signer.sign(text, idx) as Siger);
+    cigars = signers.map((s) => s.sign(text) as Cigar);
+    pre = 'EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-'; // Hab.pre from KERIpy test
+    digest = pre;
+});
+
+describe('When indexed signatures', () => {
+    const expectedHeader = [
+        'indexed="?1"',
+        '0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        '1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        '2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"',
+    ].join(';');
+
+    it('Can create signature header', async () => {
+        const signage = new Signage(sigers);
+        const header = signature([signage]);
         assert.equal(header.has('Signature'), true);
-        assert.equal(
-            header.get('Signature'),
-            'indexed="?1";0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN";1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA";2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"'
-        );
+        assert.equal(header.get('Signature'), expectedHeader);
+    });
 
-        let signages = designature(header.get('Signature')!);
+    it('Can parse signature header', async () => {
+        const signages = designature(expectedHeader);
         assert.equal(signages.length, 1);
-        signage = signages[0];
+        const signage = signages[0];
+
+        assert(signage.markers instanceof Map);
         assert.equal(signage.markers.size, 3);
-        signage.markers.forEach((item: string | Siger | Cigar, tag: string) => {
-            const marker = item as Siger;
+        signage.markers.forEach((marker, tag) => {
+            assert(marker instanceof Siger);
             const idx = parseInt(tag);
-            const siger = sigers[idx] as Siger;
+            const siger = sigers[idx];
             assert.equal(marker.qb64, siger.qb64);
             assert.equal(parseInt(tag), siger.index);
         });
+    });
+});
 
-        signage = new Signage(sigers, true, pre, '0', digest, 'CESR');
-        header = signature([signage]);
-        assert.equal(header.has('Signature'), true);
-        assert.equal(
-            header.get('Signature'),
-            'indexed="?1";signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-";ordinal="0";digest="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-";kind="CESR";0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN";1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA";2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"'
+describe('When named signatures', () => {
+    const expectedHeader = [
+        'indexed="?1"',
+        'siger0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        'siger1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        'siger2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"',
+    ].join(';');
+
+    let markers: Map<string, Siger>;
+
+    beforeEach(() => {
+        markers = new Map<string, Siger>(
+            sigers.map((s, idx) => [`siger${idx}`, s])
         );
+    });
 
-        signages = designature(header.get('Signature')!);
+    it('Can create signature header', async () => {
+        const signage = new Signage(markers);
+        const header = signature([signage]);
+        assert.equal(header.has('Signature'), true);
+        assert.equal(header.get('Signature'), expectedHeader);
+    });
+
+    it('Can parse signature header', async () => {
+        const signages = designature(expectedHeader);
         assert.equal(signages.length, 1);
-        signage = signages[0];
+        const signage = signages[0];
+
+        assert(signage.markers instanceof Map);
+        assert.equal(signage.markers.size, 3);
+        signage.markers.forEach((marker, tag) => {
+            const siger = markers.get(tag);
+
+            assert(marker instanceof Siger);
+            assert(siger);
+            assert.equal(marker.qb64, siger.qb64);
+        });
+    });
+});
+
+describe('When indexed CESR signatures', () => {
+    const expectedHeader = [
+        'indexed="?1"',
+        'signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-"',
+        'ordinal="0"',
+        'digest="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-"',
+        'kind="CESR"',
+        '0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        '1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        '2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"',
+    ].join(';');
+
+    it('Should create headers', async () => {
+        const signage = new Signage(sigers, true, pre, '0', digest, 'CESR');
+        const headers = signature([signage]);
+        assert.equal(headers.has('Signature'), true);
+        assert.equal(headers.get('Signature'), expectedHeader);
+    });
+
+    it('Should parse headers', async () => {
+        const signages = designature(expectedHeader);
+        assert.equal(signages.length, 1);
+        const signage = signages[0];
         assert.equal(signage.indexed, true);
         assert.equal(signage.signer, pre);
         assert.equal(signage.digest, digest);
         assert.equal(signage.kind, 'CESR');
 
+        assert(signage.markers instanceof Map);
         assert.equal(signage.markers.size, 3);
-        signage.markers.forEach((item: string | Siger | Cigar, tag: string) => {
-            const marker = item as Siger;
+        signage.markers.forEach((marker, tag) => {
+            assert(marker instanceof Siger);
             const idx = parseInt(tag);
-            const siger = sigers[idx] as Siger;
+            const siger = sigers[idx];
             assert.equal(marker.qb64, siger.qb64);
             assert.equal(parseInt(tag), siger.index);
         });
+    });
+});
 
-        const cigars = Array.from(signers, (signer) => signer.sign(text));
-        signage = new Signage(cigars);
-        header = signature([signage]);
+describe('When non-indexed signatures', () => {
+    const expectedHeader = [
+        'indexed="?0"',
+        'DAi2TaRNVtGmV8eSUvqHIBzTzIgrQi57vKzw5Svmy7jw="0BCsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        'DNK2KFnL0jUGlmvZHRse7HwNGVdtkM-ORvTZfFw7mDbt="0BDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        'DDvIoIYqeuXJ4Zb8e2luWfjPTg4FeIzfHzIO8lC56WjD="0BDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"',
+    ].join(';');
+
+    it('Should create headers', () => {
+        const signage = new Signage(cigars);
+        const header = signature([signage]);
         assert.equal(header.has('Signature'), true);
-        assert.equal(
-            header.get('Signature'),
-            'indexed="?0";DAi2TaRNVtGmV8eSUvqHIBzTzIgrQi57vKzw5Svmy7jw="0BCsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN";DNK2KFnL0jUGlmvZHRse7HwNGVdtkM-ORvTZfFw7mDbt="0BDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA";DDvIoIYqeuXJ4Zb8e2luWfjPTg4FeIzfHzIO8lC56WjD="0BDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"'
-        );
-        signages = designature(header.get('Signature')!);
+        assert.equal(header.get('Signature'), expectedHeader);
+    });
+
+    it('Should parse headers', () => {
+        const signages = designature(expectedHeader);
         assert.equal(signages.length, 1);
-        signage = signages[0];
+        const signage = signages[0];
         assert.equal(signage.indexed, false);
+        assert(signage.markers instanceof Map);
         assert.equal(signage.markers.size, 3);
-        signage.markers.forEach((marker: Cigar, tag: string) => {
+
+        signage.markers.forEach((marker, tag) => {
+            assert(marker instanceof Cigar);
             const cigar = cigars.find((cigar) => cigar.verfer!.qb64 == tag);
             assert.notEqual(cigar, undefined);
             assert.equal(marker.qb64, cigar!.qb64);
             assert.equal(tag, cigar!.verfer!.qb64);
         });
+    });
+});
 
-        // now combine into one header
-        signages = new Array<Signage>();
-        signages.push(
-            new Signage(sigers, true, pre, undefined, undefined, 'CESR')
-        );
-        signages.push(
-            new Signage(cigars, false, pre, undefined, undefined, 'CESR')
-        );
+describe('Combined headers', () => {
+    const expectedHeader = [
+        'indexed="?1"',
+        'signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-"',
+        'kind="CESR"',
+        '0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        '1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        '2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F",indexed="?0"',
+        'signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-"',
+        'kind="CESR"',
+        'DAi2TaRNVtGmV8eSUvqHIBzTzIgrQi57vKzw5Svmy7jw="0BCsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN"',
+        'DNK2KFnL0jUGlmvZHRse7HwNGVdtkM-ORvTZfFw7mDbt="0BDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA"',
+        'DDvIoIYqeuXJ4Zb8e2luWfjPTg4FeIzfHzIO8lC56WjD="0BDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"',
+    ].join(';');
 
-        header = signature(signages);
+    it('Should create header', () => {
+        const signages: Signage[] = [
+            new Signage(sigers, true, pre, undefined, undefined, 'CESR'),
+            new Signage(cigars, false, pre, undefined, undefined, 'CESR'),
+        ];
+
+        const header = signature(signages);
         assert.equal(header.has('Signature'), true);
-        assert.equal(
-            header.get('Signature'),
-            'indexed="?1";signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-";kind="CESR";0="AACsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN";1="ABDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA";2="ACDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F",indexed="?0";signer="EGqHykT1gVyuWxsVW6LUUsz_KtLJGYMi_SrohInwvjC-";kind="CESR";DAi2TaRNVtGmV8eSUvqHIBzTzIgrQi57vKzw5Svmy7jw="0BCsufRGYI-sRvS2c0rsOueSoSRtrjODaf48DYLJbLvvD8aHe7b2sWGebZ-y9ichhsxMF3Hhn-3LYSKIrnmH3oIN";DNK2KFnL0jUGlmvZHRse7HwNGVdtkM-ORvTZfFw7mDbt="0BDs7m2-h5l7vpjYtbFXtksicpZK5Oclm43EOkE2xoQOfr08doj73VrlKZOKNfJmRumD3tfaiFFgVZqPgiHuFVoA";DDvIoIYqeuXJ4Zb8e2luWfjPTg4FeIzfHzIO8lC56WjD="0BDVOy2LvGgFINUneL4iwA55ypJR6vDpLLbdleEsiANmFazwZARypJMiw9vu2Iu0oL7XCUiUT4JncU8P3HdIp40F"'
-        );
-        signages = designature(header.get('Signature')!);
+        assert.equal(header.get('Signature'), expectedHeader);
+    });
+
+    it('Should parse hader', () => {
+        const signages = designature(expectedHeader);
         assert.equal(signages.length, 2);
 
-        signage = signages[0];
-        assert.equal(signage.indexed, true);
-        assert.equal(signage.signer, pre);
-        assert.equal(signage.kind, 'CESR');
-        assert.equal(signage.markers.size, 3);
-        signage.markers.forEach((item: string | Siger | Cigar, tag: string) => {
-            const marker = item as Siger;
+        const signage0 = signages[0];
+        assert.equal(signage0.indexed, true);
+        assert.equal(signage0.signer, pre);
+        assert.equal(signage0.kind, 'CESR');
+        assert(signage0.markers instanceof Map);
+        assert.equal(signage0.markers.size, 3);
+        signage0.markers.forEach((marker, tag) => {
+            assert(marker instanceof Siger);
             const idx = parseInt(tag);
-            const siger = sigers[idx] as Siger;
+            const siger = sigers[idx];
             assert.equal(marker.qb64, siger.qb64);
             assert.equal(parseInt(tag), siger.index);
         });
 
-        signage = signages[1];
-        assert.equal(signage.indexed, false);
-        assert.equal(signage.signer, pre);
-        assert.equal(signage.kind, 'CESR');
-        assert.equal(signage.markers.size, 3);
-        signage.markers.forEach((marker: Cigar, tag: string) => {
+        const signage1 = signages[1];
+        assert.equal(signage1.indexed, false);
+        assert.equal(signage1.signer, pre);
+        assert.equal(signage1.kind, 'CESR');
+        assert(signage1.markers instanceof Map);
+        assert.equal(signage1.markers.size, 3);
+        signage1.markers.forEach((marker, tag) => {
+            assert(marker instanceof Cigar);
             const cigar = cigars.find((cigar) => cigar.verfer!.qb64 == tag);
             assert.notEqual(cigar, undefined);
             assert.equal(marker.qb64, cigar!.qb64);


### PR DESCRIPTION
As a continuation from https://github.com/WebOfTrust/signify-ts/pull/279, I fixed the typings for the end/ending.ts module.

Also split the tests up in to smaller tests to make it easier to follow what the module is doing. In that I added some more test cases that were missing.