### PR TITLE
chore: enrich package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,17 @@
 {
+  "name": "signify-ts",
   "version": "0.3.0",
+  "description": "Signing at the edge for KERI, ACDC, and KERIA",
+  "keywords": ["keri","acdc","keria","signify","signify-ts","decentralized identity","authentic data","zero trust architecture"],
+  "author": "Phil Feairheller",
+  "homepage": "https://github.com/WebOfTrust/signify-ts",
+  "repo": {
+    "type": "git",
+    "url": "git+https://github.com/WebOfTrust/signify-ts.git"
+  },
+  "bugs": {
+    "url": "https://github.com/WebOfTrust/signify-ts/issues"
+  },
   "license": "Apache-2.0",
   "exports": {
     ".": {
@@ -28,8 +40,6 @@
     "pretty": "prettier --write .",
     "pretty:check": "prettier --check ."
   },
-  "name": "signify-ts",
-  "author": "Phil Feairheller",
   "devDependencies": {
     "@mermaid-js/mermaid-cli": "^10.6.1",
     "@types/jest": "^29.5.8",


### PR DESCRIPTION
Bump version to 0.3.0-dev0 (latest code from today's `main` branch) and enrich the package.json with useful package metadata to support discovery via NPM.