### PR TITLE
feat: add generic agent SSE signaling client

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ Typescript source files needs to be transpiled before running scripts or integra
     console.log(actualSignifyClient);
     ```
 
+### Agent signaling
+
+KERIA can publish transient server-sent events for the connected agent at
+`GET /signals/stream`. SignifyTS exposes this generic channel through
+`client.signals()`.
+
+- `client.signals().stream()` opens the authenticated SSE stream.
+- `client.signals().verifyReplyEnvelope(envelope, { route })` verifies that the
+  SSE payload is a KERI `rpy` envelope signed by the connected KERIA agent AID.
+
+SSE delivery is not durable. Topic resources should provide durable polling
+fallbacks for missed events and restarts.
+
 ### Unit testing
 
 To run unit tests

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -12,6 +12,7 @@ export * from './keri/app/escrowing.ts';
 export * from './keri/app/exchanging.ts';
 export * from './keri/app/grouping.ts';
 export * from './keri/app/notifying.ts';
+export * from './keri/app/signaling.ts';
 
 export * from './keri/core/authing.ts';
 export * from './keri/core/cigar.ts';

--- a/src/keri/app/aiding.ts
+++ b/src/keri/app/aiding.ts
@@ -65,6 +65,7 @@ export interface IdentifierDeps {
     ): Promise<Response>;
     pidx: number;
     manager: IdentifierManagerFactory | null;
+    agent?: { pre: string } | null;
 }
 
 /**
@@ -456,8 +457,9 @@ export class Identifier {
     ): Promise<EventResult> {
         const hab = await this.get(name);
         const pre = hab.prefix;
+        const resolvedEid = this.resolveEndRoleEid(role, eid);
 
-        const rpy = this.makeEndRole(pre, role, eid, stamp);
+        const rpy = this.makeEndRole(pre, role, resolvedEid, stamp);
         const keeper = this.client.manager!.get(hab);
         const sigs = await keeper.sign(b(rpy.raw));
 
@@ -472,6 +474,25 @@ export class Identifier {
             jsondata
         );
         return new EventResult(rpy, sigs, res);
+    }
+
+    private resolveEndRoleEid(role: string, eid?: string): string {
+        if (eid !== undefined && eid.trim().length > 0) {
+            return eid;
+        }
+
+        if (role === 'agent') {
+            const agentPre = this.client.agent?.pre;
+            if (agentPre !== undefined && agentPre.trim().length > 0) {
+                return agentPre;
+            }
+
+            throw new Error(
+                'agent endpoint role authorization requires a connected agent AID'
+            );
+        }
+
+        throw new Error(`endpoint role ${role} authorization requires eid`);
     }
 
     /**

--- a/src/keri/app/clienting.ts
+++ b/src/keri/app/clienting.ts
@@ -14,6 +14,7 @@ import { Escrows } from './escrowing.ts';
 import { Exchanges } from './exchanging.ts';
 import { Groups } from './grouping.ts';
 import { Notifications } from './notifying.ts';
+import { AgentSignals } from './signaling.ts';
 
 const DEFAULT_BOOT_URL = 'http://localhost:3903';
 
@@ -56,6 +57,7 @@ export class SignifyClient {
     private _oobis = new Oobis(this);
     private _config = new Config(this);
     private _delegations = new Delegations(this);
+    private _signals = new AgentSignals(this);
     private _exchanges = new Exchanges(this);
     private _groups = new Groups(this);
     private _escrows = new Escrows(this);
@@ -501,6 +503,18 @@ export class SignifyClient {
      */
     delegations(): Delegations {
         return this._delegations;
+    }
+
+    /**
+     * Get the generic KERIA agent signaling resource.
+     *
+     * Topic modules use this for signed SSE transport and KERI `rpy` envelope
+     * verification, then apply their own durable polling and approval logic.
+     *
+     * @returns {AgentSignals}
+     */
+    signals(): AgentSignals {
+        return this._signals;
     }
 
     /**

--- a/src/keri/app/signaling.ts
+++ b/src/keri/app/signaling.ts
@@ -1,0 +1,84 @@
+import { SignifyClient } from './clienting.ts';
+import { Serder } from '../core/serder.ts';
+import { Siger } from '../core/siger.ts';
+
+/**
+ * KERIA agent-signed KERI reply envelope carried as SSE event data.
+ *
+ * The envelope format is generic. Topic modules decide which reply route and
+ * payload fields they understand, but they should all reuse
+ * `AgentSignals.verifyReplyEnvelope` before auto-approving edge-signed work.
+ */
+export interface SignedReplyEnvelope {
+    rpy: Record<string, unknown>;
+    sigs: string[];
+}
+
+/**
+ * Optional constraints applied while verifying a signed reply envelope.
+ */
+export interface VerifyReplyEnvelopeOptions {
+    /**
+     * Expected KERI reply route, such as `/test/signals/request`.
+     */
+    route?: string;
+}
+
+/**
+ * Generic signaling API for one connected KERIA agent.
+ *
+ * This class intentionally owns only live transport and server-authentication
+ * checks. Topic-specific modules use it, but do not own it. SSE delivery is
+ * transient, so topic modules must still provide durable
+ * polling fallback endpoints for missed events and restarts.
+ */
+export class AgentSignals {
+    client: SignifyClient;
+
+    constructor(client: SignifyClient) {
+        this.client = client;
+    }
+
+    /**
+     * Open KERIA's authenticated generic agent SSE stream.
+     *
+     * Browser `EventSource` cannot attach Signify authentication headers, so
+     * consumers should use this signed `fetch` response and parse SSE frames
+     * from the returned body stream.
+     */
+    async stream(): Promise<Response> {
+        const headers = new Headers({ Accept: 'text/event-stream' });
+        return await this.client.fetch('/signals/stream', 'GET', null, headers);
+    }
+
+    /**
+     * Verify one KERIA agent-signed KERI `rpy` envelope.
+     *
+     * Verification is route-agnostic by default. Pass `options.route` when a
+     * caller is expecting a specific topic request. The payload must name the
+     * connected KERIA agent in `rpy.a.agent`, and the first signature must verify
+     * against the connected agent verifier.
+     */
+    verifyReplyEnvelope(
+        envelope: SignedReplyEnvelope,
+        options: VerifyReplyEnvelopeOptions = {}
+    ): boolean {
+        if (this.client.agent === null || this.client.agent.verfer === null) {
+            throw new Error('client must be connected before verification');
+        }
+
+        const rpy = new Serder(envelope.rpy);
+        if (options.route !== undefined && rpy.sad.r !== options.route) {
+            return false;
+        }
+        if (rpy.sad.a?.agent !== this.client.agent.pre) {
+            return false;
+        }
+        if (envelope.sigs.length === 0) {
+            return false;
+        }
+
+        const siger = new Siger({ qb64: envelope.sigs[0] });
+        return this.client.agent.verfer.verify(siger.raw, rpy.raw);
+    }
+}

--- a/test/app/aiding.test.ts
+++ b/test/app/aiding.test.ts
@@ -19,6 +19,7 @@ import {
     Tier,
     Verfer,
 } from '../../src/index.ts';
+import { b } from '../../src/keri/core/core.ts';
 import { createMockIdentifierState } from './test-utils.ts';
 
 const bran = '0123456789abcdefghijk';
@@ -26,6 +27,7 @@ const bran = '0123456789abcdefghijk';
 export class MockClient implements IdentifierDeps {
     manager: IdentifierManagerFactory;
     controller: Controller;
+    agent = { pre: 'Eagent' };
     pidx = 0;
 
     fetch = vitest.fn();
@@ -348,7 +350,7 @@ describe('Aiding', () => {
         client.fetch.mockResolvedValueOnce(Response.json(aid1));
         client.fetch.mockResolvedValueOnce(Response.json({}));
 
-        await client.identifiers().addEndRole('aid1', 'agent');
+        const result = await client.identifiers().addEndRole('aid1', 'agent');
         const lastCall = client.getLastMockRequest();
         assert.equal(lastCall.path, '/identifiers/aid1/endroles');
         assert.equal(lastCall.method, 'POST');
@@ -357,7 +359,36 @@ describe('Aiding', () => {
         assert.deepEqual(lastCall.body.rpy.a, {
             cid: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
             role: 'agent',
+            eid: 'Eagent',
         });
+        const siger = new Siger({ qb64: result.sigs[0] });
+        const verfer = new Verfer({ qb64: aid1.state.k[0] });
+        expect(verfer.verify(siger.raw, b(result.serder.raw))).toBe(true);
+    });
+
+    it('Can add end role with an explicit endpoint AID', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+        client.fetch.mockResolvedValueOnce(Response.json({}));
+
+        await client
+            .identifiers()
+            .addEndRole('aid1', 'agent', 'EexplicitAgent');
+        const lastCall = client.getLastMockRequest();
+        assert.deepEqual(lastCall.body.rpy.a, {
+            cid: 'ELUvZ8aJEHAQE-0nsevyYTP98rBbGJUrTj5an-pCmwrK',
+            role: 'agent',
+            eid: 'EexplicitAgent',
+        });
+    });
+
+    it('Requires non-agent end roles to provide an endpoint AID', async () => {
+        const aid1 = await createMockIdentifierState('aid1', bran, {});
+        client.fetch.mockResolvedValueOnce(Response.json(aid1));
+
+        await expect(
+            client.identifiers().addEndRole('aid1', 'mailbox')
+        ).rejects.toThrow('endpoint role mailbox authorization requires eid');
     });
 
     it('Should throw error if fetch call fails when adding end role', async () => {

--- a/test/app/clienting.test.ts
+++ b/test/app/clienting.test.ts
@@ -17,6 +17,7 @@ import { Escrows } from '../../src/keri/app/escrowing.ts';
 import { Exchanges } from '../../src/keri/app/exchanging.ts';
 import { Groups } from '../../src/keri/app/grouping.ts';
 import { Notifications } from '../../src/keri/app/notifying.ts';
+import { AgentSignals } from '../../src/keri/app/signaling.ts';
 
 import {
     HEADER_SIG_INPUT,
@@ -117,6 +118,7 @@ describe('SignifyClient', () => {
         assert.equal(client.keyStates() instanceof KeyStates, true);
         assert.equal(client.credentials() instanceof Credentials, true);
         assert.equal(client.registries() instanceof Registries, true);
+        assert.equal(client.signals() instanceof AgentSignals, true);
         assert.equal(client.schemas() instanceof Schemas, true);
         assert.equal(client.challenges() instanceof Challenges, true);
         assert.equal(client.contacts() instanceof Contacts, true);

--- a/test/app/signaling.test.ts
+++ b/test/app/signaling.test.ts
@@ -1,0 +1,141 @@
+import { assert, describe, expect, it } from 'vitest';
+import libsodium from 'libsodium-wrappers-sumo';
+import {
+    AgentSignals,
+    b,
+    reply,
+    Serials,
+    SignifyClient,
+    Siger,
+    Signer,
+} from '../../src/index.ts';
+
+const TEST_SIGNAL_ROUTE = '/test/signals/request';
+
+const signedEnvelope = ({
+    route = TEST_SIGNAL_ROUTE,
+    agent = 'agent-aid',
+    signer,
+}: {
+    route?: string;
+    agent?: string;
+    signer: Signer;
+}) => {
+    const rpy = reply(
+        route,
+        { d: 'request-id', agent, aid: 'managed-aid' },
+        undefined,
+        undefined,
+        Serials.JSON
+    );
+    const sig = signer.sign(b(rpy.raw), 0) as Siger;
+    return {
+        rpy: rpy.sad,
+        sigs: [sig.qb64],
+    };
+};
+
+describe('AgentSignals', () => {
+    it('opens the generic agent SSE stream', async () => {
+        const calls: unknown[][] = [];
+        const client = {
+            async fetch(...args: unknown[]) {
+                calls.push(args);
+                return new Response();
+            },
+        } as unknown as SignifyClient;
+
+        await new AgentSignals(client).stream();
+
+        assert.equal(calls[0]?.[0], '/signals/stream');
+        assert.equal(calls[0]?.[1], 'GET');
+        assert.equal(calls[0]?.[2], null);
+        assert.equal(
+            (calls[0]?.[3] as Headers).get('Accept'),
+            'text/event-stream'
+        );
+    });
+
+    it('verifies an agent-signed reply envelope for an expected route', async () => {
+        await libsodium.ready;
+        const signer = new Signer({});
+        const client = {
+            agent: { pre: 'agent-aid', verfer: signer.verfer },
+        } as unknown as SignifyClient;
+
+        const verified = new AgentSignals(client).verifyReplyEnvelope(
+            signedEnvelope({ signer }),
+            { route: TEST_SIGNAL_ROUTE }
+        );
+
+        assert.equal(verified, true);
+    });
+
+    it('rejects the wrong route', async () => {
+        await libsodium.ready;
+        const signer = new Signer({});
+        const client = {
+            agent: { pre: 'agent-aid', verfer: signer.verfer },
+        } as unknown as SignifyClient;
+
+        const verified = new AgentSignals(client).verifyReplyEnvelope(
+            signedEnvelope({ route: '/wrong', signer }),
+            { route: TEST_SIGNAL_ROUTE }
+        );
+
+        assert.equal(verified, false);
+    });
+
+    it('rejects the wrong agent payload', async () => {
+        await libsodium.ready;
+        const signer = new Signer({});
+        const client = {
+            agent: { pre: 'agent-aid', verfer: signer.verfer },
+        } as unknown as SignifyClient;
+
+        const verified = new AgentSignals(client).verifyReplyEnvelope(
+            signedEnvelope({ agent: 'other-agent', signer })
+        );
+
+        assert.equal(verified, false);
+    });
+
+    it('rejects missing signatures', async () => {
+        await libsodium.ready;
+        const signer = new Signer({});
+        const client = {
+            agent: { pre: 'agent-aid', verfer: signer.verfer },
+        } as unknown as SignifyClient;
+        const envelope = signedEnvelope({ signer });
+
+        const verified = new AgentSignals(client).verifyReplyEnvelope({
+            ...envelope,
+            sigs: [],
+        });
+
+        assert.equal(verified, false);
+    });
+
+    it('rejects bad signatures', async () => {
+        await libsodium.ready;
+        const agentSigner = new Signer({});
+        const otherSigner = new Signer({});
+        const client = {
+            agent: { pre: 'agent-aid', verfer: agentSigner.verfer },
+        } as unknown as SignifyClient;
+
+        const verified = new AgentSignals(client).verifyReplyEnvelope(
+            signedEnvelope({ signer: otherSigner })
+        );
+
+        assert.equal(verified, false);
+    });
+
+    it('requires a connected agent before verification', () => {
+        const client = { agent: null } as unknown as SignifyClient;
+
+        expect(() =>
+            new AgentSignals(client).verifyReplyEnvelope({ rpy: {}, sigs: [] })
+        ).toThrow('client must be connected before verification');
+    });
+});


### PR DESCRIPTION
This adds the SignifyTS client counterpart to KERIA's SSE AgentSignals, broadcaster, SSE endpoint, and SSE iterable. This supports one or more Signify clients connecting to a given server Agent to get unique server sent events streams per SignifyClient controller instance.

This is in preparation for future event driven features including the did:webs integration, among others. The SSE event stream is also a convenient way for clients to switch from long-polling to observing events sent from an agent. Long-polling is still be supported as a fallback, though this allows SSE to be the default future communication pathway from the agent to a client. This will significantly help with both bandwidth and performance on highly used Agency servers.

This PR should be merged along side WebOfTrust/keria #435 https://github.com/WebOfTrust/keria/pull/435 