### PR TITLE
fix: drop agent EID suffix on multisig OOBI by default

### DIFF
--- a/src/keri/app/coring.ts
+++ b/src/keri/app/coring.ts
@@ -41,6 +41,10 @@ type KeyState = components['schemas']['KeyStateRecord'];
 type KeyEventRecord = components['schemas']['KeyEventRecord'];
 type AgentConfig = components['schemas']['AgentConfig'];
 
+export interface OobiGetOptions {
+    includeEid?: boolean;
+}
+
 export function randomPasscode(): string {
     const raw = libsodium.randombytes_buf(16);
     const salter = new Salter({ raw: raw });
@@ -71,8 +75,17 @@ export class Oobis {
      * @param {string} role Authorized role
      * @returns {Promise<OOBI>} A promise to the OOBI(s)
      */
-    async get(name: string, role: string = 'agent'): Promise<OOBI> {
-        const path = `/identifiers/${name}/oobis?role=${role}`;
+    async get(
+        name: string,
+        role: string = 'agent',
+        options: OobiGetOptions = {}
+    ): Promise<OOBI> {
+        const params = new URLSearchParams();
+        params.append('role', role);
+        if (options.includeEid !== undefined) {
+            params.append('includeEid', String(options.includeEid));
+        }
+        const path = `/identifiers/${name}/oobis?${params.toString()}`;
         const method = 'GET';
         const res = await this.client.fetch(path, method, null);
         return await res.json();

--- a/test-integration/delegation-multisig.test.ts
+++ b/test-integration/delegation-multisig.test.ts
@@ -205,7 +205,7 @@ test('delegation-multisig', async () => {
         }
     );
 
-    const oobiGtor = delegatorGroupNameOobi.split('/agent/')[0];
+    const oobiGtor = delegatorGroupNameOobi;
     await Promise.all([
         getOrCreateContact(
             delegatee1Client,

--- a/test-integration/delegation.test.ts
+++ b/test-integration/delegation.test.ts
@@ -85,7 +85,7 @@ test('delegation', async () => {
     const contactId = await getOrCreateContact(
         client1,
         'delegate',
-        oobis.oobis[0].split('/agent/')[0]
+        oobis.oobis[0]
     );
 
     assert.equal(contactId, aid2.prefix);

--- a/test-integration/endroles-by-aid.test.ts
+++ b/test-integration/endroles-by-aid.test.ts
@@ -125,7 +125,12 @@ beforeAll(async () => {
 
 beforeAll(async () => {
     const groupOobi = await client1.oobis().get(groupName, 'agent');
-    const oobiUrl = groupOobi.oobis[0].split('/agent/')[0];
+    const qualifiedGroupOobi = await client1
+        .oobis()
+        .get(groupName, 'agent', { includeEid: true });
+    expect(groupOobi.oobis[0].endsWith('/agent')).toBe(true);
+    expect(qualifiedGroupOobi.oobis[0]).toContain('/agent/');
+    const oobiUrl = groupOobi.oobis[0];
     await resolveOobi(aliceClient, oobiUrl, groupName);
 });
 

--- a/test-integration/multisig-holder.test.ts
+++ b/test-integration/multisig-holder.test.ts
@@ -360,7 +360,7 @@ test('multisig', async function run() {
 
     // Holder resolve multisig OOBI
     const oobisRes = await client1.oobis().get('holder', 'agent');
-    const oobiMultisig = oobisRes.oobis[0].split('/agent/')[0];
+    const oobiMultisig = oobisRes.oobis[0];
 
     op3 = await client3.oobis().resolve(oobiMultisig, 'holder');
     await waitOperation(client3, op3);

--- a/test-integration/multisig-join.test.ts
+++ b/test-integration/multisig-join.test.ts
@@ -181,7 +181,7 @@ describe('multisig-join', () => {
             client1.oobis().get(nameMultisig, 'agent'),
         ]);
 
-        const oobiMultisig = oobi4.oobis[0].split('/agent/')[0];
+        const oobiMultisig = oobi4.oobis[0];
 
         const [opOobi1, opOobi2, opOobi3, opOobi4, opOobi5] = await Promise.all(
             [

--- a/test-integration/multisig-vlei-issuance.test.ts
+++ b/test-integration/multisig-vlei-issuance.test.ts
@@ -287,7 +287,7 @@ test('multisig-vlei-issuance', async function run() {
     assert.equal(oobiGEDAbyGAR1.oobis[0], oobiGEDAbyGAR2.oobis[0]);
 
     // QARs, LARs, ECR resolve GEDA's OOBI
-    const oobiGEDA = oobiGEDAbyGAR1.oobis[0].split('/agent/')[0];
+    const oobiGEDA = oobiGEDAbyGAR1.oobis[0];
     await Promise.all([
         getOrCreateContact(clientQAR1, aidGEDA.name, oobiGEDA),
         getOrCreateContact(clientQAR2, aidGEDA.name, oobiGEDA),
@@ -466,7 +466,7 @@ test('multisig-vlei-issuance', async function run() {
     assert.equal(oobiQVIbyQAR1.oobis[0], oobiQVIbyQAR3.oobis[0]);
 
     // GARs, LARs, ECR resolve QVI AID's OOBI
-    const oobiQVI = oobiQVIbyQAR1.oobis[0].split('/agent/')[0];
+    const oobiQVI = oobiQVIbyQAR1.oobis[0];
     await Promise.all([
         getOrCreateContact(clientGAR1, aidQVI.name, oobiQVI),
         getOrCreateContact(clientGAR2, aidQVI.name, oobiQVI),
@@ -808,7 +808,7 @@ test('multisig-vlei-issuance', async function run() {
     assert.equal(oobiLEbyLAR1.oobis[0], oobiLEbyLAR3.oobis[0]);
 
     // QARs, ECR resolve LE AID's OOBI
-    const oobiLE = oobiLEbyLAR1.oobis[0].split('/agent/')[0];
+    const oobiLE = oobiLEbyLAR1.oobis[0];
     await Promise.all([
         getOrCreateContact(clientQAR1, aidLE.name, oobiLE),
         getOrCreateContact(clientQAR2, aidLE.name, oobiLE),

--- a/test/app/coring.test.ts
+++ b/test/app/coring.test.ts
@@ -46,6 +46,14 @@ describe('Coring', () => {
         assert.equal(lastCall[0]!, url + '/identifiers/aid/oobis?role=agent');
         assert.equal(lastCall[1]!.method, 'GET');
 
+        await oobis.get('aid', 'agent', { includeEid: true });
+        lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
+        assert.equal(
+            lastCall[0]!,
+            url + '/identifiers/aid/oobis?role=agent&includeEid=true'
+        );
+        assert.equal(lastCall[1]!.method, 'GET');
+
         await oobis.resolve('http://oobiurl.com');
         lastCall = fetchMock.mock.calls[fetchMock.mock.calls.length - 1]!;
         let lastBody = JSON.parse(lastCall[1]!.body!.toString());


### PR DESCRIPTION
This has been a constant source of confusion for years and should return the intuitive result by default, the multisig Agent OOBI with no agent EID suffix.

The includeEid URL parameter allows using the old behavior, if desired.

KERIA PR: https://github.com/WebOfTrust/keria/pull/447
SignifyPy PR: https://github.com/WebOfTrust/signifypy/pull/150