### PR TITLE
add npm publish script for easier npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -29,5 +29,6 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_PUBLISH_TAG: ${{ inputs.dist-tag }}
           NPM_PACKAGE_SCOPE: ${{ vars.NPM_PACKAGE_SCOPE }}
         run: ./publish.sh

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,10 +3,6 @@ name: Publish NPM
 on:
   workflow_dispatch:
     inputs:
-      dry-run:
-        type: boolean
-        default: true
-        description: Dry run publish
       dist-tag:
         type: choice
         options:
@@ -30,32 +26,8 @@ jobs:
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Set package name from vars
-        if: ${{ vars.NPM_PACKAGE_NAME }}
-        run: |
-          cat package.json | jq -r '.name = "${{ vars.NPM_PACKAGE_NAME }}"' > package.json.tmp
-          mv package.json.tmp package.json
-
-      - name: Set version from commit
-        if: ${{ inputs.dist-tag == 'dev' }}
-        run: |
-          npm version --no-git-tag-version $(cat package.json | jq .version -r)-dev.$(git rev-parse --short HEAD)
-
-      - name: Create git tag
-        run: git tag $(cat package.json | jq .version -r)
-
-      - name: Publish dev package (Dry run)
-        if: ${{ inputs.dry-run == true }}
-        run: npm publish --tag "${{ inputs.dist-tag }}" --dry-run
-
-      - name: Publish dev package
-        if: ${{ inputs.dry-run == false }}
+      - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-            npm publish --tag "${{ inputs.dist-tag }}"
-            git tag v$(cat package.json | jq .version -r)
-            git push origin  v$(cat package.json | jq .version -r)
+          NPM_PACKAGE_SCOPE: ${{ vars.NPM_PACKAGE_SCOPE }}
+        run: ./publish.sh

--- a/README.md
+++ b/README.md
@@ -141,3 +141,44 @@ Account Creation Workflow
 ![Account Creation](/diagrams/account-creation-workflow.png)
 
 ![Account Creation Webpage](/diagrams/account-creation-webpage-workflow.png)
+
+# Publishing
+
+This package is published on npm: https://www.npmjs.com/package/signify-ts.
+
+If you need to publish a version under your own scope, you can use the [publish script](./publish.sh). This enables you to create development packages. For example:
+
+```bash
+NPM_PACKAGE_SCOPE=@myorg DRY_RUN=1 ./publish.sh
+npm notice Tarball Details
+npm notice name: @myorg/signify-ts
+npm notice version: 0.3.0-rc1-dev.8fa9919
+npm notice filename: myorg-signify-ts-0.3.0-rc1-dev.8fa9919.tgz
+npm notice package size: 81.0 kB
+npm notice unpacked size: 370.0 kB
+npm notice shasum: 8c160bc99d9ec552e6c478c20922cae3388a8ace
+npm notice integrity: sha512-WRuD5PKFN3WBl[...]xVieCIS0UpVeg==
+npm notice total files: 96
+npm notice
+npm notice Publishing to https://registry.npmjs.org/ with tag dev and default access (dry-run)
++ @myorg/signify-ts@0.3.0-rc1-dev.8fa9919
+```
+
+Set the `NPM_PUBLISH_TAG` to `latest` to skip the commit hash suffix in the version:
+
+
+```bash
+NPM_PUBLISH_TAG=latest NPM_PACKAGE_SCOPE=@myorg DRY_RUN=1 ./publish.sh
+npm notice Tarball Details
+npm notice name: @myorg/signify-ts
+npm notice version: 0.3.0-rc1
+npm notice filename: myorg-signify-ts-0.3.0-rc1.tgz
+npm notice package size: 80.9 kB
+npm notice unpacked size: 370.0 kB
+npm notice shasum: 8c9e4edcf19802e8acaf5996a36061a9c335b1c4
+npm notice integrity: sha512-V1y2W3zs4Ccsn[...]vKY3WWgalcuBQ==
+npm notice total files: 96
+npm notice
+npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
++ @myorg/signify-ts@0.3.0-rc1
+```

--- a/README.md
+++ b/README.md
@@ -166,7 +166,6 @@ npm notice Publishing to https://registry.npmjs.org/ with tag dev and default ac
 
 Set the `NPM_PUBLISH_TAG` to `latest` to skip the commit hash suffix in the version:
 
-
 ```bash
 NPM_PUBLISH_TAG=latest NPM_PACKAGE_SCOPE=@myorg DRY_RUN=1 ./publish.sh
 npm notice Tarball Details

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+package_info=$(cat package.json)
+scope=${NPM_PACKAGE_SCOPE:-$(echo "$package_info" | jq .name -r | grep '/' | cut -d'/' -f1)}
+name=${NPM_PACKAGE_NAME:-$(echo "$package_info" | jq .name -r | cut -d'/' -f2)}
+
+version=$(echo "$package_info" | jq .version -r)
+tag=${NPM_PUBLISH_TAG:-dev}
+
+if [ "$scope" != "" ]; then
+    name="${scope}/${name}"
+fi
+
+if [ "$tag" = "dev" ]; then
+    version="${version}-dev.$(git rev-parse --short HEAD)"
+fi
+
+npm ci
+npm run build
+
+# Creating a temporary directory for publishing.
+#
+# This allows us to modify the version and name of the published package
+# without having to commit changes to the repo. Which is useful for tagged
+# and scoped package releases.
+publish_dir="$(mktemp -d)"
+cp -r LICENSE dist package.json package-lock.json "${publish_dir}/"
+jq ".version = \"${version}\" | .name = \"${name}\" | del(.scripts.prepare)" package.json > "${publish_dir}/package.json"
+
+if [ -z "$DRY_RUN" ]; then
+    npm publish "${publish_dir}" --tag "${tag}"
+else
+    npm publish "${publish_dir}" --tag "${tag}" --dry-run
+fi

--- a/publish.sh
+++ b/publish.sh
@@ -25,7 +25,7 @@ npm run build
 # without having to commit changes to the repo. Which is useful for tagged
 # and scoped package releases.
 publish_dir="$(mktemp -d)"
-cp -r LICENSE dist package.json package-lock.json "${publish_dir}/"
+cp -r README.md LICENSE dist package.json package-lock.json "${publish_dir}/"
 jq ".version = \"${version}\" | .name = \"${name}\" | del(.scripts.prepare)" package.json > "${publish_dir}/package.json"
 
 if [ -z "$DRY_RUN" ]; then


### PR DESCRIPTION
Tested here on my fork: https://github.com/lenkan/signify-ts/actions/runs/14033855540/job/39287547534

As an example, here is my package scope that I use for testing: https://www.npmjs.com/package/@lenkan/signify-ts?activeTab=versions

This could also be used to publish dev tags on push to main from the weboftrust repo. That way we can avoid the prepare script and other potential issues that comes with installing from github.