### PR TITLE
chore: remove outdated dependency secp256r1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.3.0-rc1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@noble/curves": "^1.8.1",
         "@noble/hashes": "^1.3.2",
         "buffer": "^6.0.3",
-        "ecdsa-secp256r1": "^1.3.3",
         "libsodium-wrappers-sumo": "^0.7.9",
         "mathjs": "^12.4.0",
         "structured-headers": "^0.5.0"
@@ -426,11 +426,28 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.8.1.tgz",
+      "integrity": "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.7.1"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1047,20 +1064,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
-    "node_modules/asn1.js/node_modules/bn.js": {
-      "version": "4.12.0",
-      "license": "MIT"
-    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -1282,18 +1285,6 @@
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/ecdsa-secp256r1": {
-      "version": "1.3.3",
-      "license": "MIT",
-      "dependencies": {
-        "asn1.js": "^5.0.1",
-        "bn.js": "^4.11.8"
-      }
-    },
-    "node_modules/ecdsa-secp256r1/node_modules/bn.js": {
-      "version": "4.12.0",
       "license": "MIT"
     },
     "node_modules/emoji-regex": {
@@ -1949,10 +1940,6 @@
         "node": ">=0.8.19"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "license": "ISC"
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "dev": true,
@@ -2280,10 +2267,6 @@
     "node_modules/minami": {
       "version": "1.2.3",
       "dev": true
-    },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "license": "ISC"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",
@@ -2630,10 +2613,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "license": "MIT"
     },
     "node_modules/seedrandom": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -58,9 +58,9 @@
     "vitest": "^3.0.9"
   },
   "dependencies": {
+    "@noble/curves": "^1.8.1",
     "@noble/hashes": "^1.3.2",
     "buffer": "^6.0.3",
-    "ecdsa-secp256r1": "^1.3.3",
     "libsodium-wrappers-sumo": "^0.7.9",
     "mathjs": "^12.4.0",
     "structured-headers": "^0.5.0"

--- a/src/keri/core/verfer.ts
+++ b/src/keri/core/verfer.ts
@@ -1,4 +1,3 @@
-export {};
 import libsodium from 'libsodium-wrappers-sumo';
 import { Matter, MatterArgs, MtrDex } from './matter.ts';
 import secp256r1 from 'ecdsa-secp256r1';
@@ -8,40 +7,40 @@ import secp256r1 from 'ecdsa-secp256r1';
  *  using .raw as verifier key and .code as signature cypher suite
  */
 export class Verfer extends Matter {
-    private readonly _verify: (sig: any, ser: any, key: any) => boolean;
     constructor({ raw, code, qb64, qb64b, qb2 }: MatterArgs) {
         super({ raw, code, qb64, qb64b, qb2 });
 
-        if (Array.from([MtrDex.Ed25519N, MtrDex.Ed25519]).includes(this.code)) {
-            this._verify = this._ed25519;
-        } else if (
-            Array.from([MtrDex.ECDSA_256r1N, MtrDex.ECDSA_256r1]).includes(
-                this.code
-            )
+        if (
+            ![
+                MtrDex.Ed25519N,
+                MtrDex.Ed25519,
+                MtrDex.ECDSA_256r1N,
+                MtrDex.ECDSA_256r1,
+            ].includes(this.code)
         ) {
-            this._verify = this._secp256r1;
-        } else {
             throw new Error(`Unsupported code = ${this.code} for verifier.`);
         }
     }
 
-    verify(sig: any, ser: any) {
-        return this._verify(sig, ser, this.raw);
-    }
-
-    _ed25519(sig: any, ser: any, key: any) {
-        try {
-            return libsodium.crypto_sign_verify_detached(sig, ser, key);
-        } catch (error) {
-            throw new Error(error as string);
-        }
-    }
-    _secp256r1(sig: any, ser: any, key: any) {
-        try {
-            const publicKey = secp256r1.fromCompressedPublicKey(key);
-            return publicKey.verify(ser, sig);
-        } catch (error) {
-            throw new Error(error as string);
+    verify(sig: Uint8Array, ser: Uint8Array) {
+        switch (this.code) {
+            case MtrDex.Ed25519:
+            case MtrDex.Ed25519N: {
+                return libsodium.crypto_sign_verify_detached(
+                    sig,
+                    ser,
+                    this.raw
+                );
+            }
+            case MtrDex.ECDSA_256r1:
+            case MtrDex.ECDSA_256r1N: {
+                const publicKey = secp256r1.fromCompressedPublicKey(this.raw);
+                return publicKey.verify(ser, sig);
+            }
+            default:
+                throw new Error(
+                    `Unsupported code = ${this.code} for verifier.`
+                );
         }
     }
 }

--- a/src/keri/core/verfer.ts
+++ b/src/keri/core/verfer.ts
@@ -1,6 +1,7 @@
 import libsodium from 'libsodium-wrappers-sumo';
 import { Matter, MatterArgs, MtrDex } from './matter.ts';
-import secp256r1 from 'ecdsa-secp256r1';
+import { p256 } from '@noble/curves/p256';
+import { b } from './core.ts';
 
 /**
  * @description  Verfer :sublclass of Matter,helps to verify signature of serialization
@@ -22,7 +23,7 @@ export class Verfer extends Matter {
         }
     }
 
-    verify(sig: Uint8Array, ser: Uint8Array) {
+    verify(sig: Uint8Array, ser: Uint8Array | string): boolean {
         switch (this.code) {
             case MtrDex.Ed25519:
             case MtrDex.Ed25519N: {
@@ -34,8 +35,8 @@ export class Verfer extends Matter {
             }
             case MtrDex.ECDSA_256r1:
             case MtrDex.ECDSA_256r1N: {
-                const publicKey = secp256r1.fromCompressedPublicKey(this.raw);
-                return publicKey.verify(ser, sig);
+                const message = typeof ser === 'string' ? b(ser) : ser;
+                return p256.verify(sig, message, this.raw);
             }
             default:
                 throw new Error(

--- a/test/core/verfer.test.ts
+++ b/test/core/verfer.test.ts
@@ -1,87 +1,130 @@
 import { MtrDex } from '../../src/keri/core/matter.ts';
 import libsodium from 'libsodium-wrappers-sumo';
-import { assert, describe, it, expect } from 'vitest';
+import { assert, describe, it, expect, beforeAll } from 'vitest';
 import { Verfer } from '../../src/keri/core/verfer.ts';
-import secp256r1 from 'ecdsa-secp256r1';
+import { p256 } from '@noble/curves/p256';
+import { b } from 'signify-ts';
 
-function base64ToUint8Array(base64: string) {
-    const binaryString = atob(base64);
-    const bytes = new Uint8Array(binaryString.length);
-    for (let i = 0; i < binaryString.length; i++) {
-        bytes[i] = binaryString.charCodeAt(i);
-    }
-    return new Uint8Array(bytes.buffer);
-}
+beforeAll(async () => {
+    await libsodium.ready;
+});
 
 describe('Verfer', () => {
-    it('should verify digests', async () => {
-        await libsodium.ready;
+    describe('Ed25519', () => {
         const seed = libsodium.randombytes_buf(libsodium.crypto_sign_SEEDBYTES);
         const keypair = libsodium.crypto_sign_seed_keypair(seed);
 
-        const verkey = keypair.publicKey;
-        const sigkey = keypair.privateKey;
+        it('should create verfer', async () => {
+            const verkey = keypair.publicKey;
 
-        let verfer = new Verfer({ raw: verkey, code: MtrDex.Ed25519N });
-        assert.notEqual(verfer, null);
+            const verfer = new Verfer({
+                raw: keypair.publicKey,
+                code: MtrDex.Ed25519N,
+            });
 
-        assert.deepStrictEqual(verfer.raw, verkey);
-        assert.deepStrictEqual(verfer.code, MtrDex.Ed25519N);
-
-        const ser = 'abcdefghijklmnopqrstuvwxyz0123456789';
-
-        const sig = libsodium.crypto_sign_detached(ser, sigkey);
-
-        assert.equal(verfer.verify(sig, ser), true);
-
-        verfer = new Verfer({
-            qb64: 'BGgVB5Aar1pOr70nRpJmRA_RP68HErflNovoEMP7b7mJ',
+            assert.deepStrictEqual(verfer.raw, verkey);
+            assert.deepStrictEqual(verfer.code, MtrDex.Ed25519N);
         });
-        assert.deepStrictEqual(
-            verfer.raw,
-            new Uint8Array([
-                104, 21, 7, 144, 26, 175, 90, 78, 175, 189, 39, 70, 146, 102,
-                68, 15, 209, 63, 175, 7, 18, 183, 229, 54, 139, 232, 16, 195,
-                251, 111, 185, 137,
-            ])
-        );
-    });
-    it('should verify secp256r1', async () => {
-        const privateKey = secp256r1.generateKey();
-        const publicKey = base64ToUint8Array(
-            privateKey.toCompressedPublicKey()
-        );
-        let verfer = new Verfer({ raw: publicKey, code: MtrDex.ECDSA_256r1 });
-        assert.notEqual(verfer, null);
 
-        assert.deepStrictEqual(verfer.raw, publicKey);
-        assert.deepStrictEqual(verfer.code, MtrDex.ECDSA_256r1);
+        it('should verify signature', () => {
+            const verfer = new Verfer({
+                raw: keypair.publicKey,
+                code: MtrDex.Ed25519N,
+            });
+            const ser = 'abcdefghijklmnopqrstuvwxyz0123456789';
 
-        const ser = 'abcdefghijklmnopqrstuvwxyz0123456789';
+            const sig = libsodium.crypto_sign_detached(ser, keypair.privateKey);
 
-        const sig = privateKey.sign(ser);
-
-        assert.equal(verfer.verify(sig, ser), true);
-
-        verfer = new Verfer({
-            qb64: '1AAJAwf0oSqmdjPud5gnK6bAPKkBLrXUMQZiOW4Vpc4XpOPf',
+            assert.equal(verfer.verify(sig, ser), true);
         });
-        assert.deepStrictEqual(
-            verfer.raw,
-            new Uint8Array([
-                3, 7, 244, 161, 42, 166, 118, 51, 238, 119, 152, 39, 43, 166,
-                192, 60, 169, 1, 46, 181, 212, 49, 6, 98, 57, 110, 21, 165, 206,
-                23, 164, 227, 223,
-            ])
-        );
+
+        it('should create verfer from qb64', async () => {
+            const verfer = new Verfer({
+                qb64: 'BGgVB5Aar1pOr70nRpJmRA_RP68HErflNovoEMP7b7mJ',
+            });
+
+            assert.deepStrictEqual(
+                verfer.raw,
+                new Uint8Array([
+                    104, 21, 7, 144, 26, 175, 90, 78, 175, 189, 39, 70, 146,
+                    102, 68, 15, 209, 63, 175, 7, 18, 183, 229, 54, 139, 232,
+                    16, 195, 251, 111, 185, 137,
+                ])
+            );
+        });
     });
+
+    describe('secp256r1', () => {
+        const privateKey = new Uint8Array([
+            138, 17, 14, 173, 86, 68, 80, 39, 61, 52, 208, 154, 211, 190, 21,
+            99, 156, 134, 184, 90, 166, 171, 226, 251, 239, 132, 127, 221, 144,
+            51, 245, 71,
+        ]);
+
+        const publicKey = p256.getPublicKey(privateKey);
+
+        it('should create verfer', async () => {
+            const verfer = new Verfer({
+                raw: publicKey,
+                code: MtrDex.ECDSA_256r1,
+            });
+
+            assert.deepStrictEqual(verfer.raw, publicKey);
+            assert.deepStrictEqual(verfer.code, MtrDex.ECDSA_256r1);
+            assert.equal(
+                verfer.qb64,
+                '1AAJA-blKBTkTkEEOX_Yq3i3KxZJvcHarPfu_crKVwcfEwvQ'
+            );
+        });
+
+        it('should verify secp256r1', async () => {
+            const verfer = new Verfer({
+                raw: publicKey,
+                code: MtrDex.ECDSA_256r1,
+            });
+
+            const ser = 'abcdefghijklmnopqrstuvwxyz0123456789';
+
+            const sig = p256.sign(b(ser), privateKey).toCompactRawBytes();
+
+            assert.deepEqual(
+                sig,
+                new Uint8Array([
+                    56, 81, 180, 93, 192, 44, 174, 128, 161, 173, 226, 227, 149,
+                    26, 203, 255, 36, 189, 144, 110, 163, 51, 67, 138, 99, 130,
+                    38, 189, 16, 170, 164, 77, 167, 254, 123, 220, 149, 72, 71,
+                    28, 32, 66, 213, 177, 197, 158, 195, 234, 167, 109, 207,
+                    174, 15, 221, 245, 85, 120, 226, 224, 33, 94, 89, 115, 49,
+                ])
+            );
+
+            assert.equal(verfer.verify(sig, ser), true);
+        });
+
+        it('should parse qb64', () => {
+            const verfer = new Verfer({
+                qb64: '1AAJAwf0oSqmdjPud5gnK6bAPKkBLrXUMQZiOW4Vpc4XpOPf',
+            });
+
+            assert.deepStrictEqual(
+                verfer.raw,
+                new Uint8Array([
+                    3, 7, 244, 161, 42, 166, 118, 51, 238, 119, 152, 39, 43,
+                    166, 192, 60, 169, 1, 46, 181, 212, 49, 6, 98, 57, 110, 21,
+                    165, 206, 23, 164, 227, 223,
+                ])
+            );
+        });
+    });
+
     it('should not verify secp256k1', async () => {
         const publicKey = new Uint8Array([
             2, 79, 93, 30, 107, 249, 254, 237, 205, 87, 8, 149, 203, 214, 36,
             187, 162, 251, 58, 206, 241, 203, 27, 76, 236, 37, 189, 148, 240,
             178, 204, 133, 31,
         ]);
-        expect(function () {
+
+        expect(() => {
             new Verfer({ raw: publicKey, code: MtrDex.ECDSA_256k1 });
         }).toThrow(new Error(`Unsupported code = 1AAB for verifier.`));
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-    "include": ["src", "test", "test-integration", "types.d.ts"],
+    "include": ["src", "test", "test-integration"],
     "exclude": ["node_modules", "dist"],
     "compilerOptions": {
         "noEmit": true,

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,1 +1,0 @@
-declare module 'ecdsa-secp256r1';


### PR DESCRIPTION
This dependency has not been updated in 6 years and has no typings. The @noble package suite is maintained. See also related change in cesr-ts here: https://github.com/WebOfTrust/cesr-ts/pull/16