### PR TITLE
Types for e, s, r accomodate SAIDs and blocks.

### DIFF
--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -356,11 +356,22 @@ export class Credentials {
 
         const keeper = this.client.manager.get(hab);
 
-        const [, subject] = Saider.saidify({
-            d: '',
-            ...args.a,
-            dt: args.a.dt ?? new Date().toISOString().replace('Z', '000+00:00'),
-        });
+        let subject;
+        let dt: string;
+        if (typeof args.a === 'string') {
+            subject = args.a;
+            dt = new Date().toISOString().replace('Z', '000+00:00');
+        } else if (typeof args.a !== 'string') {
+            dt =
+                args.a.dt ?? new Date().toISOString().replace('Z', '000+00:00');
+            [, subject] = Saider.saidify({
+                d: '',
+                ...args.a,
+                dt: dt,
+            });
+        } else {
+            throw new Error('Data section must be valid CredentialData');
+        }
 
         const [, acdc] = Saider.saidify({
             v: versify(Protocols.ACDC, undefined, Serials.JSON, 0),
@@ -381,7 +392,7 @@ export class Credentials {
             i: acdc.d,
             s: '0',
             ri: args.ri,
-            dt: subject.dt,
+            dt: dt,
         });
 
         const sn = parseInt(hab.state.s, 16);

--- a/src/keri/app/credentialing.ts
+++ b/src/keri/app/credentialing.ts
@@ -80,23 +80,23 @@ export interface CredentialData {
     /**
      * Registry id.
      */
-    ri?: string;
+    ri?: string; // Note: this is rd in the approved ACDC spec.
     /**
      * Schema id
      */
-    s?: string;
+    s?: string | { [key: string]: unknown }; // Either the SAID of the schema or the schema block itself.
     /**
      * Credential subject data
      */
-    a: CredentialSubject;
+    a: CredentialSubject | string; // Either a block representing Credential Subject or the SAID itself
     /**
      * Credential source section
      */
-    e?: { [key: string]: unknown };
+    e?: string | { [key: string]: unknown }; // Either the block of edges or the SAID of block of edges itself
     /**
      * Credential rules section
      */
-    r?: { [key: string]: unknown };
+    r?: string | { [key: string]: unknown }; // Either a block of rules or the SAID itself
 }
 
 export interface IssueCredentialResult {

--- a/test-integration/multisig-holder.test.ts
+++ b/test-integration/multisig-holder.test.ts
@@ -1,3 +1,5 @@
+import type { CredentialSubject } from '../src/keri/app/credentialing.ts';
+
 import { assert, test } from 'vitest';
 import signify, {
     SignifyClient,
@@ -477,7 +479,7 @@ async function createRegistry(
 async function issueCredential(
     client: SignifyClient,
     name: string,
-    data: CredentialData
+    data: CredentialData & { a: CredentialSubject }
 ) {
     const result = await client.credentials().issue(name, data);
 


### PR DESCRIPTION
Changed type specifications to allow for the fact that these fields can accomodate SAIDs and blocks.