### PR TITLE
chore: add lint rule to ensure only defined globals are used

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,11 +3,29 @@
 import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
+import globals from 'globals';
 
 export default tseslint.config(
     eslint.configs.recommended,
     tseslint.configs.recommended,
     { rules: prettier.rules },
+    {
+        rules: {
+            'no-undef': 'error',
+        },
+    },
+    {
+        files: ['src/**'],
+        languageOptions: {
+            globals: globals['shared-node-browser'],
+        },
+    },
+    {
+        files: ['test/**', 'test-integration/**'],
+        languageOptions: {
+            globals: globals.node,
+        },
+    },
     {
         // These are files with more lenient lint config because they have not been "fixed" yet
         // Once a directory here is fixed, it should be removed from here so the strict rules applies

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "bip39": "^3.1.0",
         "eslint": "^9.22.0",
         "eslint-config-prettier": "^10.1.1",
+        "globals": "^16.0.0",
         "minami": "^1.2.3",
         "prettier": "^3.5.3",
         "ts-mockito": "^2.6.1",
@@ -233,6 +234,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@eslint/js": {
@@ -1828,9 +1842,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.0.0.tgz",
+      "integrity": "sha512-iInW14XItCXET01CQFqudPOWP2jYMl7T+QRQT+UNcR/iQncN/F0UNpgd76iFkBPgNQb4+X3LV9tLJYzwh+Gl3A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "bip39": "^3.1.0",
     "eslint": "^9.22.0",
     "eslint-config-prettier": "^10.1.1",
+    "globals": "^16.0.0",
     "minami": "^1.2.3",
     "prettier": "^3.5.3",
     "ts-mockito": "^2.6.1",

--- a/src/keri/core/base64.ts
+++ b/src/keri/core/base64.ts
@@ -1,8 +1,6 @@
 import { fromByteArray, toByteArray } from 'base64-js';
 
-export function encodeBase64Url(buffer: Uint8Array): string {
-    const input = Buffer.from(buffer);
-
+export function encodeBase64Url(input: Uint8Array): string {
     return fromByteArray(input)
         .replace(/\+/g, '-')
         .replace(/\//g, '_')


### PR DESCRIPTION
This will ensure that the signify-ts code does not use any code that cannot run in browser _and_ node.js. 

For example:

- No access to `process` is allowed.
- No access to the global `Buffer` class in node.js (you can still use 'Buffer' if you install a Buffer library and import it).

This lint rule would have stopped disallowed access to Buffer in base64.ts.