### PR TITLE
Adds generated api types to default exports

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -42,3 +42,5 @@ export * from './keri/core/verfer.ts';
 export * from './keri/core/keyState.ts';
 
 export * from './keri/end/ending.ts';
+
+export * as KeriaApi from './types/keria-api-schema.ts';


### PR DESCRIPTION
For discussion, these types and enums are hard to get at but are helpful when developing and using this library as a dependency.  This change allows these types to be exposed in the default import via the KeriaApi namespace.

A solution to #384 