### PR TITLE
fix: EventResult should await OK response

### DIFF
--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -266,7 +266,7 @@ export class Identifier {
         jsondata[algo] = keeper.params();
 
         this.client.pidx = this.client.pidx + 1;
-        const res = this.client.fetch('/identifiers', 'POST', jsondata);
+        const res = await this.client.fetch('/identifiers', 'POST', jsondata);
         return new EventResult(serder, sigs, res);
     }
 
@@ -447,7 +447,7 @@ export class Identifier {
             sigs: sigs,
         };
 
-        const res = this.client.fetch(
+        const res = await this.client.fetch(
             '/identifiers/' + name + '/endroles',
             'POST',
             jsondata
@@ -500,16 +500,16 @@ export class Identifier {
 export class EventResult {
     private readonly _serder: Serder;
     private readonly _sigs: string[];
-    private readonly promise: Promise<Response> | Response;
+    private readonly response: Response;
 
     constructor(
         serder: Serder,
         sigs: string[],
-        promise: Promise<Response> | Response
+        response: Response
     ) {
         this._serder = serder;
         this._sigs = sigs;
-        this.promise = promise;
+        this.response = response;
     }
 
     get serder() {
@@ -521,7 +521,6 @@ export class EventResult {
     }
 
     async op(): Promise<any> {
-        const res = await this.promise;
-        return await res.json();
+        return await this.response.json();
     }
 }

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -502,11 +502,7 @@ export class EventResult {
     private readonly _sigs: string[];
     private readonly response: Response;
 
-    constructor(
-        serder: Serder,
-        sigs: string[],
-        response: Response
-    ) {
+    constructor(serder: Serder, sigs: string[], response: Response) {
         this._serder = serder;
         this._sigs = sigs;
         this.response = response;

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -200,6 +200,16 @@ describe('Aiding', () => {
         assert.deepEqual(lastCall.body.salty.transferable, true);
     });
 
+    it('Should throw error if fetch call fails when creating identifier', async () => {
+        const error = new Error(`Fail ${randomUUID()}`);
+        client.fetch.mockRejectedValue(error);
+        await expect(
+            client
+                .identifiers()
+                .create('aid1', { bran: '0123456789abcdefghijk' })
+        ).rejects.toThrow(error);
+    });
+
     it('Can rotate salty identifier', async () => {
         const aid1 = await createMockIdentifierState('aid1', bran, {});
         client.fetch.mockResolvedValueOnce(Response.json(aid1));
@@ -344,6 +354,14 @@ describe('Aiding', () => {
             cid: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
             role: 'agent',
         });
+    });
+
+    it('Should throw error if fetch call fails when adding end role', async () => {
+        const error = new Error(`Fail ${randomUUID()}`);
+        client.fetch.mockRejectedValue(error);
+        await expect(
+            client.identifiers().addEndRole('aid1', 'agent')
+        ).rejects.toThrow(error);
     });
 
     it('Can get members', async () => {


### PR DESCRIPTION
In places, we were still passing a `Promise<Response>` to `EventResult`. This is problematic because if a non 2xx code is returned as the fetch call will reject after the function has returned.