### PR TITLE
refactor: clean up equality checks and docs

### DIFF
--- a/src/keri/core/signer.ts
+++ b/src/keri/core/signer.ts
@@ -10,28 +10,68 @@ import { Siger } from './siger.ts';
 import { IdrDex } from './indexer.ts';
 import { concat } from './core.ts';
 
-/**
- * @description Signer is Matter subclass with method to create signature of serialization
- * It will use .raw as signing (private) key seed
- * .code as cipher suite for signing and new property .verfer whose property
- *  .raw is public key for signing.
- *  If not provided .verfer is generated from private key seed using .code
- as cipher suite for creating key-pair.
- */
 interface SignerArgs {
+    /** Raw private signing seed bytes. */
     raw?: Uint8Array | undefined;
+
+    /**
+     * CESR signer seed derivation code.
+     *
+     * Defaults to `MtrDex.Ed25519_Seed`.
+     */
     code?: string;
+
+    /** Fully qualified seed material as Base64 bytes, interpreted by `Matter`. */
     qb64b?: Uint8Array | undefined;
+
+    /** Fully qualified seed material as a Base64 string, interpreted by `Matter`. */
     qb64?: string;
+
+    /** Fully qualified seed material as binary CESR bytes, interpreted by `Matter`. */
     qb2?: Uint8Array | undefined;
+
+    /**
+     * Whether the derived verifier should use a transferable verifier code.
+     *
+     * This controls `verfer.code`; the signer seed code itself does not encode
+     * transferability.
+     */
     transferable?: boolean;
 }
 
