### PR TITLE
Add 'latest' version to keria-version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        keria-version: ['0.2.0-rc2']
+        keria-version: ['0.2.0-rc2', 'latest']
         node-version: ['20']
     env:
       KERIA_IMAGE_TAG: ${{ matrix.keria-version }}


### PR DESCRIPTION
signify-ts integration tests were only running against the old version of KERIA.  Added 'latest' keria to the test matrix in order to test against the latest version of KERIA.

`latest` matrix action test fails due to https://github.com/WebOfTrust/signify-ts/issues/392