### PR TITLE
feat: NPM Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -9,26 +9,28 @@ on:
           - dev
           - latest
         default: dev
-        description: Npm dist tag
+        description: NPM dist tag
 jobs:
   publish:
     name: Publish NPM
     permissions:
-        contents: write
+      contents: read
+      id-token: write
+    environment: npm-publish
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: '24'
           cache: 'npm'
           registry-url: 'https://registry.npmjs.org'
 
       - name: Publish package
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_PUBLISH_TAG: ${{ inputs.dist-tag }}
           NPM_PACKAGE_SCOPE: ${{ vars.NPM_PACKAGE_SCOPE }}
+          NPM_PUBLISH_PROVENANCE: 1
         run: ./publish.sh

--- a/README.md
+++ b/README.md
@@ -154,6 +154,20 @@ Account Creation Workflow
 
 This package is published on npm: https://www.npmjs.com/package/signify-ts.
 
+## Release publishing
+
+Releases are published with npm trusted publishing from GitHub Actions. The
+normal release flow is:
+
+1. Validate the release locally.
+2. Create and push a signed version tag.
+3. Run the `Publish NPM` workflow against that tag with the intended npm dist tag.
+4. Approve the `npm-publish` GitHub environment when prompted.
+5. Verify the published package and npm dist tag.
+
+The npm package has a trusted publisher configured for the `WebOfTrust/signify-ts` repository,
+the `publish-npm.yml` workflow, and the `npm-publish` environment.
+
 If you need to publish a version under your own scope, you can use the [publish script](./publish.sh). This enables you to create development packages. For example:
 
 ```bash
@@ -189,3 +203,7 @@ npm notice
 npm notice Publishing to https://registry.npmjs.org/ with tag latest and default access (dry-run)
 + @myorg/signify-ts@0.3.0-rc1
 ```
+
+Direct local publishing to the public `signify-ts` package should be treated as
+an emergency fallback. It requires an npm account with publish access and any
+OTP required by npm.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   ],
   "author": "Phil Feairheller",
   "homepage": "https://github.com/WebOfTrust/signify-ts",
-  "repo": {
+  "repository": {
     "type": "git",
     "url": "git+https://github.com/WebOfTrust/signify-ts.git"
   },

--- a/publish.sh
+++ b/publish.sh
@@ -28,8 +28,13 @@ publish_dir="$(mktemp -d)"
 cp -r README.md LICENSE dist package.json package-lock.json "${publish_dir}/"
 jq ".version = \"${version}\" | .name = \"${name}\" | del(.scripts.prepare)" package.json > "${publish_dir}/package.json"
 
+provenance_arg=""
+if [ "${NPM_PUBLISH_PROVENANCE:-}" = "1" ]; then
+    provenance_arg="--provenance"
+fi
+
 if [ -z "$DRY_RUN" ]; then
-    npm publish "${publish_dir}" --tag "${tag}"
+    npm publish "${publish_dir}" --tag "${tag}" ${provenance_arg}
 else
-    npm publish "${publish_dir}" --tag "${tag}" --dry-run
+    npm publish "${publish_dir}" --tag "${tag}" ${provenance_arg} --dry-run
 fi


### PR DESCRIPTION
Uses the npm-publish GitHub Environment along with GitHub Actions to perform trusted publishing to the npmjs.com NPM package registry using OIDC with scopes constraining the authorization to the local GitHub Actions runner for a given CI run.