### PR TITLE
tests: Fix the integration tests to work with 0.4.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,16 +33,16 @@ jobs:
           npm cache clean --force
           npm set registry https://registry.npmjs.org/
           npm ci
-      
+
       - name: Check formatting
-        run: npm run pretty:check 
-      
+        run: npm run pretty:check
+
       - name: Lint
         run: npm run lint
 
       - name: Build
         run: npm run build
- 
+
       - name: Test
         run: npm test -- --coverage=true
 
@@ -57,7 +57,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        keria-version: ['0.2.0-rc2', 'latest']
+        keria-version: ['0.4.0', 'latest']
         node-version: ['20']
     env:
       KERIA_IMAGE_TAG: ${{ matrix.keria-version }}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,10 +10,10 @@ x-python-env: &python-env
 
 services:
     vlei-server:
-        image: gleif/vlei:0.2.0
+        image: gleif/vlei:1.0.3
         environment:
             <<: *python-env
-        command: vLEI-server -s ./schema/acdc -c ./samples/acdc/ -o ./samples/oobis/
+        command: vLEI-server -s /vLEI/schema -c /vLEI/credentials -o /vLEI/oobis
         healthcheck:
             test: curl -f http://localhost:7723/oobi/EBfdlu8R27Fbx-ehrqwImnK-8Cm79sqbAQ4MmvEAYqao
             <<: *healthcheck

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,13 +21,13 @@ services:
             - 7723:7723
 
     keria:
-        image: ${KERIA_IMAGE:-weboftrust/keria}:${KERIA_IMAGE_TAG:-0.2.0-rc2}
+        image: ${KERIA_IMAGE:-weboftrust/keria}:${KERIA_IMAGE_TAG:-0.4.0}
         environment:
             KERI_AGENT_CORS: 1
             <<: *python-env
         volumes:
             - ./config/keria.json:/keria/config/keri/cf/keria.json
-        command: start --config-dir /keria/config --config-file keria --name agent
+        command: start --config-dir /keria/config --config-file keria --name keria
         healthcheck:
             test: wget --spider http://keria:3902/spec.yaml
             <<: *healthcheck
@@ -37,11 +37,12 @@ services:
             - 3903:3903
 
     witness-demo:
-        image: weboftrust/keri-witness-demo:1.1.0
+        image: ${KERI_IMAGE:-weboftrust/keri}:${KERI_IMAGE_TAG:-1.2.13}
         environment:
             <<: *python-env
+        command: witness demo
         healthcheck:
-            test: curl -f http://localhost:5642/oobi
+            test: wget --spider http://127.0.0.1:5642/oobi
             <<: *healthcheck
         volumes:
             - ./config/witness-demo:/keripy/scripts/keri/cf/main

