### PR TITLE
chore: simplify docker compose file

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Print docker compose config
         run: docker compose config
       - name: Start dependencies
-        run: docker compose up deps --pull always
+        run: docker compose up --wait --pull always
       - name: Run integration test
         run: npm run test:integration
       - name: Print logs

--- a/README.md
+++ b/README.md
@@ -78,22 +78,18 @@ npm test
 The integration tests depends on a local instance of KERIA, vLEI-Server and Witness Demo. These are specified in the [Docker Compose](./docker-compose.yaml) file. To start the dependencies, use docker compose:
 
 ```bash
-docker compose up deps
+docker compose up --wait
 ```
 
 If successful, it should print someting like this:
 
 ```bash
-$ docker compose up deps
-[+] Running 5/4
+$ docker compose up --wait
+[+] Running 4/4
  ✔ Network signify-ts_default           Created                                           0.0s
- ✔ Container signify-ts-vlei-server-1   Created                                           0.1s
- ✔ Container signify-ts-keria-1         Created                                           0.1s
- ✔ Container signify-ts-witness-demo-1  Created                                           0.1s
- ✔ Container signify-ts-deps-1          Created                                           0.0s
-Attaching to signify-ts-deps-1
-signify-ts-deps-1  | Dependencies running
-signify-ts-deps-1 exited with code 0
+ ✔ Container signify-ts-vlei-server-1   Healthy                                           5.7s
+ ✔ Container signify-ts-keria-1         Healthy                                           6.2s
+ ✔ Container signify-ts-witness-demo-1  Healthy                                           6.2s
 ```
 
 It is possible to change the keria image by using environment variables. For example, to use weboftrust/keria:0.1.3, do:
@@ -101,7 +97,7 @@ It is possible to change the keria image by using environment variables. For exa
 ```bash
 export KERIA_IMAGE_TAG=0.1.3
 docker compose pull
-docker compose up deps
+docker compose up --wait
 ```
 
 To use another repository, you can do:
@@ -109,7 +105,7 @@ To use another repository, you can do:
 ```bash
 export KERIA_IMAGE=gleif/keria
 docker compose pull
-docker compose up deps
+docker compose up --wait
 ```
 
 **Important!** The integration tests runs on the build output in `dist/` directory. Make sure to run build before running the integration tests.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,56 +1,36 @@
+x-healthcheck: &healthcheck
+    interval: 2s
+    timeout: 3s
+    retries: 5
+    start_period: 2s
+
+x-python-env: &python-env
+    PYTHONUNBUFFERED: 1
+    PYTHONIOENCODING: UTF-8
+
 services:
     vlei-server:
         image: gleif/vlei
         environment:
-            - PYTHONUNBUFFERED=1
-            - PYTHONIOENCODING=UTF-8
-        command:
-            - vLEI-server
-            - -s
-            - ./schema/acdc
-            - -c
-            - ./samples/acdc/
-            - -o
-            - ./samples/oobis/
+            <<: *python-env
+        command: vLEI-server -s ./schema/acdc -c ./samples/acdc/ -o ./samples/oobis/
         healthcheck:
-            test:
-                - CMD
-                - curl
-                - -f
-                - http://localhost:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
-            interval: 2s
-            timeout: 3s
-            retries: 5
-            start_period: 2s
+            test: curl -f http://localhost:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
+            <<: *healthcheck
         ports:
             - 7723:7723
 
     keria:
         image: ${KERIA_IMAGE:-weboftrust/keria}:${KERIA_IMAGE_TAG:-0.2.0-dev4}
         environment:
-            - KERI_AGENT_CORS=1
-            - KERI_URL=http://keria:3902
-            - PYTHONUNBUFFERED=1
-            - PYTHONIOENCODING=UTF-8
+            KERI_AGENT_CORS: 1
+            <<: *python-env
         volumes:
             - ./config/keria.json:/keria/config/keri/cf/keria.json
-        entrypoint:
-            [
-                'keria',
-                'start',
-                '--config-dir',
-                '/keria/config',
-                '--config-file',
-                'keria',
-                '--name',
-                'agent',
-            ]
+        command: --config-dir /keria/config --config-file keria --name agent
         healthcheck:
-            test: ['CMD', 'wget', '--spider', 'http://keria:3902/spec.yaml']
-            interval: 2s
-            timeout: 3s
-            retries: 5
-            start_period: 2s
+            test: wget --spider http://keria:3902/spec.yaml
+            <<: *healthcheck
         ports:
             - 3901:3901
             - 3902:3902
@@ -59,28 +39,13 @@ services:
     witness-demo:
         image: weboftrust/keri-witness-demo:1.1.0
         environment:
-            - PYTHONUNBUFFERED=1
-            - PYTHONIOENCODING=UTF-8
+            <<: *python-env
         healthcheck:
-            test: ['CMD', 'curl', '-f', 'http://localhost:5642/oobi']
-            interval: 2s
-            timeout: 3s
-            retries: 5
-            start_period: 2s
+            test: curl -f http://localhost:5642/oobi
+            <<: *healthcheck
         volumes:
             - ./config/witness-demo:/keripy/scripts/keri/cf/main
         ports:
             - 5642:5642
             - 5643:5643
             - 5644:5644
-
-    deps:
-        image: alpine
-        command: ['echo', 'Dependencies running']
-        depends_on:
-            vlei-server:
-                condition: service_healthy
-            keria:
-                condition: service_healthy
-            witness-demo:
-                condition: service_healthy


### PR DESCRIPTION
- Use `--wait` option instead of the `deps` service: https://docs.docker.com/reference/cli/docker/compose/up/
- Use yaml anchors to avoid repetitive healthcheck and environment options.