### PR TITLE
fix: send exn for each recipient; no early return

### DIFF
--- a/src/keri/app/exchanging.ts
+++ b/src/keri/app/exchanging.ts
@@ -79,6 +79,7 @@ export class Exchanges {
         embeds: Dict<any>,
         recipients: string[]
     ): Promise<any> {
+        const results = [];
         for (const recipient of recipients) {
             const [exn, sigs, atc] = await this.createExchangeMessage(
                 sender,
@@ -87,15 +88,17 @@ export class Exchanges {
                 embeds,
                 recipient
             );
-            return await this.sendFromEvents(
+            const result = await this.sendFromEvents(
                 name,
                 topic,
                 exn,
                 sigs,
                 atc,
-                recipients
+                [recipient]
             );
+            results.push(result);
         }
+        return results;
     }
 
     /**


### PR DESCRIPTION
Fixes #310 . The existing code would return early rather than execute for each recipient. This was okay from a functional perspective because of how KERIA acts as a delivery service for EXN messages. Yet, the way the code is written it indicates the for loop would execute for each member of the array, which is not how the code works because it returns early.

KERIA would take the list of recipients in the EXN message and then deliver all EXN messages as declared.