--- a/test-integration/credentials.test.ts
+++ b/test-integration/credentials.test.ts
@@ -9,12 +9,14 @@ import {
 import { resolveEnvironment } from './utils/resolve-env.ts';
 import {
     assertNotifications,
+    assertNoNotifications,
     assertOperations,
     createAid,
     getOrCreateClients,
     getOrCreateContact,
     markAndRemoveNotification,
     resolveOobi,
+    waitAndMarkNotification,
     waitForNotifications,
     waitOperation,
 } from './utils/test-util.ts';
@@ -52,6 +54,12 @@ let legalEntityAid: Aid;
 let applySaid: string;
 let offerSaid: string;
 let agreeSaid: string;
+let qviGrantSaid: string;
+let presentationGrantSaid: string;
+let leGrantSaid: string;
+let qviAdmitSaid: string;
+let presentationAdmitSaid: string;
+let leAdmitSaid: string;
 
 beforeAll(async () => {
     [issuerClient, holderClient, verifierClient, legalEntityClient] =
@@ -257,6 +265,7 @@ test('single signature credentials', { timeout: 90000 }, async () => {
             recipient: holderAid.prefix,
             datetime: dt,
         });
+        qviGrantSaid = grant.said;
 
         const op = await issuerClient
             .ipex()
@@ -264,6 +273,9 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 holderAid.prefix,
             ]);
         await waitOperation(issuerClient, op);
+        await waitAndMarkNotification(issuerClient, '/exn/ipex/grant', {
+            said: qviGrantSaid,
+        });
     });
 
     await step(
@@ -279,23 +291,31 @@ test('single signature credentials', { timeout: 90000 }, async () => {
     );
 
     await step('holder IPEX admit', async () => {
-        const holderNotifications = await waitForNotifications(
+        const grantNotifications = await waitForNotifications(
             holderClient,
-            '/exn/ipex/grant'
+            '/exn/ipex/grant',
+            { said: qviGrantSaid }
         );
-        const grantNotification = holderNotifications[0]; // should only have one notification right now
+        assert.equal(grantNotifications.length, 1);
+        const grantNotification = grantNotifications[0];
+        assert(grantNotification.a.d);
 
         const [admit, sigs, aend] = await holderClient.ipex().admit({
             senderName: holderAid.name,
             message: '',
-            grantSaid: grantNotification.a.d!,
+            grantSaid: grantNotification.a.d,
             recipient: issuerAid.prefix,
             datetime: createTimestamp(),
         });
+        qviAdmitSaid = admit.said;
+
         const op = await holderClient
             .ipex()
             .submitAdmit(holderAid.name, admit, sigs, aend, [issuerAid.prefix]);
         await waitOperation(holderClient, op);
+        await waitAndMarkNotification(holderClient, '/exn/ipex/admit', {
+            said: qviAdmitSaid,
+        });
 
         await markAndRemoveNotification(holderClient, grantNotification);
     });
@@ -303,9 +323,12 @@ test('single signature credentials', { timeout: 90000 }, async () => {
     await step('issuer IPEX grant response', async () => {
         const issuerNotifications = await waitForNotifications(
             issuerClient,
-            '/exn/ipex/admit'
+            '/exn/ipex/admit',
+            { said: qviAdmitSaid }
         );
-        await markAndRemoveNotification(issuerClient, issuerNotifications[0]);
+        assert.equal(issuerNotifications.length, 1);
+        const issuerNotification = issuerNotifications[0];
+        await markAndRemoveNotification(issuerClient, issuerNotification);
     });
 
     await step('holder has credential', async () => {
@@ -320,34 +343,43 @@ test('single signature credentials', { timeout: 90000 }, async () => {
         assert.equal(holderCredential.sad.i, issuerAid.prefix);
         assert.equal(holderCredential.status.s, '0');
         assert(holderCredential.atc !== undefined);
+
+        await assertNoNotifications(holderClient, '/exn/ipex/grant', {
+            said: qviGrantSaid,
+        });
     });
 
     await step('verifier IPEX apply', async () => {
-        const [apply, sigs, _] = await verifierClient.ipex().apply({
+        const [apply, sigs] = await verifierClient.ipex().apply({
             senderName: verifierAid.name,
             schemaSaid: QVI_SCHEMA_SAID,
             attributes: { LEI: '5493001KJTIIGC8Y1R17' },
             recipient: holderAid.prefix,
             datetime: createTimestamp(),
         });
+        applySaid = apply.said;
 
         const op = await verifierClient
             .ipex()
             .submitApply(verifierAid.name, apply, sigs, [holderAid.prefix]);
         await waitOperation(verifierClient, op);
+        await waitAndMarkNotification(verifierClient, '/exn/ipex/apply', {
+            said: applySaid,
+        });
     });
 
     await step('holder IPEX apply receive and offer', async () => {
-        const holderNotifications = await waitForNotifications(
+        const holderApplyNotes = await waitForNotifications(
             holderClient,
-            '/exn/ipex/apply'
+            '/exn/ipex/apply',
+            { said: applySaid }
         );
-
-        const holderApplyNote = holderNotifications[0];
+        assert.equal(holderApplyNotes.length, 1);
+        const holderApplyNote = holderApplyNotes[0];
         assert(holderApplyNote.a.d);
 
         const apply = await holderClient.exchanges().get(holderApplyNote.a.d);
-        applySaid = apply.exn.d;
+        assert.strictEqual(apply.exn.d, applySaid);
 
         const exnA = apply.exn.a as Record<string, unknown>;
         const filter: { [x: string]: unknown } = { '-s': exnA.s };
@@ -361,15 +393,16 @@ test('single signature credentials', { timeout: 90000 }, async () => {
         const matchingCreds = await holderClient.credentials().list({ filter });
         assert.strictEqual(matchingCreds.length, 1);
 
-        await markAndRemoveNotification(holderClient, holderNotifications[0]);
+        await markAndRemoveNotification(holderClient, holderApplyNote);
 
         const [offer, sigs, end] = await holderClient.ipex().offer({
             senderName: holderAid.name,
             recipient: verifierAid.prefix,
             acdc: new Serder(matchingCreds[0].sad),
-            applySaid: applySaid,
+            applySaid: holderApplyNote.a.d,
             datetime: createTimestamp(),
         });
+        offerSaid = offer.said;
 
         const op = await holderClient
             .ipex()
@@ -377,51 +410,60 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 verifierAid.prefix,
             ]);
         await waitOperation(holderClient, op);
+        await waitAndMarkNotification(holderClient, '/exn/ipex/offer', {
+            said: offerSaid,
+        });
     });
 
     await step('verifier receive offer and agree', async () => {
-        const verifierNotifications = await waitForNotifications(
+        const verifierOfferNotes = await waitForNotifications(
             verifierClient,
-            '/exn/ipex/offer'
+            '/exn/ipex/offer',
+            { said: offerSaid }
         );
-
-        const verifierOfferNote = verifierNotifications[0];
+        assert.equal(verifierOfferNotes.length, 1);
+        const verifierOfferNote = verifierOfferNotes[0];
         assert(verifierOfferNote.a.d);
 
         const offer = assertIpexOffer(
             await verifierClient.exchanges().get(verifierOfferNote.a.d)
         );
-        offerSaid = offer.exn.d;
+        assert.strictEqual(offer.exn.d, offerSaid);
 
         assert.strictEqual(offer.exn.p, applySaid);
         assert.strictEqual(offer.exn.e.acdc.d, qviCredentialId);
 
         await markAndRemoveNotification(verifierClient, verifierOfferNote);
 
-        const [agree, sigs, _] = await verifierClient.ipex().agree({
+        const [agree, sigs] = await verifierClient.ipex().agree({
             senderName: verifierAid.name,
             recipient: holderAid.prefix,
-            offerSaid: offerSaid,
+            offerSaid: verifierOfferNote.a.d,
             datetime: createTimestamp(),
         });
+        agreeSaid = agree.said;
 
         const op = await verifierClient
             .ipex()
             .submitAgree(verifierAid.name, agree, sigs, [holderAid.prefix]);
         await waitOperation(verifierClient, op);
+        await waitAndMarkNotification(verifierClient, '/exn/ipex/agree', {
+            said: agreeSaid,
+        });
     });
 
     await step('holder IPEX receive agree and grant/present', async () => {
-        const holderNotifications = await waitForNotifications(
+        const holderAgreeNotes = await waitForNotifications(
             holderClient,
-            '/exn/ipex/agree'
+            '/exn/ipex/agree',
+            { said: agreeSaid }
         );
-
-        const holderAgreeNote = holderNotifications[0];
+        assert.equal(holderAgreeNotes.length, 1);
+        const holderAgreeNote = holderAgreeNotes[0];
         assert(holderAgreeNote.a.d);
 
         const agree = await holderClient.exchanges().get(holderAgreeNote.a.d);
-        agreeSaid = agree.exn.d;
+        assert.strictEqual(agree.exn.d, agreeSaid);
 
         assert.strictEqual(agree.exn.p, offerSaid);
 
@@ -440,9 +482,10 @@ test('single signature credentials', { timeout: 90000 }, async () => {
             acdcAttachment: holderCredential.atc,
             ancAttachment: holderCredential.ancatc,
             issAttachment: holderCredential.issatc,
-            agreeSaid: agreeSaid,
+            agreeSaid: holderAgreeNote.a.d,
             datetime: createTimestamp(),
         });
+        presentationGrantSaid = grant2.said;
 
         const op = await holderClient
             .ipex()
@@ -450,27 +493,34 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 verifierAid.prefix,
             ]);
         await waitOperation(holderClient, op);
+        await waitAndMarkNotification(holderClient, '/exn/ipex/grant', {
+            said: presentationGrantSaid,
+        });
     });
 
     await step('verifier receives IPEX grant', async () => {
-        const verifierNotifications = await waitForNotifications(
+        const verifierGrantNotes = await waitForNotifications(
             verifierClient,
-            '/exn/ipex/grant'
+            '/exn/ipex/grant',
+            { said: presentationGrantSaid }
         );
-
-        const verifierGrantNote = verifierNotifications[0];
+        assert.equal(verifierGrantNotes.length, 1);
+        const verifierGrantNote = verifierGrantNotes[0];
         assert(verifierGrantNote.a.d);
 
-        const grant = await holderClient.exchanges().get(verifierGrantNote.a.d);
+        const grant = await verifierClient
+            .exchanges()
+            .get(verifierGrantNote.a.d);
         assert.strictEqual(grant.exn.p, agreeSaid);
 
         const [admit3, sigs3, aend3] = await verifierClient.ipex().admit({
             senderName: verifierAid.name,
             message: '',
-            grantSaid: verifierGrantNote.a.d!,
+            grantSaid: verifierGrantNote.a.d,
             recipient: holderAid.prefix,
             datetime: createTimestamp(),
         });
+        presentationAdmitSaid = admit3.said;
 
         const op = await verifierClient
             .ipex()
@@ -478,6 +528,9 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 holderAid.prefix,
             ]);
         await waitOperation(verifierClient, op);
+        await waitAndMarkNotification(verifierClient, '/exn/ipex/admit', {
+            said: presentationAdmitSaid,
+        });
 
         await markAndRemoveNotification(verifierClient, verifierGrantNote);
 
@@ -488,15 +541,22 @@ test('single signature credentials', { timeout: 90000 }, async () => {
         assert.equal(verifierCredential.sad.s, QVI_SCHEMA_SAID);
         assert.equal(verifierCredential.sad.i, issuerAid.prefix);
         assert.equal(verifierCredential.status.s, '0'); // 0 = issued
+
+        await assertNoNotifications(verifierClient, '/exn/ipex/grant', {
+            said: presentationGrantSaid,
+        });
     });
 
     await step('holder IPEX present response', async () => {
         const holderNotifications = await waitForNotifications(
             holderClient,
-            '/exn/ipex/admit'
+            '/exn/ipex/admit',
+            { said: presentationAdmitSaid }
         );
+        assert.equal(holderNotifications.length, 1);
+        const holderNotification = holderNotifications[0];
 
-        await markAndRemoveNotification(holderClient, holderNotifications[0]);
+        await markAndRemoveNotification(holderClient, holderNotification);
     });
 
     const holderRegistry: { regk: string } = await step(
@@ -571,6 +631,7 @@ test('single signature credentials', { timeout: 90000 }, async () => {
             recipient: legalEntityAid.prefix,
             datetime: dt,
         });
+        leGrantSaid = grant.said;
 
         const op = await holderClient
             .ipex()
@@ -578,22 +639,29 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 legalEntityAid.prefix,
             ]);
         await waitOperation(holderClient, op);
+        await waitAndMarkNotification(holderClient, '/exn/ipex/grant', {
+            said: leGrantSaid,
+        });
     });
 
     await step('Legal Entity IPEX admit', async () => {
-        const notifications = await waitForNotifications(
+        const grantNotifications = await waitForNotifications(
             legalEntityClient,
-            '/exn/ipex/grant'
+            '/exn/ipex/grant',
+            { said: leGrantSaid }
         );
-        const grantNotification = notifications[0];
+        assert.equal(grantNotifications.length, 1);
+        const grantNotification = grantNotifications[0];
+        assert(grantNotification.a.d);
 
         const [admit, sigs, aend] = await legalEntityClient.ipex().admit({
             senderName: legalEntityAid.name,
             message: '',
-            grantSaid: grantNotification.a.d!,
+            grantSaid: grantNotification.a.d,
             recipient: holderAid.prefix,
             datetime: createTimestamp(),
         });
+        leAdmitSaid = admit.said;
 
         const op = await legalEntityClient
             .ipex()
@@ -601,6 +669,9 @@ test('single signature credentials', { timeout: 90000 }, async () => {
                 holderAid.prefix,
             ]);
         await waitOperation(legalEntityClient, op);
+        await waitAndMarkNotification(legalEntityClient, '/exn/ipex/admit', {
+            said: leAdmitSaid,
+        });
 
         await markAndRemoveNotification(legalEntityClient, grantNotification);
     });
@@ -608,9 +679,12 @@ test('single signature credentials', { timeout: 90000 }, async () => {
     await step('LE credential IPEX grant response', async () => {
         const notifications = await waitForNotifications(
             holderClient,
-            '/exn/ipex/admit'
+            '/exn/ipex/admit',
+            { said: leAdmitSaid }
         );
-        await markAndRemoveNotification(holderClient, notifications[0]);
+        assert.equal(notifications.length, 1);
+        const notification = notifications[0];
+        await markAndRemoveNotification(holderClient, notification);
     });
 
     await step('Legal Entity has chained credential', async () => {
@@ -636,6 +710,10 @@ test('single signature credentials', { timeout: 90000 }, async () => {
         };
         assert.equal(firstChain.sad.d, qviCredentialId);
         assert(legalEntityCredential.atc !== undefined);
+
+        await assertNoNotifications(legalEntityClient, '/exn/ipex/grant', {
+            said: leGrantSaid,
+        });
     });
 
     await step('Issuer revoke QVI credential', async () => {

--- a/test-integration/delegation-multisig.test.ts
+++ b/test-integration/delegation-multisig.test.ts
@@ -5,11 +5,11 @@ import {
     assertOperations,
     createAID,
     createTimestamp,
+    assertNoNotifications,
     getOrCreateClient,
     getOrCreateContact,
     markAndRemoveNotification,
     resolveOobi,
-    waitAndMarkNotification,
     waitForNotifications,
     waitOperation,
 } from './utils/test-util.ts';
@@ -182,8 +182,8 @@ test('delegation-multisig', async () => {
                 opList2.map((op) => waitOperation(delegator2Client, op))
             );
 
-            await waitAndMarkNotification(delegator1Client, '/multisig/rpy');
-            await waitAndMarkNotification(delegator2Client, '/multisig/rpy');
+            await assertNoNotifications(delegator1Client, '/multisig/rpy');
+            await assertNoNotifications(delegator2Client, '/multisig/rpy');
 
             const [odelegatorGroupName1, odelegatorGroupName2] =
                 await Promise.all([
@@ -294,7 +294,8 @@ test('delegation-multisig', async () => {
 
         assert.equal(dresult1.response, dresult2.response);
 
-        await waitAndMarkNotification(delegator1Client, '/multisig/ixn');
+        await assertNoNotifications(delegator1Client, '/multisig/ixn');
+        await assertNoNotifications(delegator2Client, '/multisig/ixn');
     });
 
     const queryOp1 = await delegator1Client

--- a/test-integration/multisig-holder.test.ts
+++ b/test-integration/multisig-holder.test.ts
@@ -8,12 +8,13 @@ import signify, {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env.ts';
 import {
+    assertNotifications,
+    assertNoNotifications,
     assertOperations,
     getOrCreateClient,
     getOrCreateIdentifier,
     waitAndMarkNotification,
     waitOperation,
-    warnNotifications,
 } from './utils/test-util.ts';
 import {
     acceptMultisigIncept,
@@ -371,7 +372,7 @@ test('multisig', async function run() {
 
     console.log(`Issuer starting credential issuance to holder...`);
     const registires = await client3.registries().list('issuer');
-    await issueCredential(client3, 'issuer', {
+    const issuedGrantSaid = await issueCredential(client3, 'issuer', {
         ri: registires[0].regk,
         s: SCHEMA_SAID,
         a: {
@@ -383,7 +384,8 @@ test('multisig', async function run() {
 
     const grantMsgSaid = await waitAndMarkNotification(
         client1,
-        '/exn/ipex/grant'
+        '/exn/ipex/grant',
+        { said: issuedGrantSaid }
     );
     console.log(
         `Member1 received /exn/ipex/grant msg with SAID: ${grantMsgSaid} `
@@ -391,18 +393,20 @@ test('multisig', async function run() {
     const exnRes = assertIpexGrant(await client1.exchanges().get(grantMsgSaid));
 
     recp = [aid2['state']].map((state) => state['i']);
-    const exOp1 = await multisigAdmitCredential(
+    const admitResult1 = await multisigAdmitCredential(
         client1,
         'holder',
         'member1',
         exnRes.exn.d,
         exnRes.exn.i,
-        recp
+        recp,
+        true
     );
 
     const grantMsgSaid2 = await waitAndMarkNotification(
         client2,
-        '/exn/ipex/grant'
+        '/exn/ipex/grant',
+        { said: issuedGrantSaid }
     );
     console.log(
         `Member2 received /exn/ipex/grant msg with SAID: ${grantMsgSaid2} `
@@ -416,7 +420,7 @@ test('multisig', async function run() {
     console.log(`Member2 /exn/ipex/grant msg :  ` + JSON.stringify(exnRes2));
 
     const recp2 = [aid1['state']].map((state) => state['i']);
-    const exOp2 = await multisigAdmitCredential(
+    const admitResult2 = await multisigAdmitCredential(
         client2,
         'holder',
         'member2',
@@ -425,8 +429,21 @@ test('multisig', async function run() {
         recp2
     );
 
-    await waitOperation(client1, exOp1);
-    await waitOperation(client2, exOp2);
+    assert.equal(admitResult1.admitSaid, admitResult2.admitSaid);
+
+    await waitOperation(client1, admitResult1.op);
+    await waitOperation(client2, admitResult2.op);
+    await assertNoNotifications(client1, '/multisig/exn');
+    await assertNoNotifications(client2, '/multisig/exn');
+    await waitAndMarkNotification(client1, '/exn/ipex/admit', {
+        said: admitResult1.admitSaid,
+    });
+    await waitAndMarkNotification(client2, '/exn/ipex/admit', {
+        said: admitResult1.admitSaid,
+    });
+    await waitAndMarkNotification(client3, '/exn/ipex/admit', {
+        said: admitResult1.admitSaid,
+    });
 
     let creds1 = await client1.credentials().list();
     console.log(`Member1 has ${creds1.length} credential`);
@@ -448,7 +465,7 @@ test('multisig', async function run() {
     assert.equal(creds1.length, 1);
 
     await assertOperations(client1, client2, client3);
-    await warnNotifications(client1, client2, client3);
+    await assertNotifications(client1, client2, client3);
 }, 360000);
 
 async function createAID(client: SignifyClient, name: string, wits: string[]) {
@@ -478,7 +495,7 @@ async function issueCredential(
     client: SignifyClient,
     name: string,
     data: CredentialData
-) {
+): Promise<string> {
     const result = await client.credentials().issue(name, data);
 
     await waitOperation(client, result.op);
@@ -504,11 +521,15 @@ async function issueCredential(
             .ipex()
             .submitGrant(name, grant, gsigs, end, [data.a.i]);
         await waitOperation(client, op);
+        await waitAndMarkNotification(client, '/exn/ipex/grant', {
+            said: grant.said,
+        });
+        return grant.said;
     }
 
     console.log('Grant message sent');
 
-    return creds[0];
+    return '';
 }
 
 function createTimestamp() {
@@ -522,10 +543,12 @@ async function multisigAdmitCredential(
     memberAlias: string,
     grantSaid: string,
     issuerPrefix: string,
-    recipients: string[]
-): Promise<Operation> {
+    recipients: string[],
+    isInitiator: boolean = false
+): Promise<{ op: Operation; admitSaid: string }> {
     const mHab = await client.identifiers().get(memberAlias);
     const gHab = await client.identifiers().get(groupName);
+    if (!isInitiator) await waitAndMarkNotification(client, '/multisig/exn');
 
     const [admit, sigs, end] = await client.ipex().admit({
         senderName: groupName,
@@ -564,5 +587,5 @@ async function multisigAdmitCredential(
             recipients
         );
 
-    return op;
+    return { op, admitSaid: admit.said };
 }

--- a/test-integration/multisig-vlei-issuance.test.ts
+++ b/test-integration/multisig-vlei-issuance.test.ts
@@ -21,6 +21,7 @@ import {
     waitForCredential,
     admitSinglesig,
     waitAndMarkNotification,
+    assertNoNotifications,
 } from './utils/test-util.ts';
 import {
     addEndRoleMultisig,
@@ -238,8 +239,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientGAR1, multisigAIDOp1),
             waitOperation(clientGAR2, multisigAIDOp2),
         ]);
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/icp');
+        await assertNoNotifications(clientGAR1, '/multisig/icp');
 
         aidGEDAbyGAR1 = await clientGAR1.identifiers().get('GEDA');
         aidGEDAbyGAR2 = await clientGAR2.identifiers().get('GEDA');
@@ -276,8 +276,7 @@ test('multisig-vlei-issuance', async function run() {
 
         await Promise.all(opList1.map((op) => waitOperation(clientGAR1, op)));
         await Promise.all(opList2.map((op) => waitOperation(clientGAR2, op)));
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/rpy');
+        await assertNoNotifications(clientGAR1, '/multisig/rpy');
 
         [oobiGEDAbyGAR1, oobiGEDAbyGAR2] = await Promise.all([
             clientGAR1.oobis().get(aidGEDA.name, 'agent'),
@@ -376,8 +375,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientGAR1, ixnOp1),
             waitOperation(clientGAR2, ixnOp2),
         ]);
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/ixn');
+        await assertNoNotifications(clientGAR1, '/multisig/ixn');
 
         // QARs query the GEDA's key state
         const queryOp1 = await clientQAR1
@@ -398,8 +396,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientQAR2, queryOp2),
             waitOperation(clientQAR3, queryOp3),
         ]);
-
-        await waitAndMarkNotification(clientQAR1, '/multisig/icp');
+        await assertNoNotifications(clientQAR1, '/multisig/icp');
 
         aidQVIbyQAR1 = await clientQAR1.identifiers().get('QVI');
         aidQVIbyQAR2 = await clientQAR2.identifiers().get('QVI');
@@ -454,8 +451,8 @@ test('multisig-vlei-issuance', async function run() {
         await Promise.all(opList2.map((op) => waitOperation(clientQAR2, op)));
         await Promise.all(opList3.map((op) => waitOperation(clientQAR3, op)));
 
-        await waitAndMarkNotification(clientQAR1, '/multisig/rpy');
-        await waitAndMarkNotification(clientQAR2, '/multisig/rpy');
+        await assertNoNotifications(clientQAR1, '/multisig/rpy');
+        await assertNoNotifications(clientQAR2, '/multisig/rpy');
 
         [oobiQVIbyQAR1, oobiQVIbyQAR2, oobiQVIbyQAR3] = await Promise.all([
             clientQAR1.oobis().get(aidQVI.name, 'agent'),
@@ -509,8 +506,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientGAR1, registryOp1),
             waitOperation(clientGAR2, registryOp2),
         ]);
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/vcp');
+        await assertNoNotifications(clientGAR1, '/multisig/vcp');
 
         [gedaRegistrybyGAR1, gedaRegistrybyGAR2] = await Promise.all([
             clientGAR1.registries().list(aidGEDA.name),
@@ -567,8 +563,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientGAR1, IssOp1),
             waitOperation(clientGAR2, IssOp2),
         ]);
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/iss');
+        await assertNoNotifications(clientGAR1, '/multisig/iss');
 
         qviCredbyGAR1 = await getIssuedCredential(
             clientGAR1,
@@ -584,7 +579,7 @@ test('multisig-vlei-issuance', async function run() {
         );
 
         const grantTime = createTimestamp();
-        await grantMultisig(
+        const qviGrantSaid1 = await grantMultisig(
             clientGAR1,
             aidGAR1,
             [aidGAR2],
@@ -594,7 +589,7 @@ test('multisig-vlei-issuance', async function run() {
             grantTime,
             true
         );
-        await grantMultisig(
+        const qviGrantSaid2 = await grantMultisig(
             clientGAR2,
             aidGAR2,
             [aidGAR1],
@@ -603,8 +598,14 @@ test('multisig-vlei-issuance', async function run() {
             qviCredbyGAR2,
             grantTime
         );
-
-        await waitAndMarkNotification(clientGAR1, '/multisig/exn');
+        assert.equal(qviGrantSaid1, qviGrantSaid2);
+        await waitAndMarkNotification(clientGAR1, '/exn/ipex/grant', {
+            said: qviGrantSaid1,
+        });
+        await waitAndMarkNotification(clientGAR2, '/exn/ipex/grant', {
+            said: qviGrantSaid2,
+        });
+        await assertNoNotifications(clientGAR1, '/multisig/exn');
     }
     assert.equal(qviCredbyGAR1.sad.d, qviCredbyGAR2.sad.d);
     assert.equal(qviCredbyGAR1.sad.s, QVI_SCHEMA_SAID);
@@ -631,15 +632,16 @@ test('multisig-vlei-issuance', async function run() {
     let qviCredbyQAR3 = await getReceivedCredential(clientQAR3, qviCred.sad.d);
     if (!(qviCredbyQAR1 && qviCredbyQAR2 && qviCredbyQAR3)) {
         const admitTime = createTimestamp();
-        await admitMultisig(
+        const qviAdmitSaid1 = await admitMultisig(
             clientQAR1,
             aidQAR1,
             [aidQAR2, aidQAR3],
             aidQVI,
             aidGEDA,
-            admitTime
+            admitTime,
+            true
         );
-        await admitMultisig(
+        const qviAdmitSaid2 = await admitMultisig(
             clientQAR2,
             aidQAR2,
             [aidQAR1, aidQAR3],
@@ -647,7 +649,7 @@ test('multisig-vlei-issuance', async function run() {
             aidGEDA,
             admitTime
         );
-        await admitMultisig(
+        const qviAdmitSaid3 = await admitMultisig(
             clientQAR3,
             aidQAR3,
             [aidQAR1, aidQAR2],
@@ -655,14 +657,26 @@ test('multisig-vlei-issuance', async function run() {
             aidGEDA,
             admitTime
         );
-        await waitAndMarkNotification(clientGAR1, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientGAR2, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientQAR1, '/multisig/exn');
-        await waitAndMarkNotification(clientQAR2, '/multisig/exn');
-        await waitAndMarkNotification(clientQAR3, '/multisig/exn');
-        await waitAndMarkNotification(clientQAR1, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientQAR2, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientQAR3, '/exn/ipex/admit');
+        assert.equal(qviAdmitSaid1, qviAdmitSaid2);
+        assert.equal(qviAdmitSaid1, qviAdmitSaid3);
+        await waitAndMarkNotification(clientGAR1, '/exn/ipex/admit', {
+            said: qviAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientGAR2, '/exn/ipex/admit', {
+            said: qviAdmitSaid1,
+        });
+        await assertNoNotifications(clientQAR1, '/multisig/exn');
+        await assertNoNotifications(clientQAR2, '/multisig/exn');
+        await assertNoNotifications(clientQAR3, '/multisig/exn');
+        await waitAndMarkNotification(clientQAR1, '/exn/ipex/admit', {
+            said: qviAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientQAR2, '/exn/ipex/admit', {
+            said: qviAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientQAR3, '/exn/ipex/admit', {
+            said: qviAdmitSaid1,
+        });
 
         qviCredbyQAR1 = await waitForCredential(clientQAR1, qviCred.sad.d);
         qviCredbyQAR2 = await waitForCredential(clientQAR2, qviCred.sad.d);
@@ -724,8 +738,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientLAR2, multisigAIDOp2),
             waitOperation(clientLAR3, multisigAIDOp3),
         ]);
-
-        await waitAndMarkNotification(clientLAR1, '/multisig/icp');
+        await assertNoNotifications(clientLAR1, '/multisig/icp');
 
         aidLEbyLAR1 = await clientLAR1.identifiers().get('LE');
         aidLEbyLAR2 = await clientLAR2.identifiers().get('LE');
@@ -780,8 +793,8 @@ test('multisig-vlei-issuance', async function run() {
         await Promise.all(opList2.map((op) => waitOperation(clientLAR2, op)));
         await Promise.all(opList3.map((op) => waitOperation(clientLAR3, op)));
 
-        await waitAndMarkNotification(clientLAR1, '/multisig/rpy');
-        await waitAndMarkNotification(clientLAR2, '/multisig/rpy');
+        await assertNoNotifications(clientLAR1, '/multisig/rpy');
+        await assertNoNotifications(clientLAR2, '/multisig/rpy');
 
         [oobiLEbyLAR1, oobiLEbyLAR2, oobiLEbyLAR3] = await Promise.all([
             clientLAR1.oobis().get(aidLE.name, 'agent'),
@@ -848,8 +861,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientQAR2, registryOp2),
             waitOperation(clientQAR3, registryOp3),
         ]);
-
-        await waitAndMarkNotification(clientQAR1, '/multisig/vcp');
+        await assertNoNotifications(clientQAR1, '/multisig/vcp');
 
         [qviRegistrybyQAR1, qviRegistrybyQAR2, qviRegistrybyQAR3] =
             await Promise.all([
@@ -934,8 +946,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientQAR2, IssOp2),
             waitOperation(clientQAR3, IssOp3),
         ]);
-
-        await waitAndMarkNotification(clientQAR1, '/multisig/iss');
+        await assertNoNotifications(clientQAR1, '/multisig/iss');
 
         leCredbyQAR1 = await getIssuedCredential(
             clientQAR1,
@@ -957,7 +968,7 @@ test('multisig-vlei-issuance', async function run() {
         );
 
         const grantTime = createTimestamp();
-        await grantMultisig(
+        const leGrantSaid1 = await grantMultisig(
             clientQAR1,
             aidQAR1,
             [aidQAR2, aidQAR3],
@@ -967,7 +978,7 @@ test('multisig-vlei-issuance', async function run() {
             grantTime,
             true
         );
-        await grantMultisig(
+        const leGrantSaid2 = await grantMultisig(
             clientQAR2,
             aidQAR2,
             [aidQAR1, aidQAR3],
@@ -976,7 +987,7 @@ test('multisig-vlei-issuance', async function run() {
             leCredbyQAR2,
             grantTime
         );
-        await grantMultisig(
+        const leGrantSaid3 = await grantMultisig(
             clientQAR3,
             aidQAR3,
             [aidQAR1, aidQAR2],
@@ -985,8 +996,18 @@ test('multisig-vlei-issuance', async function run() {
             leCredbyQAR3,
             grantTime
         );
-
-        await waitAndMarkNotification(clientQAR1, '/multisig/exn');
+        assert.equal(leGrantSaid1, leGrantSaid2);
+        assert.equal(leGrantSaid1, leGrantSaid3);
+        await waitAndMarkNotification(clientQAR1, '/exn/ipex/grant', {
+            said: leGrantSaid1,
+        });
+        await waitAndMarkNotification(clientQAR2, '/exn/ipex/grant', {
+            said: leGrantSaid1,
+        });
+        await waitAndMarkNotification(clientQAR3, '/exn/ipex/grant', {
+            said: leGrantSaid1,
+        });
+        await assertNoNotifications(clientQAR1, '/multisig/exn');
     }
     assert.equal(leCredbyQAR1.sad.d, leCredbyQAR2.sad.d);
     assert.equal(leCredbyQAR1.sad.d, leCredbyQAR3.sad.d);
@@ -1012,15 +1033,16 @@ test('multisig-vlei-issuance', async function run() {
     let leCredbyLAR3 = await getReceivedCredential(clientLAR3, leCred.sad.d);
     if (!(leCredbyLAR1 && leCredbyLAR2 && leCredbyLAR3)) {
         const admitTime = createTimestamp();
-        await admitMultisig(
+        const leAdmitSaid1 = await admitMultisig(
             clientLAR1,
             aidLAR1,
             [aidLAR2, aidLAR3],
             aidLE,
             aidQVI,
-            admitTime
+            admitTime,
+            true
         );
-        await admitMultisig(
+        const leAdmitSaid2 = await admitMultisig(
             clientLAR2,
             aidLAR2,
             [aidLAR1, aidLAR3],
@@ -1028,7 +1050,7 @@ test('multisig-vlei-issuance', async function run() {
             aidQVI,
             admitTime
         );
-        await admitMultisig(
+        const leAdmitSaid3 = await admitMultisig(
             clientLAR3,
             aidLAR3,
             [aidLAR1, aidLAR2],
@@ -1036,15 +1058,29 @@ test('multisig-vlei-issuance', async function run() {
             aidQVI,
             admitTime
         );
-        await waitAndMarkNotification(clientQAR1, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientQAR2, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientQAR3, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientLAR1, '/multisig/exn');
-        await waitAndMarkNotification(clientLAR2, '/multisig/exn');
-        await waitAndMarkNotification(clientLAR3, '/multisig/exn');
-        await waitAndMarkNotification(clientLAR1, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientLAR2, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientLAR3, '/exn/ipex/admit');
+        assert.equal(leAdmitSaid1, leAdmitSaid2);
+        assert.equal(leAdmitSaid1, leAdmitSaid3);
+        await waitAndMarkNotification(clientQAR1, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientQAR2, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientQAR3, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
+        await assertNoNotifications(clientLAR1, '/multisig/exn');
+        await assertNoNotifications(clientLAR2, '/multisig/exn');
+        await assertNoNotifications(clientLAR3, '/multisig/exn');
+        await waitAndMarkNotification(clientLAR1, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientLAR2, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
+        await waitAndMarkNotification(clientLAR3, '/exn/ipex/admit', {
+            said: leAdmitSaid1,
+        });
 
         leCredbyLAR1 = await waitForCredential(clientLAR1, leCred.sad.d);
         leCredbyLAR2 = await waitForCredential(clientLAR2, leCred.sad.d);
@@ -1099,8 +1135,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientLAR2, registryOp2),
             waitOperation(clientLAR3, registryOp3),
         ]);
-
-        await waitAndMarkNotification(clientLAR1, '/multisig/vcp');
+        await assertNoNotifications(clientLAR1, '/multisig/vcp');
 
         [leRegistrybyLAR1, leRegistrybyLAR2, leRegistrybyLAR3] =
             await Promise.all([
@@ -1189,8 +1224,7 @@ test('multisig-vlei-issuance', async function run() {
             waitOperation(clientLAR2, IssOp2),
             waitOperation(clientLAR3, IssOp3),
         ]);
-
-        await waitAndMarkNotification(clientLAR1, '/multisig/iss');
+        await assertNoNotifications(clientLAR1, '/multisig/iss');
 
         ecrCredbyLAR1 = await getIssuedCredential(
             clientLAR1,
@@ -1212,7 +1246,7 @@ test('multisig-vlei-issuance', async function run() {
         );
 
         const grantTime = createTimestamp();
-        await grantMultisig(
+        const ecrGrantSaid1 = await grantMultisig(
             clientLAR1,
             aidLAR1,
             [aidLAR2, aidLAR3],
@@ -1222,7 +1256,7 @@ test('multisig-vlei-issuance', async function run() {
             grantTime,
             true
         );
-        await grantMultisig(
+        const ecrGrantSaid2 = await grantMultisig(
             clientLAR2,
             aidLAR2,
             [aidLAR1, aidLAR3],
@@ -1231,7 +1265,7 @@ test('multisig-vlei-issuance', async function run() {
             ecrCredbyLAR2,
             grantTime
         );
-        await grantMultisig(
+        const ecrGrantSaid3 = await grantMultisig(
             clientLAR3,
             aidLAR3,
             [aidLAR1, aidLAR2],
@@ -1240,8 +1274,18 @@ test('multisig-vlei-issuance', async function run() {
             ecrCredbyLAR3,
             grantTime
         );
-
-        await waitAndMarkNotification(clientLAR1, '/multisig/exn');
+        assert.equal(ecrGrantSaid1, ecrGrantSaid2);
+        assert.equal(ecrGrantSaid1, ecrGrantSaid3);
+        await waitAndMarkNotification(clientLAR1, '/exn/ipex/grant', {
+            said: ecrGrantSaid1,
+        });
+        await waitAndMarkNotification(clientLAR2, '/exn/ipex/grant', {
+            said: ecrGrantSaid1,
+        });
+        await waitAndMarkNotification(clientLAR3, '/exn/ipex/grant', {
+            said: ecrGrantSaid1,
+        });
+        await assertNoNotifications(clientLAR1, '/multisig/exn');
     }
     assert.equal(ecrCredbyLAR1.sad.d, ecrCredbyLAR2.sad.d);
     assert.equal(ecrCredbyLAR1.sad.d, ecrCredbyLAR3.sad.d);
@@ -1267,10 +1311,23 @@ test('multisig-vlei-issuance', async function run() {
     // Skip if ECR Person has already received the credential.
     let ecrCredbyECR = await getReceivedCredential(clientECR, ecrCred.sad.d);
     if (!ecrCredbyECR) {
-        await admitSinglesig(clientECR, aidECR.name, aidLE);
-        await waitAndMarkNotification(clientLAR1, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientLAR2, '/exn/ipex/admit');
-        await waitAndMarkNotification(clientLAR3, '/exn/ipex/admit');
+        const ecrAdmitSaid = await admitSinglesig(
+            clientECR,
+            aidECR.name,
+            aidLE
+        );
+        await waitAndMarkNotification(clientECR, '/exn/ipex/admit', {
+            said: ecrAdmitSaid,
+        });
+        await waitAndMarkNotification(clientLAR1, '/exn/ipex/admit', {
+            said: ecrAdmitSaid,
+        });
+        await waitAndMarkNotification(clientLAR2, '/exn/ipex/admit', {
+            said: ecrAdmitSaid,
+        });
+        await waitAndMarkNotification(clientLAR3, '/exn/ipex/admit', {
+            said: ecrAdmitSaid,
+        });
 
         ecrCredbyECR = await waitForCredential(clientECR, ecrCred.sad.d);
     }

--- a/test-integration/multisig.test.ts
+++ b/test-integration/multisig.test.ts
@@ -18,12 +18,13 @@ import {
 } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env.ts';
 import {
+    assertNotifications,
+    assertNoNotifications,
     assertOperations,
     getOrCreateClient,
     getOrCreateIdentifier,
     waitAndMarkNotification,
     waitOperation,
-    warnNotifications,
 } from './utils/test-util.ts';
 
 const { vleiServerUrl } = resolveEnvironment();
@@ -1122,7 +1123,25 @@ test('multisig', async function run() {
 
     console.log('Member3 joined grant message, waiting for others to join...');
 
-    msgSaid = await waitAndMarkNotification(client4, '/exn/ipex/grant');
+    assert.equal(grant.said, grant2.said);
+    assert.equal(grant.said, grant3.said);
+    await waitAndMarkNotification(client1, '/exn/ipex/grant', {
+        said: grant.said,
+    });
+    await waitAndMarkNotification(client2, '/exn/ipex/grant', {
+        said: grant.said,
+    });
+    await waitAndMarkNotification(client3, '/exn/ipex/grant', {
+        said: grant.said,
+    });
+
+    await assertNoNotifications(client1, '/multisig/exn');
+    await assertNoNotifications(client2, '/multisig/exn');
+    await assertNoNotifications(client3, '/multisig/exn');
+
+    msgSaid = await waitAndMarkNotification(client4, '/exn/ipex/grant', {
+        said: grant.said,
+    });
     console.log('Holder received exchange message with the grant message');
 
     const exchangeResource = await client4.exchanges().get(msgSaid);
@@ -1137,6 +1156,9 @@ test('multisig', async function run() {
     const exOp4 = await client4
         .ipex()
         .submitAdmit('holder', admit, asigs, aend, [m['prefix']]);
+    await waitAndMarkNotification(client4, '/exn/ipex/admit', {
+        said: admit.said,
+    });
 
     await Promise.all([
         waitOperation(client1, exOp1),
@@ -1147,13 +1169,21 @@ test('multisig', async function run() {
 
     console.log('Holder creates and sends admit message');
 
-    msgSaid = await waitAndMarkNotification(client1, '/exn/ipex/admit');
+    msgSaid = await waitAndMarkNotification(client1, '/exn/ipex/admit', {
+        said: admit.said,
+    });
+    await assertNoNotifications(client2, '/exn/ipex/admit', {
+        said: admit.said,
+    });
+    await assertNoNotifications(client3, '/exn/ipex/admit', {
+        said: admit.said,
+    });
     console.log('Member1 received exchange message with the admit response');
     const creds = await client4.credentials().list();
     console.log(`Holder holds ${creds.length} credential`);
 
     await assertOperations(client1, client2, client3, client4);
-    await warnNotifications(client1, client2, client3, client4);
+    await assertNotifications(client1, client2, client3, client4);
 
     console.log('Revoking credential...');
     const REVTIME = new Date().toISOString().replace('Z', '000+00:00');

--- a/test-integration/singlesig-vlei-issuance.test.ts
+++ b/test-integration/singlesig-vlei-issuance.test.ts
@@ -3,6 +3,7 @@ import { Saider, Serder, SignifyClient } from 'signify-ts';
 import { resolveEnvironment } from './utils/resolve-env.ts';
 import {
     Aid,
+    assertNotifications,
     assertOperations,
     createAid,
     getOrCreateClients,
@@ -10,10 +11,11 @@ import {
     getOrIssueCredential,
     getReceivedCredential,
     markAndRemoveNotification,
+    type Notification,
     resolveOobi,
+    waitAndMarkNotification,
     waitForNotifications,
     waitOperation,
-    warnNotifications,
 } from './utils/test-util.ts';
 import { retry } from './utils/retry.ts';
 
@@ -183,8 +185,26 @@ test('singlesig-vlei-issuance', async function run() {
     let qviCredHolder = await getReceivedCredential(qviClient, qviCred.sad.d);
 
     if (!qviCredHolder) {
-        await sendGrantMessage(gleifClient, gleifAid, qviAid, qviCred);
-        await sendAdmitMessage(qviClient, qviAid, gleifAid);
+        const qviGrantSaid = await sendGrantMessage(
+            gleifClient,
+            gleifAid,
+            qviAid,
+            qviCred
+        );
+        const qviGrantNotifications = await waitForGrantNotificationsCount(
+            qviClient,
+            qviGrantSaid,
+            1
+        );
+        const qviAdmitSaid = await sendAdmitMessage(
+            qviClient,
+            qviAid,
+            gleifAid,
+            qviGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(gleifClient, '/exn/ipex/admit', {
+            said: qviAdmitSaid,
+        });
 
         qviCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(qviClient, qviCred.sad.d);
@@ -223,8 +243,26 @@ test('singlesig-vlei-issuance', async function run() {
     let leCredHolder = await getReceivedCredential(leClient, leCred.sad.d);
 
     if (!leCredHolder) {
-        await sendGrantMessage(qviClient, qviAid, leAid, leCred);
-        await sendAdmitMessage(leClient, leAid, qviAid);
+        const leGrantSaid = await sendGrantMessage(
+            qviClient,
+            qviAid,
+            leAid,
+            leCred
+        );
+        const leGrantNotifications = await waitForGrantNotificationsCount(
+            leClient,
+            leGrantSaid,
+            1
+        );
+        const leAdmitSaid = await sendAdmitMessage(
+            leClient,
+            leAid,
+            qviAid,
+            leGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(qviClient, '/exn/ipex/admit', {
+            said: leAdmitSaid,
+        });
 
         leCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(leClient, leCred.sad.d);
@@ -265,8 +303,26 @@ test('singlesig-vlei-issuance', async function run() {
     let ecrCredHolder = await getReceivedCredential(roleClient, ecrCred.sad.d);
 
     if (!ecrCredHolder) {
-        await sendGrantMessage(leClient, leAid, roleAid, ecrCred);
-        await sendAdmitMessage(roleClient, roleAid, leAid);
+        const ecrGrantSaid = await sendGrantMessage(
+            leClient,
+            leAid,
+            roleAid,
+            ecrCred
+        );
+        const roleGrantNotifications = await waitForGrantNotificationsCount(
+            roleClient,
+            ecrGrantSaid,
+            1
+        );
+        const ecrAdmitSaid = await sendAdmitMessage(
+            roleClient,
+            roleAid,
+            leAid,
+            roleGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(leClient, '/exn/ipex/admit', {
+            said: ecrAdmitSaid,
+        });
 
         ecrCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(roleClient, ecrCred.sad.d);
@@ -310,8 +366,26 @@ test('singlesig-vlei-issuance', async function run() {
     );
 
     if (!ecrAuthCredHolder) {
-        await sendGrantMessage(leClient, leAid, qviAid, ecrAuthCred);
-        await sendAdmitMessage(qviClient, qviAid, leAid);
+        const ecrAuthGrantSaid = await sendGrantMessage(
+            leClient,
+            leAid,
+            qviAid,
+            ecrAuthCred
+        );
+        const qviGrantNotifications = await waitForGrantNotificationsCount(
+            qviClient,
+            ecrAuthGrantSaid,
+            1
+        );
+        const ecrAuthAdmitSaid = await sendAdmitMessage(
+            qviClient,
+            qviAid,
+            leAid,
+            qviGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(leClient, '/exn/ipex/admit', {
+            said: ecrAuthAdmitSaid,
+        });
 
         ecrAuthCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(
@@ -360,8 +434,26 @@ test('singlesig-vlei-issuance', async function run() {
     );
 
     if (!ecrCredHolder2) {
-        await sendGrantMessage(qviClient, qviAid, roleAid, ecrCred2);
-        await sendAdmitMessage(roleClient, roleAid, qviAid);
+        const ecrGrantSaid2 = await sendGrantMessage(
+            qviClient,
+            qviAid,
+            roleAid,
+            ecrCred2
+        );
+        const roleGrantNotifications = await waitForGrantNotificationsCount(
+            roleClient,
+            ecrGrantSaid2,
+            1
+        );
+        const ecrAdmitSaid2 = await sendAdmitMessage(
+            roleClient,
+            roleAid,
+            qviAid,
+            roleGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(qviClient, '/exn/ipex/admit', {
+            said: ecrAdmitSaid2,
+        });
 
         ecrCredHolder2 = await retry(async () => {
             const cred = await getReceivedCredential(
@@ -407,8 +499,26 @@ test('singlesig-vlei-issuance', async function run() {
     );
 
     if (!oorAuthCredHolder) {
-        await sendGrantMessage(leClient, leAid, qviAid, oorAuthCred);
-        await sendAdmitMessage(qviClient, qviAid, leAid);
+        const oorAuthGrantSaid = await sendGrantMessage(
+            leClient,
+            leAid,
+            qviAid,
+            oorAuthCred
+        );
+        const qviGrantNotifications = await waitForGrantNotificationsCount(
+            qviClient,
+            oorAuthGrantSaid,
+            1
+        );
+        const oorAuthAdmitSaid = await sendAdmitMessage(
+            qviClient,
+            qviAid,
+            leAid,
+            qviGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(leClient, '/exn/ipex/admit', {
+            said: oorAuthAdmitSaid,
+        });
 
         oorAuthCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(
@@ -453,8 +563,26 @@ test('singlesig-vlei-issuance', async function run() {
     let oorCredHolder = await getReceivedCredential(roleClient, oorCred.sad.d);
 
     if (!oorCredHolder) {
-        await sendGrantMessage(qviClient, qviAid, roleAid, oorCred);
-        await sendAdmitMessage(roleClient, roleAid, qviAid);
+        const oorGrantSaid = await sendGrantMessage(
+            qviClient,
+            qviAid,
+            roleAid,
+            oorCred
+        );
+        const roleGrantNotifications = await waitForGrantNotificationsCount(
+            roleClient,
+            oorGrantSaid,
+            1
+        );
+        const oorAdmitSaid = await sendAdmitMessage(
+            roleClient,
+            roleAid,
+            qviAid,
+            roleGrantNotifications.at(-1)!
+        );
+        await waitAndMarkNotification(qviClient, '/exn/ipex/admit', {
+            said: oorAdmitSaid,
+        });
 
         oorCredHolder = await retry(async () => {
             const cred = await getReceivedCredential(roleClient, oorCred.sad.d);
@@ -471,7 +599,7 @@ test('singlesig-vlei-issuance', async function run() {
     assert(oorCredHolder.atc !== undefined);
 
     await assertOperations(gleifClient, qviClient, leClient, roleClient);
-    await warnNotifications(gleifClient, qviClient, leClient, roleClient);
+    await assertNotifications(gleifClient, qviClient, leClient, roleClient);
 }, 360000);
 
 async function getOrCreateRegistry(
@@ -497,7 +625,7 @@ async function sendGrantMessage(
     senderAid: Aid,
     recipientAid: Aid,
     credential: any
-) {
+): Promise<string> {
     const [grant, gsigs, gend] = await senderClient.ipex().grant({
         senderName: senderAid.name,
         acdc: new Serder(credential.sad),
@@ -512,20 +640,36 @@ async function sendGrantMessage(
         .ipex()
         .submitGrant(senderAid.name, grant, gsigs, gend, [recipientAid.prefix]);
     await waitOperation(senderClient, op);
+
+    await waitAndMarkNotification(senderClient, '/exn/ipex/grant', {
+        said: grant.said,
+    });
+
+    return grant.said;
+}
+
+async function waitForGrantNotificationsCount(
+    client: SignifyClient,
+    said: string,
+    expectedCount: number
+): Promise<Notification[]> {
+    return retry(async () => {
+        const notifications = await waitForNotifications(
+            client,
+            '/exn/ipex/grant',
+            { said }
+        );
+        assert.equal(notifications.length, expectedCount);
+        return notifications;
+    }, CRED_RETRY_DEFAULTS);
 }
 
 async function sendAdmitMessage(
     senderClient: SignifyClient,
     senderAid: Aid,
-    recipientAid: Aid
-) {
-    const notifications = await waitForNotifications(
-        senderClient,
-        '/exn/ipex/grant'
-    );
-    assert.equal(notifications.length, 1);
-    const grantNotification = notifications[0];
-
+    recipientAid: Aid,
+    grantNotification: Notification
+): Promise<string> {
     const [admit, sigs, aend] = await senderClient.ipex().admit({
         senderName: senderAid.name,
         message: '',
@@ -539,5 +683,11 @@ async function sendAdmitMessage(
         .submitAdmit(senderAid.name, admit, sigs, aend, [recipientAid.prefix]);
     await waitOperation(senderClient, op);
 
+    await waitAndMarkNotification(senderClient, '/exn/ipex/admit', {
+        said: admit.said,
+    });
+
     await markAndRemoveNotification(senderClient, grantNotification);
+
+    return admit.said;
 }

--- a/test-integration/utils/multisig-utils.ts
+++ b/test-integration/utils/multisig-utils.ts
@@ -95,11 +95,16 @@ export async function addEndRoleMultisig(
     timestamp: string,
     isInitiator: boolean = false
 ) {
-    if (!isInitiator) await waitAndMarkNotification(client, '/multisig/rpy');
-
     const opList: any[] = [];
     const members = await client.identifiers().members(multisigAID.name);
     const signings = members['signing'];
+    // there should be a notification to mark per multisig member since each
+    // member will send /multisig/rpy exn messages per-member to each other member.
+    if (!isInitiator) {
+        await waitAndMarkNotification(client, '/multisig/rpy', {
+            minCount: signings.length,
+        });
+    }
 
     for (const signing of signings) {
         const agentEnds = signing.ends.agent;
@@ -157,9 +162,12 @@ export async function admitMultisig(
     otherMembersAIDs: HabState[],
     multisigAID: HabState,
     recipientAID: HabState,
-    timestamp: string
+    timestamp: string,
+    isInitiator: boolean = false
     // numGrantMsgs: number
-) {
+): Promise<string> {
+    if (!isInitiator) await waitAndMarkNotification(client, '/multisig/exn');
+
     const grantMsgSaid = await waitAndMarkNotification(
         client,
         '/exn/ipex/grant'
@@ -202,6 +210,8 @@ export async function admitMultisig(
             gembeds,
             recp
         );
+
+    return admit.said;
 }
 
 export async function createAIDMultisig(
@@ -369,7 +379,7 @@ export async function grantMultisig(
     credential: any,
     timestamp: string,
     isInitiator: boolean = false
-) {
+): Promise<string> {
     if (!isInitiator) await waitAndMarkNotification(client, '/multisig/exn');
 
     const [grant, sigs, end] = await client.ipex().grant({
@@ -410,6 +420,8 @@ export async function grantMultisig(
             gembeds,
             recp
         );
+
+    return grant.said;
 }
 
 export async function issueCredentialMultisig(

--- a/test-integration/utils/test-util.ts
+++ b/test-integration/utils/test-util.ts
@@ -41,7 +41,6 @@ import signify, {
 import { RetryOptions, retry } from './retry.ts';
 import assert from 'assert';
 import { resolveEnvironment } from './resolve-env.ts';
-import { expect } from 'vitest';
 
 export interface Aid {
     name: string;
@@ -56,6 +55,29 @@ export interface Notification {
     a: { r: string; d?: string; m?: string };
 }
 
+export interface NotificationOptions extends RetryOptions {
+    said?: string;
+    minCount?: number;
+}
+
+function matchesNotification(
+    note: Notification,
+    route: string,
+    said?: string
+): boolean {
+    return (
+        note.a.r === route &&
+        note.r === false &&
+        (said === undefined || note.a.d === said)
+    );
+}
+
+function notificationFilterDescription(route: string, said?: string): string {
+    return said === undefined
+        ? `route ${route}`
+        : `route ${route} and SAID ${said}`;
+}
+
 export function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => {
         setTimeout(resolve, ms);
@@ -66,7 +88,7 @@ export async function admitSinglesig(
     client: SignifyClient,
     aidName: string,
     recipientAid: HabState
-) {
+): Promise<string> {
     const grantMsgSaid = await waitAndMarkNotification(
         client,
         '/exn/ipex/grant'
@@ -79,9 +101,12 @@ export async function admitSinglesig(
         recipient: recipientAid.prefix,
     });
 
-    await client
+    const op = await client
         .ipex()
         .submitAdmit(aidName, admit, sigs, aend, [recipientAid.prefix]);
+    await waitOperation(client, op);
+
+    return admit.said;
 }
 
 /**
@@ -107,11 +132,36 @@ export async function assertOperations(
 export async function assertNotifications(
     ...clients: SignifyClient[]
 ): Promise<void> {
-    for (const client of clients) {
+    for (const [index, client] of clients.entries()) {
         const res = await client.notifications().list();
         const notes = res.notes.filter((i: { r: boolean }) => i.r === false);
-        assert.strictEqual(notes.length, 0);
+        assert.strictEqual(
+            notes.length,
+            0,
+            `Unread notifications remain for client ${index}: ${JSON.stringify(notes)}`
+        );
     }
+}
+
+export async function assertNoNotifications(
+    client: SignifyClient,
+    route: string,
+    options: Pick<NotificationOptions, 'said'> = {}
+): Promise<void> {
+    const response: { notes: Notification[] } = await client
+        .notifications()
+        .list();
+    const notes = response.notes.filter((note) =>
+        matchesNotification(note, route, options.said)
+    );
+    assert.strictEqual(
+        notes.length,
+        0,
+        `Unexpected unread notifications with ${notificationFilterDescription(
+            route,
+            options.said
+        )}: ${JSON.stringify(notes)}`
+    );
 }
 
 export async function createAid(
@@ -401,26 +451,6 @@ export async function hasEndRole(
     return false;
 }
 
-/**
- * Logs a warning for each un-handled notification.
- * <p>Replace warnNotifications with assertNotifications when test handles all notifications
- * @see assertNotifications
- */
-export async function warnNotifications(
-    ...clients: SignifyClient[]
-): Promise<void> {
-    let count = 0;
-    for (const client of clients) {
-        const res = await client.notifications().list();
-        const notes = res.notes.filter((i: { r: boolean }) => i.r === false);
-        if (notes.length > 0) {
-            count += notes.length;
-            console.warn('notifications', notes);
-        }
-    }
-    expect(count).toBeGreaterThan(0); // replace warnNotifications with assertNotifications
-}
-
 async function deleteOperations(client: SignifyClient, op: Operation) {
     if (op.metadata && 'depends' in op.metadata && op.metadata.depends) {
         await deleteOperations(client, op.metadata.depends);
@@ -499,7 +529,7 @@ export async function waitForCredential(
 export async function waitAndMarkNotification(
     client: SignifyClient,
     route: string,
-    options: RetryOptions = {}
+    options: NotificationOptions = {}
 ) {
     const notes = await waitForNotifications(client, route, options);
 
@@ -515,19 +545,25 @@ export async function waitAndMarkNotification(
 export async function waitForNotifications(
     client: SignifyClient,
     route: string,
-    options: RetryOptions = {}
+    options: NotificationOptions = {}
 ): Promise<Notification[]> {
     return retry(async () => {
         const response: { notes: Notification[] } = await client
             .notifications()
             .list();
 
-        const notes = response.notes.filter(
-            (note) => note.a.r === route && note.r === false
+        const notes = response.notes.filter((note) =>
+            matchesNotification(note, route, options.said)
         );
 
-        if (!notes.length) {
-            throw new Error(`No notifications with route ${route}`);
+        const minCount = options.minCount ?? 1;
+        if (notes.length < minCount) {
+            throw new Error(
+                `No notifications with ${notificationFilterDescription(
+                    route,
+                    options.said
+                )}; expected at least ${minCount}, got ${notes.length}`
+            );
         }
 
         return notes;


### PR DESCRIPTION
- Fixes the docker compose file to use "keria" rather than "agent" as the agency name.
- Upgrades to KERIA 0.4.0 for the docker compose file, and KERIpy 1.2.13 for witnesses

Cleans up multisig notification expectations during notification wait loops by making them strict according to the following rules:
- `/multisig/exn` or other `/multisig/*` messages should only ever create notifications for non-initiators. 
  - Prior to #401 then `hby.exc`, the default exchanger, only had generic Exchanger behavior for EXNs submitted through `/identifiers/{name}/exchanges` which did not deduplicate coordination notifications.
  - The important changes are:
    - `/multisig/exn` notifications are now deduplicated since Multiplexor records it as approved/submitted and dedupes it.
    - `/multisig/exn` messages are properly indexed so they are searchable by the edge client.
    - This changed from 0.2.0-rc2 to 0.4.0 because #401, correctly routed Exchange messages to the Agent's exchanger (`agent.exc`), and eventually to the `Multiplexor.add` function, which deduplicates exn notifications by source/sender being local or not.
- `assertNoNotifications` added to make explicit when notifications should not be present. This shapes our integration tests around the specific notification behavior of KERIpy and KERIA so we know when something changes.
- `NotificationOptions` extends RetryOptions with `said` to support specific retrieval of exn messages by send for consistent notification selection during IPEX Grant operations and `minCount` to support batch handling of `/multisig/rpy` notifications for endpoint role notification handling.
- `matchesNotification` to clean up notification filter reuse after adding `said` to the filter.


