### PR TITLE
feat: rename managed identifier

### DIFF
--- a/examples/integration-scripts/salty.test.ts
+++ b/examples/integration-scripts/salty.test.ts
@@ -168,5 +168,14 @@ test('salty', async () => {
 
     await assertOperations(client1);
 
+    aid = await client1.identifiers().rename('aid3', 'aid4');
+    assert.equal(aid.name, 'aid4');
+    aid = await client1.identifiers().get('aid4');
+    assert.equal(aid.name, 'aid4');
+    aids = await client1.identifiers().list(2, 2);
+    assert.equal(aids.aids.length, 1);
+    aid = aids.aids[0];
+    assert.equal(aid.name, 'aid4');
+
     console.log('Salty test passed');
 }, 30000);

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -7,7 +7,6 @@ import { MtrDex } from '../core/matter';
 import { Serder } from '../core/serder';
 import { parseRangeHeaders } from '../core/httping';
 import { KeyManager } from '../core/keeping';
-import { Operation } from './coring';
 import { HabState } from '../core/state';
 
 /** Arguments required to create an identfier */
@@ -111,14 +110,31 @@ export class Identifier {
      * Get information for a managed identifier
      * @async
      * @param {string} name Name or alias of the identifier
-     * @returns {Promise<any>} A promise to the identifier information
+     * @returns {Promise<HabState>} A promise to the identifier information
      */
     async get(name: string): Promise<HabState> {
         const path = `/identifiers/${encodeURIComponent(name)}`;
         const data = null;
         const method = 'GET';
         const res = await this.client.fetch(path, method, data);
-        return await res.json();
+        return res.json();
+    }
+
+    /**
+     * Rename managed identifier
+     * @async
+     * @param {string} name Name or alias of the identifier
+     * @param {string} newName New name for the identifier
+     * @returns {Promise<HabState>} A promise to the identifier information after updating
+     */
+    async rename(name: string, newName: string): Promise<HabState> {
+        const path = `/identifiers/${name}`;
+        const method = 'PUT';
+        const data = {
+            name: newName,
+        };
+        const res = await this.client.fetch(path, method, data);
+        return res.json();
     }
 
     /**
@@ -472,7 +488,7 @@ export class Identifier {
             'GET',
             undefined
         );
-        return await res.json();
+        return res.json();
     }
 }
 
@@ -502,6 +518,6 @@ export class EventResult {
 
     async op(): Promise<any> {
         const res = await this.promise;
-        return await res.json();
+        return res.json();
     }
 }

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -369,6 +369,15 @@ describe('Aiding', () => {
         assert.deepEqual(lastCall.body.randy.transferable, true);
     });
 
+    it('Can rename identifier', async () => {
+        client.fetch.mockResolvedValue(Response.json({}));
+        await client.identifiers().rename('aid1', 'aid2');
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers/aid1');
+        assert.equal(lastCall.method, 'PUT');
+        assert.equal(lastCall.body.name, 'aid2');
+    });
+
     describe('Group identifiers', () => {
         it('Can Rotate group', async () => {
             const member1 = await createMockIdentifierState(


### PR DESCRIPTION
I believe this was only added to signifypy following WebOfTrust/keria#218.