### PR TITLE
Feat/loc scheme

### DIFF
--- a/examples/integration-scripts/endpoints.test.ts
+++ b/examples/integration-scripts/endpoints.test.ts
@@ -1,0 +1,67 @@
+import { strict as assert } from 'assert';
+import { SignifyClient } from 'signify-ts';
+import {
+    getEndRoles,
+    getOrCreateClient,
+    waitOperation,
+} from './utils/test-util';
+
+let client: SignifyClient;
+let cid: string;
+
+beforeAll(async () => {
+    client = await getOrCreateClient();
+    const icpResult = await client.identifiers().create('aid1');
+    cid = (await waitOperation(client, await icpResult.op())).response.i;
+});
+
+describe('endpoint authorisation', () => {
+    test('can authorise agent role for KERIA', async () => {
+        assert.equal((await getEndRoles(client, 'aid1', 'agent')).length, 0);
+
+        const rpyResult = await client
+            .identifiers()
+            .addEndRole('aid1', 'agent', client.agent!.pre);
+        await waitOperation(client, await rpyResult.op());
+
+        const endRoles = await getEndRoles(client, 'aid1', 'agent');
+        assert.equal(endRoles.length, 1);
+        assert.equal(
+            JSON.stringify(endRoles[0]),
+            JSON.stringify({
+                cid,
+                role: 'agent',
+                eid: client.agent!.pre,
+            })
+        );
+    });
+
+    test('can authorise an endpoint we control', async () => {
+        // For sake of demonstrating this test, cid = eid.
+        // Other use cases might have a different agent act as cid.
+        const endRpyResult = await client
+            .identifiers()
+            .addEndRole('aid1', 'mailbox', cid);
+        await waitOperation(client, await endRpyResult.op());
+
+        const endRoles = await getEndRoles(client, 'aid1', 'mailbox');
+        assert.equal(endRoles.length, 1);
+        assert.equal(
+            JSON.stringify(endRoles[0]),
+            JSON.stringify({
+                cid,
+                role: 'mailbox',
+                eid: cid,
+            })
+        );
+
+        const locRpyResult = await client.identifiers().addLocScheme('aid1', {
+            url: 'https://mymailbox.com',
+            scheme: 'https',
+        });
+        await waitOperation(client, await locRpyResult.op());
+
+        const oobi = (await client.oobis().get('aid1', 'mailbox')).oobis[0];
+        assert.equal(oobi, `https://mymailbox.com/oobi/${cid}/mailbox/${cid}`);
+    });
+});

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -492,7 +492,7 @@ export class Identifier {
      * @param {LocSchemeArgs} args
      * @param name Name or alias of the identifier to sign reply message
      * @param args Arguments to create authorising reply message from
-     * @returns
+     * @returns A promise to the result of the authorization
      */
     async addLocScheme(
         name: string,

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -73,6 +73,13 @@ export interface IdentifierInfo {
     name: string;
 }
 
+export interface LocSchemeArgs {
+    url: string;
+    scheme?: string;
+    eid?: string;
+    stamp?: string;
+}
+
 /** Identifier */
 export class Identifier {
     public client: IdentifierDeps;
@@ -478,6 +485,48 @@ export class Identifier {
         }
         const route = '/end/role/add';
         return reply(route, data, stamp, undefined, Serials.JSON);
+    }
+
+    /**
+     * Authorises a new location scheme (endpoint) for a particular endpoint identifier.
+     * @param {LocSchemeArgs} args
+     * @param name Name or alias of the identifier to sign reply message
+     * @param args Arguments to create authorising reply message from
+     * @returns
+     */
+    async addLocScheme(
+        name: string,
+        args: LocSchemeArgs
+    ): Promise<EventResult> {
+        const { url, scheme, eid, stamp } = args;
+        const hab = await this.get(name);
+
+        const rpyData = {
+            eid: eid ?? hab.prefix,
+            url,
+            scheme: scheme ?? 'http',
+        };
+        const rpy = reply(
+            '/loc/scheme',
+            rpyData,
+            stamp,
+            undefined,
+            Serials.JSON
+        );
+
+        const keeper = this.client.manager!.get(hab);
+        const sigs = await keeper.sign(b(rpy.raw));
+
+        const jsondata = {
+            rpy: rpy.ked,
+            sigs: sigs,
+        };
+        const res = await this.client.fetch(
+            '/identifiers/' + name + '/locschemes',
+            'POST',
+            jsondata
+        );
+        return new EventResult(rpy, sigs, res);
     }
 
     /**

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -364,6 +364,50 @@ describe('Aiding', () => {
         ).rejects.toThrow(error);
     });
 
+    it('Can authorise location/endpoint for an endpoint identifier', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+
+        await client.identifiers().addLocScheme('aid1', {
+            url: 'https://test.com',
+            scheme: 'https',
+            eid: 'EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY',
+            stamp: '2021-06-27T21:26:21.233257+00:00',
+        });
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers/aid1/locschemes');
+        assert.equal(lastCall.method, 'POST');
+        assert.equal(lastCall.body.rpy.t, 'rpy');
+        assert.equal(lastCall.body.rpy.r, '/loc/scheme');
+        assert.equal(lastCall.body.rpy.dt, '2021-06-27T21:26:21.233257+00:00');
+        assert.deepEqual(lastCall.body.rpy.a, {
+            url: 'https://test.com',
+            scheme: 'https',
+            eid: 'EHgwVwQT15OJvilVvW57HE4w0-GPs_Stj2OFoAHZSysY',
+        });
+    });
+
+    it('Can authorise location/endpoint for own identifier as default', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+
+        await client.identifiers().addLocScheme('aid1', {
+            url: 'http://test.com',
+        });
+        const lastCall = client.getLastMockRequest();
+        assert.equal(lastCall.path, '/identifiers/aid1/locschemes');
+        assert.equal(lastCall.method, 'POST');
+        assert.equal(lastCall.body.rpy.t, 'rpy');
+        assert.equal(lastCall.body.rpy.r, '/loc/scheme');
+        assert.deepEqual(lastCall.body.rpy.a, {
+            url: 'http://test.com',
+            scheme: 'http',
+            eid: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
+        });
+    });
+
     it('Can get members', async () => {
         client.fetch.mockResolvedValue(Response.json({}));
         await client.identifiers().members('aid1');


### PR DESCRIPTION
_Requires a new KERIA dev release before merging._

Allows signify controller to sign and submit a `/loc/scheme` reply message to authorise an endpoint it controls. Generally the signing hab is the `eid` but that could be different for multi-sig (mhab/ghab).