### PR TITLE
Updated cross-spawn library due to sec vulnerabilty.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3368,10 +3368,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",


### PR DESCRIPTION
Happened to get
https://github.com/WebOfTrust/signify-ts/actions/runs/11895128350/job/33143979521?pr=291 when updating README in #291.

This PR fixes that vulnerability in cross-spawn so that test should pass now.