+/*
+ * Signing function interface
+ */
+type SignFn = (
+        ser: Uint8Array,
+        seed: Uint8Array,
+        verfer: Verfer,
+        index: number | null,
+        only: boolean,
+        ondex: number | undefined
+    ) => Siger | Cigar;
+
+/**
+ * Private signing seed material with suite-specific signing behavior.
+ *
+ * `Signer` stores the qualified seed material inherited from `Matter`, derives
+ * a matching `Verfer`, and signs byte serializations. This implementation
+ * currently supports Ed25519 seed material.
+ */
 export class Signer extends Matter {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-    private readonly _sign: Function;
+    /** Suite-specific signing function selected from the signer seed code. */
+    private readonly _sign: SignFn;
     private readonly _verfer: Verfer;
 
+    /**
+     * Create a signer from raw or fully qualified seed material.
+     *
+     * When no seed material is supplied, an Ed25519 seed is generated randomly.
+     * The derived verifier uses a transferable or non-transferable verifier code
+     * based on `transferable`.
+     *
+     * @throws Error if `code` or the decoded seed code is unsupported.
+     */
     constructor({
         raw,
         code = MtrDex.Ed25519_Seed,
@@ -44,7 +84,7 @@ export class Signer extends Matter {
             super({ raw, code, qb64, qb64b, qb2 });
         } catch (e) {
             if (e instanceof EmptyMaterialError) {
-                if (code == MtrDex.Ed25519_Seed) {
+                if (code === MtrDex.Ed25519_Seed) {
                     const raw = libsodium.randombytes_buf(
                         libsodium.crypto_sign_SEEDBYTES
                     );
@@ -57,7 +97,7 @@ export class Signer extends Matter {
             }
         }
         let verfer;
-        if (this.code == MtrDex.Ed25519_Seed) {
+        if (this.code === MtrDex.Ed25519_Seed) {
             this._sign = this._ed25519;
             const keypair = libsodium.crypto_sign_seed_keypair(this.raw);
             verfer = new Verfer({
@@ -72,14 +112,32 @@ export class Signer extends Matter {
     }
 
     /**
-     * @description Property verfer:
-     Returns Verfer instance
-     Assumes ._verfer is correctly assigned
+     * Public verifier derived from this signer's seed.
+     *
+     * `verfer.raw` is the public verification key corresponding to the private
+     * seed in `raw`.
      */
     get verfer(): Verfer {
         return this._verfer;
     }
 
+    /**
+     * Sign a byte serialization.
+     *
+     * With `index === null` or an omitted `index`, returns an unindexed `Cigar`.
+     * With a non-null `index`, returns an indexed `Siger`.
+     *
+     * @param ser Bytes to sign.
+     * @param index Current, or main, signing key index in the event key list.
+     * Defaults to `null`, which creates an unindexed signature.
+     * @param only When `true`, create a current-list-only indexed signature and
+     * omit `ondex`. When `false`, create a dual-index signature.
+     * @param ondex Other index for dual-index signatures, commonly the prior-next
+     * key digest index. Defaults to `index` when `only` is `false`.
+     * @returns `Cigar` for unindexed signatures; `Siger` for indexed signatures.
+     * @throws Error if an indexed signature is requested with a non-whole
+     * `index` or `ondex`.
+     */
     sign(
         ser: Uint8Array,
         index: number | null = null,
@@ -89,6 +147,25 @@ export class Signer extends Matter {
         return this._sign(ser, this.raw, this.verfer, index, only, ondex);
     }
 
+    /**
+     * Ed25519 implementation behind `sign`.
+     *
+     * Prefer `sign()` for normal use; this method expects the caller to supply
+     * the seed and verifier that match this signing suite.
+     *
+     * @param ser Bytes to sign.
+     * @param seed Raw private Ed25519 seed bytes.
+     * @param verfer Verifier whose `raw` value is the public verification key.
+     * @param index Current, or main, signing key index. `null` returns a `Cigar`;
+     * otherwise the result is a `Siger`.
+     * @param only When `true`, ignore `ondex` and create a current-list-only
+     * signature.
+     * @param ondex Other index for dual-index signatures. Defaults to `index`
+     * when omitted and `only` is `false`.
+     * @returns `Cigar` for unindexed signatures; `Siger` for indexed signatures.
+     * @throws Error if `index` or `ondex` is not a non-negative integer.
+     * @internal
+     */
     _ed25519(
         ser: Uint8Array,
         seed: Uint8Array,
@@ -96,16 +173,31 @@ export class Signer extends Matter {
         index: number | null,
         only: boolean = false,
         ondex: number | undefined
-    ) {
+    ): Siger | Cigar {
+        if (
+            index !== null &&
+            (!Number.isInteger(index) || index < 0)
+        ) {
+            throw new Error(
+                `Invalid signing index = ${index}, not whole number.`
+            );
+        }
+
+        if (ondex !== undefined && (!Number.isInteger(ondex) || ondex < 0)) {
+            throw new Error(
+                `Invalid ondex = ${ondex}, not whole number or undefined.`
+            );
+        }
+
         const sig = libsodium.crypto_sign_detached(
             ser,
             concat(seed, verfer.raw)
         );
 
-        if (index == null) {
+        if (index === null) {
             return new Cigar({ raw: sig, code: MtrDex.Ed25519_Sig }, verfer);
         } else {
-            let code;
+            let code: string;
             if (only) {
                 ondex = undefined;
                 if (index <= 63) {
@@ -114,11 +206,11 @@ export class Signer extends Matter {
                     code = IdrDex.Ed25519_Big_Crt_Sig;
                 }
             } else {
-                if (ondex == undefined) {
+                if (ondex === undefined) {
                     ondex = index;
                 }
 
-                if (ondex == index && index <= 63)
+                if (ondex === index && index <= 63)
                     // both same and small
                     code = IdrDex.Ed25519_Sig; //  use  small both same
                 //  otherwise big or both not same so use big both

--- a/test/core/signer.test.ts
+++ b/test/core/signer.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, it } from 'vitest';
 import libsodium from 'libsodium-wrappers-sumo';
 
-import { Signer } from '../../src/index.ts';
+import { Cigar, IdrDex, Siger, Signer } from '../../src/index.ts';
 import { Matter, MtrDex } from '../../src/index.ts';
 import { b } from '../../src/index.ts';
 
@@ -21,9 +21,70 @@ describe('Signer', () => {
         const ser = b('abcdefghijklmnopqrstuvwxyz0123456789');
 
         const cigar = signer.sign(ser);
+        assert.equal(cigar instanceof Cigar, true);
         assert.equal(cigar.code, MtrDex.Ed25519_Sig);
         assert.equal(cigar.raw.length, Matter._rawSize(cigar.code));
         const result = signer.verfer.verify(cigar.raw, ser);
         assert.equal(result, true);
+    });
+
+    it('creates indexed Ed25519 signatures with the right index code', async () => {
+        await libsodium.ready;
+
+        const signer = new Signer({});
+        const ser = b('abcdefghijklmnopqrstuvwxyz0123456789');
+
+        const defaultSiger = signer.sign(ser, 5) as Siger;
+        assert.equal(defaultSiger instanceof Siger, true);
+        assert.equal(defaultSiger.code, IdrDex.Ed25519_Sig);
+        assert.equal(defaultSiger.index, 5);
+        assert.equal(defaultSiger.ondex, 5);
+
+        const currentOnlySiger = signer.sign(ser, 3, true) as Siger;
+        assert.equal(currentOnlySiger instanceof Siger, true);
+        assert.equal(currentOnlySiger.code, IdrDex.Ed25519_Crt_Sig);
+        assert.equal(currentOnlySiger.index, 3);
+        assert.equal(currentOnlySiger.ondex, undefined);
+
+        const bigCurrentOnlySiger = signer.sign(ser, 68, true) as Siger;
+        assert.equal(bigCurrentOnlySiger instanceof Siger, true);
+        assert.equal(bigCurrentOnlySiger.code, IdrDex.Ed25519_Big_Crt_Sig);
+        assert.equal(bigCurrentOnlySiger.index, 68);
+        assert.equal(bigCurrentOnlySiger.ondex, undefined);
+
+        const differentOndexSiger = signer.sign(ser, 3, false, 5) as Siger;
+        assert.equal(differentOndexSiger instanceof Siger, true);
+        assert.equal(differentOndexSiger.code, IdrDex.Ed25519_Big_Sig);
+        assert.equal(differentOndexSiger.index, 3);
+        assert.equal(differentOndexSiger.ondex, 5);
+    });
+
+    it('rejects invalid indexed signature indexes at runtime', async () => {
+        await libsodium.ready;
+
+        const signer = new Signer({});
+        const ser = b('abcdefghijklmnopqrstuvwxyz0123456789');
+
+        for (const index of [-1, 1.5, '1']) {
+            assert.throws(
+                () => signer.sign(ser, index as unknown as number),
+                /Invalid signing index/
+            );
+        }
+    });
+
+    it('rejects invalid indexed signature ondices at runtime', async () => {
+        await libsodium.ready;
+
+        const signer = new Signer({});
+        const ser = b('abcdefghijklmnopqrstuvwxyz0123456789');
+
+        for (const ondex of [-1, 1.5, '1', null]) {
+            assert.throws(
+                () =>
+                    signer.sign(ser, 0, false, ondex as unknown as number),
+                /Invalid ondex/
+            );
+        }
     });
 });


### PR DESCRIPTION
There were a few equality checks that would possibly coerce values in an unexpected way. This PR changes double equals `==` to explicit triple equals`===` that do not do type coercion. The new tests exercise the new invalid index and ondex checks.

It also adds thorough docs to the Signer class.