### PR TITLE
chore: remove buffer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/hashes": "^1.3.2",
-        "buffer": "^6.0.3",
+        "base64-js": "^1.5.1",
         "ecdsa-secp256r1": "^1.3.3",
         "libsodium-wrappers-sumo": "^0.7.9",
         "mathjs": "^12.4.0",
@@ -1078,6 +1078,8 @@
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
       "funding": [
         {
           "type": "github",
@@ -1124,28 +1126,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
       }
     },
     "node_modules/cac": {
@@ -1895,24 +1875,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "dependencies": {
     "@noble/hashes": "^1.3.2",
-    "buffer": "^6.0.3",
+    "base64-js": "^1.5.1",
     "ecdsa-secp256r1": "^1.3.3",
     "libsodium-wrappers-sumo": "^0.7.9",
     "mathjs": "^12.4.0",

--- a/src/keri/core/base64.ts
+++ b/src/keri/core/base64.ts
@@ -1,15 +1,9 @@
-import { Buffer } from 'buffer';
-// base64url is supported by node Buffer, but not in buffer package for browser compatibility
-// https://github.com/feross/buffer/issues/309
+import { fromByteArray, toByteArray } from 'base64-js';
 
-// Instead of using a node.js-only module and forcing us to polyfill the Buffer global,
-// we insert code from https://gitlab.com/seangenabe/safe-base64 here
+export function encodeBase64Url(buffer: Uint8Array): string {
+    const input = Buffer.from(buffer);
 
-export function encodeBase64Url(buffer: Buffer | Uint8Array): string {
-    const input = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
-
-    return input
-        .toString('base64')
+    return fromByteArray(input)
         .replace(/\+/g, '-')
         .replace(/\//g, '_')
         .replace(/=+/, '');
@@ -23,5 +17,5 @@ export function decodeBase64Url(input: string): Uint8Array {
     const n = input.length % 4;
     const padded = input + '='.repeat(n > 0 ? 4 - n : n);
     const base64String = padded.replace(/-/g, '+').replace(/_/g, '/');
-    return Uint8Array.from(Buffer.from(base64String, 'base64'));
+    return toByteArray(base64String);
 }

--- a/src/keri/core/bexter.ts
+++ b/src/keri/core/bexter.ts
@@ -1,7 +1,7 @@
 import { BexDex, Matter, MatterArgs, MtrDex } from './matter.ts';
 import { EmptyMaterialError } from './kering.ts';
-import { Buffer } from 'buffer';
 import { decodeBase64Url, encodeBase64Url } from './base64.ts';
+import { concat } from './core.ts';
 
 const B64REX = '^[A-Za-z0-9\\-_]*$';
 export const Reb64 = new RegExp(B64REX);
@@ -123,7 +123,7 @@ export class Bexter extends Matter {
     get bext(): string {
         const sizage = Matter.Sizes.get(this.code);
         const wad = Uint8Array.from(new Array(sizage?.ls).fill(0));
-        const bext = encodeBase64Url(Buffer.from([...wad, ...this.raw]));
+        const bext = encodeBase64Url(concat(wad, this.raw));
 
         let ws = 0;
         if (sizage?.ls === 0 && bext !== undefined) {

--- a/src/keri/core/diger.ts
+++ b/src/keri/core/diger.ts
@@ -1,6 +1,5 @@
 import { blake3 } from '@noble/hashes/blake3';
 import { Matter, MatterArgs, MtrDex } from './matter.ts';
-import { Buffer } from 'buffer';
 
 /**
  * @description : Diger is subset of Matter and is used to verify the digest of serialization
@@ -10,10 +9,7 @@ import { Buffer } from 'buffer';
  */
 
 export class Diger extends Matter {
-    private readonly _verify: (
-        a: Uint8Array,
-        b: Uint8Array | Buffer
-    ) => boolean;
+    private readonly _verify: (a: Uint8Array, b: Uint8Array) => boolean;
 
     // This constructor will assign digest verification function to ._verify
     constructor(
@@ -79,13 +75,11 @@ export class Diger extends Matter {
         return diger.verify(ser) && this.verify(ser);
     }
 
-    blake3_256(ser: Uint8Array, dig: Uint8Array | Buffer) {
+    blake3_256(ser: Uint8Array, dig: Uint8Array) {
         const digest = blake3.create({ dkLen: 32 }).update(ser).digest();
-        const other = Uint8Array.from(dig);
 
         return (
-            digest.length == other.length &&
-            digest.toString() === other.toString()
+            digest.length == dig.length && digest.toString() === dig.toString()
         );
     }
 }

--- a/src/keri/core/httping.ts
+++ b/src/keri/core/httping.ts
@@ -10,7 +10,6 @@ import { b } from './core.ts';
 import { Cigar } from './cigar.ts';
 import { nowUTC } from './utils.ts';
 import { Siger } from './siger.ts';
-import { Buffer } from 'buffer';
 import { encodeBase64Url } from './base64.ts';
 
 export const HEADER_SIG_INPUT = normalize('Signature-Input');
@@ -130,7 +129,7 @@ export class Unqualified {
     }
 
     get qb64(): string {
-        return encodeBase64Url(Buffer.from(this._raw));
+        return encodeBase64Url(this._raw);
     }
 
     get qb64b(): Uint8Array {

--- a/src/keri/core/indexer.ts
+++ b/src/keri/core/indexer.ts
@@ -1,6 +1,5 @@
 import { EmptyMaterialError } from './kering.ts';
 import { b, b64ToInt, d, intToB64, readInt } from './core.ts';
-import { Buffer } from 'buffer';
 import { decodeBase64Url, encodeBase64Url } from './base64.ts';
 
 export class IndexerCodex {
@@ -398,8 +397,7 @@ export class Indexer {
             bytes[odx] = raw[i];
         }
 
-        const full =
-            both + encodeBase64Url(Buffer.from(bytes)).slice(ps - xizage.ls);
+        const full = both + encodeBase64Url(bytes).slice(ps - xizage.ls);
         if (full.length != xizage.fs) {
             throw new Error(`Invalid code=${both} for raw size=${raw.length}.`);
         }

--- a/src/keri/core/matter.ts
+++ b/src/keri/core/matter.ts
@@ -2,7 +2,6 @@ import { EmptyMaterialError } from './kering.ts';
 
 import { intToB64, readInt } from './core.ts';
 import { b, d } from './core.ts';
-import { Buffer } from 'buffer';
 import { decodeBase64Url, encodeBase64Url } from './base64.ts';
 
 export class Codex {
@@ -421,7 +420,7 @@ export class Matter {
                 bytes[odx] = raw[i];
             }
 
-            return both + encodeBase64Url(Buffer.from(bytes));
+            return both + encodeBase64Url(bytes);
         } else {
             const both = code;
             const cs = both.length;
@@ -443,7 +442,7 @@ export class Matter {
                 bytes[odx] = raw[i];
             }
 
-            return both + encodeBase64Url(Buffer.from(bytes)).slice(cs % 4);
+            return both + encodeBase64Url(bytes).slice(cs % 4);
         }
     }
 

--- a/test/core/base64.test.ts
+++ b/test/core/base64.test.ts
@@ -3,14 +3,13 @@ import {
     decodeBase64Url,
     encodeBase64Url,
 } from '../../src/keri/core/base64.ts';
-import { Buffer } from 'buffer';
 
 test('encode', () => {
-    assert.equal(encodeBase64Url(Uint8Array.from(Buffer.from('f'))), 'Zg');
-    assert.equal(encodeBase64Url(Uint8Array.from(Buffer.from('fi'))), 'Zmk');
-    assert.equal(encodeBase64Url(Uint8Array.from(Buffer.from('fis'))), 'Zmlz');
+    assert.equal(encodeBase64Url(Uint8Array.from([102])), 'Zg');
+    assert.equal(encodeBase64Url(Uint8Array.from([102, 105])), 'Zmk');
+    assert.equal(encodeBase64Url(Uint8Array.from([102, 105, 115])), 'Zmlz');
     assert.equal(
-        encodeBase64Url(Uint8Array.from(Buffer.from('fish'))),
+        encodeBase64Url(Uint8Array.from([102, 105, 115, 104])),
         'ZmlzaA'
     );
     assert.equal(encodeBase64Url(Uint8Array.from([248])), '-A');
@@ -25,18 +24,17 @@ test('decode', () => {
         decodeBase64Url('ZmlzaA'),
         Uint8Array.from([102, 105, 115, 104])
     );
-    assert.deepEqual(Buffer.from([248]), decodeBase64Url('-A'));
-    assert.deepEqual(Buffer.from([252]), decodeBase64Url('_A'));
+    assert.deepEqual(Uint8Array.from([248]), decodeBase64Url('-A'));
+    assert.deepEqual(Uint8Array.from([252]), decodeBase64Url('_A'));
 });
 
 test('Test encode / decode compare with built in node Buffer', () => {
     const text = '🏳️🏳️';
     const b64url = '8J-Ps--4j_Cfj7PvuI8';
+    const data = Uint8Array.from([
+        240, 159, 143, 179, 239, 184, 143, 240, 159, 143, 179, 239, 184, 143,
+    ]);
 
-    assert.deepEqual(
-        Buffer.from(text).toString('base64url'),
-        encodeBase64Url(Buffer.from(text))
-    );
-
-    assert.deepEqual(Buffer.from(b64url, 'base64url'), decodeBase64Url(b64url));
+    assert.deepEqual(b64url, encodeBase64Url(new TextEncoder().encode(text)));
+    assert.deepEqual(data, decodeBase64Url(b64url));
 });

--- a/test/core/diger.test.ts
+++ b/test/core/diger.test.ts
@@ -4,18 +4,18 @@ import { blake3 } from '@noble/hashes/blake3';
 
 import { Diger } from '../../src/keri/core/diger.ts';
 import { MtrDex } from '../../src/keri/core/matter.ts';
-import { Buffer } from 'buffer';
+import { concat } from '../../src/keri/core/core.ts';
+
+function encodeText(text: string) {
+    return new TextEncoder().encode(text);
+}
 
 describe('Diger', () => {
     it('should generate digests', () => {
         // Create something to digest and verify
-        const ser = Buffer.from(
-            'abcdefghijklmnopqrstuvwxyz0123456789',
-            'binary'
-        );
-        const digest = Buffer.from(
-            blake3.create({ dkLen: 32 }).update(ser).digest()
-        );
+        const ser = encodeText('abcdefghijklmnopqrstuvwxyz0123456789');
+
+        const digest = blake3.create({ dkLen: 32 }).update(ser).digest();
 
         let diger = new Diger({ raw: digest });
         assert.deepStrictEqual(diger.code, MtrDex.Blake3_256);
@@ -25,9 +25,7 @@ describe('Diger', () => {
         let result = diger.verify(ser);
         assert.equal(result, true);
 
-        result = diger.verify(
-            Buffer.concat([ser, Buffer.from('2j2idjpwjfepjtgi', 'binary')])
-        );
+        result = diger.verify(concat(ser, encodeText('2j2idjpwjfepjtgi')));
         assert.equal(result, false);
         diger = new Diger({ raw: digest, code: MtrDex.Blake3_256 });
         assert.deepStrictEqual(diger.code, MtrDex.Blake3_256);

--- a/test/core/indexer.test.ts
+++ b/test/core/indexer.test.ts
@@ -2,7 +2,6 @@ import libsodium from 'libsodium-wrappers-sumo';
 import { assert, describe, it } from 'vitest';
 import { IdrDex, Indexer } from '../../src/keri/core/indexer.ts';
 import { b, intToB64 } from '../../src/keri/core/core.ts';
-import { Buffer } from 'buffer';
 import {
     decodeBase64Url,
     encodeBase64Url,
@@ -71,7 +70,7 @@ describe('Indexer', () => {
             const odx = i + ps;
             bytes[odx] = sig[i];
         }
-        const sig64 = encodeBase64Url(Buffer.from(bytes));
+        const sig64 = encodeBase64Url(bytes);
         assert.equal(sig64.length, 88);
         assert.equal(
             sig64,
@@ -95,16 +94,13 @@ describe('Indexer', () => {
         // b'\xde\xca\xfc\x7f~\xd7o|\x17\x82\x1d\xd4<o"\x81&\t')
         assert.deepStrictEqual(
             qsig2b,
-            Buffer.from(
-                new Uint8Array([
-                    0, 0, 153, 210, 60, 57, 36, 36, 48, 159, 107, 251, 24, 160,
-                    140, 64, 114, 18, 50, 46, 107, 178, 199, 31, 112, 14, 39,
-                    109, 143, 64, 170, 165, 140, 200, 110, 133, 200, 33, 246,
-                    113, 145, 112, 169, 236, 207, 146, 175, 41, 222, 202, 252,
-                    127, 126, 215, 111, 124, 23, 130, 29, 212, 60, 111, 34, 129,
-                    38, 9,
-                ])
-            )
+            new Uint8Array([
+                0, 0, 153, 210, 60, 57, 36, 36, 48, 159, 107, 251, 24, 160, 140,
+                64, 114, 18, 50, 46, 107, 178, 199, 31, 112, 14, 39, 109, 143,
+                64, 170, 165, 140, 200, 110, 133, 200, 33, 246, 113, 145, 112,
+                169, 236, 207, 146, 175, 41, 222, 202, 252, 127, 126, 215, 111,
+                124, 23, 130, 29, 212, 60, 111, 34, 129, 38, 9,
+            ])
         );
 
         let indexer = new Indexer({ raw: sig });


### PR DESCRIPTION
'Buffer' is a node.js-only API. So exposing it from signify-ts can cause confusion for people using it in browsers, even if we use a polyfill package. This PR removes all references to `Buffer`.

Also, note that `base64-js` was a dependency of the `buffer` module: https://github.com/feross/buffer/blob/5857e295f4d37e3ad02c3abcbf7e8e5ef51f3be6/package.json#L19, so now we just use the base64 encoding explicitly.