### PR TITLE
feat(parsing): frame CESR 2.0 (v2) streams (stacked on #402)

### DIFF
--- a/src/exports.ts
+++ b/src/exports.ts
@@ -29,6 +29,7 @@ export * from './keri/core/kering.ts';
 export * from './keri/core/manager.ts';
 export * from './keri/core/matter.ts';
 export * from './keri/core/number.ts';
+export * from './keri/core/parsing.ts';
 export * from './keri/core/prefixer.ts';
 export * from './keri/core/saider.ts';
 export * from './keri/core/salter.ts';

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -1,0 +1,441 @@
+// CESR stream parser (v1): message framing + attachment-group decomposition.
+//
+// signify-ts already has the primitive classes (Matter, Counter, Indexer) and
+// emits framed streams (eventing.messagize), but has no parser that CONSUMES a
+// stream. This module fills that gap: it frames a byte stream deterministically
+// — by the version-string size and the attachment counters, never by sniffing a
+// leading `{` — delegating all primitive/counter/indexer SIZING to the existing
+// classes. It is resilient: on a code it cannot frame it stops and reports,
+// returning everything parsed so far, so a single bad byte never loses the
+// stream prefix that did parse.
+
+import { Counter } from './counter.ts';
+import { Indexer } from './indexer.ts';
+import { Matter } from './matter.ts';
+
+// Lazily-created shared decoder — constructing it at module load would be a
+// side effect that stops bundlers tree-shaking this module away for consumers
+// who never use the parser. Building it on first use keeps the module pure.
+let decoder: TextDecoder | undefined;
+const td = (): TextDecoder => (decoder ??= new TextDecoder());
+const DASH = 0x2d; // '-'
+
+/** A half-open byte range [start, end) into the original stream. */
+export interface ByteSpan {
+    start: number;
+    end: number;
+}
+
+/** Framing outcome for a node. */
+export type NodeState =
+    | 'known' // recognized code, fully framed
+    | 'unknown' // well-formed but code not recognized; may be framable by size
+    | 'invalid'; // cannot be framed
+
+/** A single CESR primitive (key, digest, signature, sequence number, …). */
+export interface Primitive {
+    kind: 'primitive';
+    code: string;
+    /** Which code table framed it — disambiguates `code`, since the Matter and
+     * Indexer tables collide (e.g. 'A' is a seed as Matter, an Ed25519 indexed
+     * signature as Indexer). */
+    class: 'matter' | 'indexer';
+    span: ByteSpan;
+}
+
+/** A counter-framed attachment group (e.g. controller sigs `-A`, quadlets `-V`). */
+export interface AttachmentGroup {
+    kind: 'group';
+    code: string;
+    count: number;
+    span: ByteSpan;
+    state: NodeState;
+    /** Typed children; empty for opaque quadlet frames and unknown codes. */
+    items: AttachmentNode[];
+}
+
+/** A node in the attachment tree. */
+export type AttachmentNode = AttachmentGroup | Primitive;
+
+/** A parsed message (KEL/TEL event or ACDC) with its attachments. */
+export interface CesrMessage {
+    proto: string; // e.g. 'KERI', 'ACDC'
+    version: string; // e.g. '1.0'
+    kind: string; // serialization, e.g. 'JSON'
+    ilk: string | null; // the `t` field, null for ACDCs
+    sn: string | null; // the `s` field (hex sequence number), where present
+    said: string | null; // the `d` field
+    /** The deserialized body, or null when framed but not decoded. */
+    sad: Record<string, unknown> | null;
+    span: ByteSpan; // the message body bytes (attachments excluded)
+    attachments: AttachmentGroup[];
+}
+
+/** Decodes a serialized message body (the bytes between the version string and
+ * the attachments) into its field map. JSON is built in; other serializations
+ * (CBOR/MGPK) are injected via {@link ParseOptions}. */
+export type BodyDecoder = (body: Uint8Array) => Record<string, unknown>;
+
+/** Options for {@link parse}. */
+export interface ParseOptions {
+    /** Body decoders keyed by serialization kind (e.g. 'CBOR', 'MGPK'); JSON is
+     * always built in. */
+    decoders?: Record<string, BodyDecoder>;
+}
+
+/** A stable symbolic code for a framing failure — branch on this, not the prose. */
+export type ParseErrorCode =
+    | 'no-version-string' // no CESR version string — not a recognizable message
+    | 'malformed-body' // the version size is claimed but the body does not decode
+    | 'unparseable-counter' // a '-' counter code that could not be parsed
+    | 'unframable-group'; // a recognized counter whose group could not be framed
+
+/** A framing failure, with a stable code, the byte position, and its permanence. */
+export interface ParseError {
+    code: ParseErrorCode;
+    message: string;
+    span: ByteSpan;
+    /** The parser is pure and deterministic — the same bytes always fail the
+     * same way. */
+    permanent: true;
+}
+
+/** The result of parsing a stream: what parsed, what failed, and how far we got. */
+export interface ParseResult {
+    messages: CesrMessage[];
+    errors: ParseError[];
+    consumed: number; // bytes contiguously framed from the start
+}
+
+/** A CESR version string as a BARE token, e.g. `KERI10JSON00012b_` -> proto
+ * KERI, ver 1.0, kind JSON, size 0x12b. Matched WITHOUT the JSON `"v":"..."`
+ * framing so it is found inside binary CBOR/MGPK bodies too, where it still
+ * appears as ASCII. */
+const VERSION_RE = /([A-Z]{4})(\d)(\d)([A-Z]{4})([0-9a-f]{6})_/;
+
+/** The built-in JSON body decoder (a language builtin — no dependency). */
+const jsonDecoder: BodyDecoder = (body) => JSON.parse(td().decode(body));
+
+interface Version {
+    proto: string;
+    version: string;
+    kind: string;
+    size: number;
+}
+
+/** Parse the version string at `at`, or null if none is present in the leading
+ * window. */
+export function parseVersion(bytes: Uint8Array, at: number): Version | null {
+    const window = td().decode(bytes.subarray(at, at + 128));
+    const m = window.match(VERSION_RE);
+    if (!m) return null;
+    return {
+        proto: m[1],
+        version: `${m[2]}.${m[3]}`,
+        kind: m[4],
+        size: parseInt(m[5], 16),
+    };
+}
+
+/** One element of a group item: a primitive (`p` = Matter, `sig` = indexed
+ * Indexer) or `grp` = one nested attachment group (e.g. the -A ControllerIdxSigs
+ * inside a -F/-H). */
+type PrimitivePart = 'p' | 'sig';
+type Part = PrimitivePart | 'grp';
+
+interface GroupSpec {
+    quadlet?: boolean;
+    /** The element sequence of ONE item; repeated `count` times. */
+    parts?: Part[];
+}
+
+const GROUP_SPEC: Record<string, GroupSpec> = {
+    '-V': { quadlet: true }, // AttachedMaterialQuadlets (universal wrapper)
+    '-0V': { quadlet: true }, // BigAttachedMaterialQuadlets
+    '-L': { quadlet: true }, // PathedMaterialQuadlets
+    '-A': { parts: ['sig'] }, // ControllerIdxSigs
+    '-B': { parts: ['sig'] }, // WitnessIdxSigs
+    '-C': { parts: ['p', 'p'] }, // NonTransReceiptCouples (verfer, cigar)
+    '-D': { parts: ['p', 'p', 'p', 'sig'] }, // TransReceiptQuadruples
+    '-E': { parts: ['p', 'p'] }, // FirstSeenReplayCouples (seqner, dater)
+    '-F': { parts: ['p', 'p', 'p', 'grp'] }, // TransIdxSigGroups (+ nested -A)
+    '-G': { parts: ['p', 'p'] }, // SealSourceCouples (seqner, saider)
+    '-H': { parts: ['p', 'grp'] }, // TransLastIdxSigGroups (prefixer, nested -A)
+    '-I': { parts: ['p', 'p', 'p'] }, // SealSourceTriples (prefixer, seqner, saider)
+};
+
+interface FramedGroup {
+    group: AttachmentGroup;
+    /** Byte offset just past the group (only meaningful when state === 'known'). */
+    end: number;
+}
+
+/** The outcome of framing a run of attachment groups over a byte window. */
+interface GroupSequence {
+    items: AttachmentGroup[];
+    end: number; // where framing stopped
+    error?: ParseError; // set when framing halted on a group it could not frame
+}
+
+/** Frame one primitive of the given part kind at `at`, delegating sizing to the
+ * Matter/Indexer classes. */
+function framePrimitive(
+    bytes: Uint8Array,
+    at: number,
+    part: PrimitivePart
+): Primitive | null {
+    const q = td().decode(bytes.subarray(at, at + 128));
+    try {
+        const prim =
+            part === 'sig' ? new Indexer({ qb64: q }) : new Matter({ qb64: q });
+        const cls = part === 'sig' ? 'indexer' : 'matter';
+        return {
+            kind: 'primitive',
+            code: prim.code,
+            class: cls,
+            span: { start: at, end: at + prim.qb64.length },
+        };
+    } catch {
+        return null;
+    }
+}
+
+/** Frame one attachment group at `at`. Returns null if the counter itself is
+ * unparseable. */
+function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
+    let counter: Counter;
+    try {
+        counter = new Counter({
+            qb64: td().decode(bytes.subarray(at, at + 8)),
+        });
+    } catch {
+        return null;
+    }
+    const { code, count } = counter;
+    const headerLen = counter.qb64.length;
+    const base = { kind: 'group' as const, code, count };
+    const spec = GROUP_SPEC[code];
+
+    if (!spec) {
+        // A recognized counter (e.g. -J/-K SadPathSig groups) whose inner framing
+        // is not yet modeled: framed structurally as far as its header, marked
+        // unknown so the walk stays resilient rather than halting.
+        const end = at + headerLen;
+        return {
+            group: {
+                ...base,
+                span: { start: at, end },
+                state: 'unknown',
+                items: [],
+            },
+            end,
+        };
+    }
+
+    if (spec.quadlet) {
+        // A material-quadlet wrapper self-declares its size as count*4, so it is
+        // always framed; only its inner content varies in how (or whether) we
+        // decompose it.
+        const innerStart = at + headerLen;
+        const innerEnd = innerStart + count * 4;
+        if (code === '-L') {
+            // -L (PathedMaterialQuadlets) leads with a path primitive, not a
+            // plain group run; its inner decomposition is deferred, so the
+            // quadlet body stays opaque for now.
+            return {
+                group: {
+                    ...base,
+                    span: { start: at, end: innerEnd },
+                    state: 'known',
+                    items: [],
+                },
+                end: innerEnd,
+            };
+        }
+        // -V / -0V universal wrappers: recurse into a typed nested group
+        // sequence. The wrapper's size is self-declaring (count*4), so it is a
+        // RESILIENCE BOUNDARY: inner decomposition proceeds as far as it can, an
+        // inner limit stops decomposing THIS wrapper without condemning it, and
+        // framing resumes at innerEnd — so decomposing a wrapper is never less
+        // resilient than leaving it opaque.
+        const seq = frameGroupSequence(bytes, innerStart, innerEnd);
+        return {
+            group: {
+                ...base,
+                span: { start: at, end: innerEnd },
+                state: 'known',
+                items: seq.items,
+            },
+            end: innerEnd,
+        };
+    }
+
+    const parts = spec.parts as Part[];
+    const items: AttachmentNode[] = [];
+    let p = at + headerLen;
+    for (let k = 0; k < count; k++) {
+        for (const part of parts) {
+            if (part === 'grp') {
+                // A nested attachment group (the -A ControllerIdxSigs inside a
+                // -F/-H); frame it recursively and require it fully known, else
+                // this item — and so this group — cannot be framed.
+                const nested = frameGroup(bytes, p);
+                if (!nested || nested.group.state !== 'known') {
+                    return {
+                        group: {
+                            ...base,
+                            span: { start: at, end: p },
+                            state: 'invalid',
+                            items,
+                        },
+                        end: p,
+                    };
+                }
+                items.push(nested.group);
+                p = nested.end;
+            } else {
+                const prim = framePrimitive(bytes, p, part);
+                if (!prim) {
+                    // A malformed item — we can no longer frame this group.
+                    return {
+                        group: {
+                            ...base,
+                            span: { start: at, end: p },
+                            state: 'invalid',
+                            items,
+                        },
+                        end: p,
+                    };
+                }
+                items.push(prim);
+                p = prim.span.end;
+            }
+        }
+    }
+    return {
+        group: {
+            ...base,
+            span: { start: at, end: p },
+            state: 'known',
+            items,
+        },
+        end: p,
+    };
+}
+
+/** Frame a run of attachment groups over [start, limit). Stops at `limit`, at
+ * the first byte that is not a counter, or at the first group it cannot frame
+ * (recording a typed error). Shared by the top-level attachment loop and the
+ * -V/-0V wrapper recursion, so both frame identically. */
+function frameGroupSequence(
+    bytes: Uint8Array,
+    start: number,
+    limit: number
+): GroupSequence {
+    const items: AttachmentGroup[] = [];
+    let pos = start;
+    while (pos < limit && bytes[pos] === DASH) {
+        const framed = frameGroup(bytes, pos);
+        if (!framed) {
+            return {
+                items,
+                end: pos,
+                error: {
+                    code: 'unparseable-counter',
+                    message: `The attachment counter at byte ${pos} is not a recognized CESR code.`,
+                    span: { start: pos, end: limit },
+                    permanent: true,
+                },
+            };
+        }
+        items.push(framed.group);
+        if (framed.group.state !== 'known') {
+            return {
+                items,
+                end: pos,
+                error: {
+                    code: 'unframable-group',
+                    message: `The ${framed.group.code} group at byte ${pos} could not be framed.`,
+                    span: { start: pos, end: limit },
+                    permanent: true,
+                },
+            };
+        }
+        pos = framed.end;
+    }
+    return { items, end: pos };
+}
+
+/** Parse a CESR stream into a provenance-carrying decomposition. Body decoding
+ * is pluggable: JSON is built in, and other serializations (CBOR/MGPK) are
+ * decoded only when a decoder for their kind is injected via `opts.decoders`;
+ * an undecoded body is framed with sad=null. */
+export function parse(bytes: Uint8Array, opts: ParseOptions = {}): ParseResult {
+    const decoders: Record<string, BodyDecoder> = {
+        JSON: jsonDecoder,
+        ...opts.decoders,
+    };
+    const messages: CesrMessage[] = [];
+    const errors: ParseError[] = [];
+    const n = bytes.length;
+    let i = 0;
+
+    while (i < n) {
+        // A message is marked by its version string (near the start in every
+        // serialization), not by a leading '{' — CBOR/MGPK bodies begin with a
+        // map-header byte.
+        const ver = parseVersion(bytes, i);
+        if (!ver) {
+            errors.push({
+                code: 'no-version-string',
+                message: `No CESR version string was found at byte ${i}; this is not a recognizable message.`,
+                span: { start: i, end: n },
+                permanent: true,
+            });
+            break;
+        }
+        const bodyEnd = i + ver.size;
+        const decoder = decoders[ver.kind]; // undefined if none for this kind
+        let sad: Record<string, unknown> | null = null;
+        if (decoder) {
+            try {
+                sad = decoder(bytes.subarray(i, bodyEnd));
+            } catch {
+                errors.push({
+                    code: 'malformed-body',
+                    message: `The message body at byte ${i} is not valid ${ver.kind}.`,
+                    span: { start: i, end: bodyEnd },
+                    permanent: true,
+                });
+                break;
+            }
+        }
+        // When no decoder handles this serialization, the body is framed but
+        // left undecoded (sad = null).
+
+        const seq = frameGroupSequence(bytes, bodyEnd, n);
+        messages.push({
+            proto: ver.proto,
+            version: ver.version,
+            kind: ver.kind,
+            ilk: sad && typeof sad.t === 'string' ? sad.t : null,
+            sn: sad && typeof sad.s === 'string' ? sad.s : null,
+            said: sad && typeof sad.d === 'string' ? sad.d : null,
+            sad,
+            span: { start: i, end: bodyEnd },
+            attachments: seq.items,
+        });
+
+        i = seq.end;
+        if (seq.error) {
+            // A top-level group we cannot frame has no enclosing wrapper size to
+            // resync from, so the walk halts here (only size-known wrappers are
+            // resilience boundaries). A wrong wrapper count*4 also surfaces here,
+            // by desynchronising the next message boundary.
+            errors.push(seq.error);
+            break;
+        }
+    }
+
+    return { messages, errors, consumed: i };
+}

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -48,6 +48,10 @@ export interface AttachmentGroup {
     kind: 'group';
     code: string;
     count: number;
+    /** CESR genus major (1 or 2). The same code denotes different groups by
+     * genus (e.g. v1 -C is NonTransReceiptCouples, v2 -C is the AttachmentGroup
+     * wrapper), so a consumer must know the genus to interpret `code`. */
+    genus: number;
     span: ByteSpan;
     state: NodeState;
     /** Typed children; empty for opaque quadlet frames and unknown codes. */
@@ -117,30 +121,64 @@ export interface ParseResult {
  * appears as ASCII. */
 const VERSION_RE = /([A-Z]{4})(\d)(\d)([A-Z]{4})([0-9a-f]{6})_/;
 
+/** A CESR v2 (CESR 2.0) version string as a BARE token, e.g. `KERICAACAAJSONAAD_.`
+ * -> proto KERI, protocol version 2.0, CESR genus version 2.0, kind JSON, size
+ * 255. Its layout is proto(4) + protocol-major(1) + protocol-minor(2) +
+ * genus-major(1) + genus-minor(2) + kind(4) + size(4) + '.' terminator, every
+ * field after the proto in base64url. The embedded GENUS version selects the v2
+ * counter table. */
+const VERSION_RE_2 =
+    /([A-Z]{4})([A-Za-z0-9_-])([A-Za-z0-9_-]{2})([A-Za-z0-9_-])([A-Za-z0-9_-]{2})([A-Z]{4})([A-Za-z0-9_-]{4})\./;
+
+/** The CESR base64url alphabet, index = value (A=0 … _=63). */
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+/** Decode a base64url token to its integer value (v2 sizes and counts are
+ * base64, not hex). */
+function b64ToInt(s: string): number {
+    let n = 0;
+    for (const c of s) n = n * 64 + B64.indexOf(c);
+    return n;
+}
+
 /** The built-in JSON body decoder (a language builtin — no dependency). */
 const jsonDecoder: BodyDecoder = (body) => JSON.parse(td().decode(body));
 
 interface Version {
     proto: string;
-    version: string;
+    version: string; // the PROTOCOL version, e.g. '1.0' or '2.0'
     kind: string;
     size: number;
+    genus: number; // the CESR GENUS major version (1 or 2) — selects the counter table
     /** The version-string TOKEN's own length; a message cannot be shorter. */
     length: number;
 }
 
 /** Parse the version string at `at`, or null if none is present in the leading
- * window. */
+ * window. Tries the v2 layout first (its terminator and base64 fields cannot
+ * cross-match a v1 string, and vice versa), then falls back to v1. The returned
+ * `genus` drives v1-vs-v2 counter framing. */
 export function parseVersion(bytes: Uint8Array, at: number): Version | null {
     const window = td().decode(bytes.subarray(at, at + 128));
-    const m = window.match(VERSION_RE);
-    if (!m) return null;
+    const m2 = window.match(VERSION_RE_2);
+    if (m2) {
+        return {
+            proto: m2[1],
+            version: `${b64ToInt(m2[2])}.${b64ToInt(m2[3])}`,
+            kind: m2[6],
+            size: b64ToInt(m2[7]),
+            genus: b64ToInt(m2[4]),
+            length: m2[0].length,
+        };
+    }
+    const m1 = window.match(VERSION_RE);
+    if (!m1) return null;
     return {
-        proto: m[1],
-        version: `${m[2]}.${m[3]}`,
-        kind: m[4],
-        size: parseInt(m[5], 16),
-        length: m[0].length,
+        proto: m1[1],
+        version: `${m1[2]}.${m1[3]}`,
+        kind: m1[4],
+        size: parseInt(m1[5], 16),
+        genus: 1,
+        length: m1[0].length,
     };
 }
 
@@ -249,8 +287,142 @@ function framePrimitive(
     }
 }
 
-/** Frame one attachment group at `at`. */
-function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
+/* --- CESR 2.0 (genus 2) counter framing. -------------------------------------
+ * signify-ts's Counter carries only the v1 table and SILENTLY MISFRAMES v2 codes
+ * (they collide with v1 strings but denote different groups), so v2 counters are
+ * framed natively here, from keripy 2.0's CtrDex_2_0. Two facts make v2 framing
+ * uniform: every v2 group counts its body in QUADLETS (so it self-frames as
+ * count*4 bytes, like the v1 -V wrapper), and a counter always begins with '-'
+ * while a primitive never does. */
+const V2_GENUS_CODE = '-_AAA'; // genus-version counter (a bodyless declaration)
+const V2_LETTERS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabc'; // the defined CtrDex_2_0 letters
+const V2_KNOWN = new Set<string>([V2_GENUS_CODE]);
+for (const c of V2_LETTERS) {
+    V2_KNOWN.add(`-${c}`); // regular (hard 2, soft 2)
+    V2_KNOWN.add(`--${c}`); // big (hard 3, soft 5)
+}
+/** Codes whose DIRECT bare primitives are indexed signatures (Indexer), not
+ * Matter: ControllerIdxSigs / WitnessIdxSigs and their big forms. */
+const V2_SIG_CODES = new Set(['-K', '-L', '--K', '--L']);
+
+/** Parse a v2 counter header at `at`: its code (hard) and quadlet count (soft).
+ * Both callers guarantee `bytes[at]` is '-' (they test DASH first). The hard/soft
+ * split is fixed by the first two chars — `--` big (3/5), `-_` genus (5/3), else
+ * regular (2/2) — per keripy's v2 Sizes table. */
+function parseV2Counter(
+    bytes: Uint8Array,
+    at: number
+): Attempt<{ code: string; count: number; headerLen: number }> {
+    const b = td().decode(bytes.subarray(at, at + 8));
+    const [hs, ss] = b[1] === '-' ? [3, 5] : b[1] === '_' ? [5, 3] : [2, 2];
+    const code = b.slice(0, hs);
+    const soft = b.slice(hs, hs + ss);
+    // A header cut off by the end of the stream is short, not malformed; a
+    // full-length soft that is not base64 is malformed.
+    if (bytes.length - at < hs + ss) return { fail: 'short' };
+    // The bytes are there, so a decode that yields fewer CHARS than the header
+    // needs means they are not the ASCII a counter header is made of.
+    if (soft.length < ss || !/^[A-Za-z0-9_-]+$/.test(soft)) {
+        return { fail: 'bad' };
+    }
+    return { node: { code, count: b64ToInt(soft), headerLen: hs + ss } };
+}
+
+/** Frame the enclosed material of a v2 group over [start, limit): a run of nested
+ * counters and/or primitives (Indexer when `sigCtx`, else Matter). Stops at the
+ * first element it cannot frame within the bound — the enclosing group's size is
+ * already known (count*4), so this is a RESILIENCE BOUNDARY: a partial decode
+ * never condemns the self-framed wrapper. */
+function frameEnclosedV2(
+    bytes: Uint8Array,
+    start: number,
+    limit: number,
+    sigCtx: boolean
+): AttachmentNode[] {
+    const items: AttachmentNode[] = [];
+    let p = start;
+    while (p < limit) {
+        if (bytes[p] === DASH) {
+            const nested = frameGroupV2(bytes, p);
+            if (failed(nested) || nested.node.end > limit) break;
+            items.push(nested.node.group);
+            p = nested.node.end;
+        } else {
+            const prim = framePrimitive(bytes, p, sigCtx ? 'sig' : 'p');
+            if (failed(prim) || prim.node.span.end > limit) break;
+            items.push(prim.node);
+            p = prim.node.span.end;
+        }
+    }
+    return items;
+}
+
+/** Frame one v2 (genus 2) attachment group at `at`. Every v2 group self-frames as
+ * count*4 bytes, so even an unrecognized code is UNKNOWN-BUT-FRAMED with a known
+ * span; only a genus-version counter (`-_…`) is bodyless. */
+function frameGroupV2(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
+    const hdr = parseV2Counter(bytes, at);
+    if (failed(hdr)) return hdr;
+    const { code, count, headerLen } = hdr.node;
+    const base = { kind: 'group' as const, code, count, genus: 2 };
+    if (code[1] === '_') {
+        // A genus/version counter declares the CESR genus for the following
+        // material; it has no quadlet body.
+        const end = at + headerLen;
+        const state = code === V2_GENUS_CODE ? 'known' : 'unknown';
+        return {
+            node: {
+                group: { ...base, span: { start: at, end }, state, items: [] },
+                end,
+            },
+        };
+    }
+    const innerStart = at + headerLen;
+    const innerEnd = innerStart + count * 4; // self-framing: count is quadlets
+    // Self-framing cuts both ways: a count that runs past the end of the stream
+    // means the group is not all here yet, so it is short rather than framed.
+    if (innerEnd > bytes.length) return { fail: 'short' };
+    if (!V2_KNOWN.has(code)) {
+        return {
+            node: {
+                group: {
+                    ...base,
+                    span: { start: at, end: innerEnd },
+                    state: 'unknown',
+                    items: [],
+                },
+                end: innerEnd,
+            },
+        };
+    }
+    const items = frameEnclosedV2(
+        bytes,
+        innerStart,
+        innerEnd,
+        V2_SIG_CODES.has(code)
+    );
+    return {
+        node: {
+            group: {
+                ...base,
+                span: { start: at, end: innerEnd },
+                state: 'known',
+                items,
+            },
+            end: innerEnd,
+        },
+    };
+}
+
+/** Frame one attachment group at `at`, dispatching by CESR genus: genus 2 uses
+ * the native v2 tables above; genus 1 delegates counter sizing to the Counter
+ * class. */
+function frameGroup(
+    bytes: Uint8Array,
+    at: number,
+    genus: number
+): Attempt<FramedGroup> {
+    if (genus === 2) return frameGroupV2(bytes, at);
     // A counter header cut off by the end of the stream is short, not
     // unparseable, so the header's own length is checked against the tables
     // before Counter is asked to parse it.
@@ -271,7 +443,7 @@ function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
     }
     const { code, count } = counter;
     const headerLen = counter.qb64.length;
-    const base = { kind: 'group' as const, code, count };
+    const base = { kind: 'group' as const, code, count, genus: 1 };
     const spec = GROUP_SPEC[code];
 
     if (!spec) {
@@ -323,7 +495,7 @@ function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
         // inner limit stops decomposing THIS wrapper without condemning it, and
         // framing resumes at innerEnd — so decomposing a wrapper is never less
         // resilient than leaving it opaque.
-        const seq = frameGroupSequence(bytes, innerStart, innerEnd);
+        const seq = frameGroupSequence(bytes, innerStart, innerEnd, 1);
         return {
             node: {
                 group: {
@@ -361,7 +533,7 @@ function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
                 // A nested attachment group (the -A ControllerIdxSigs inside a
                 // -F/-H); frame it recursively and require it fully known, else
                 // this item — and so this group — cannot be framed.
-                const nested = frameGroup(bytes, p);
+                const nested = frameGroup(bytes, p, 1);
                 if (failed(nested)) {
                     if (nested.fail === 'short') return nested;
                     return invalid(p);
@@ -400,12 +572,13 @@ function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
 function frameGroupSequence(
     bytes: Uint8Array,
     start: number,
-    limit: number
+    limit: number,
+    genus: number
 ): GroupSequence {
     const items: AttachmentGroup[] = [];
     let pos = start;
     while (pos < limit && bytes[pos] === DASH) {
-        const framed = frameGroup(bytes, pos);
+        const framed = frameGroup(bytes, pos, genus);
         if (failed(framed)) {
             // A group the stream ends inside is reported as a shortfall, not an
             // error: only the caller knows whether this window is the live end
@@ -431,7 +604,10 @@ function frameGroupSequence(
         // reported that case as short.
         if (framed.node.end > limit) break;
         items.push(framed.node.group);
-        if (framed.node.group.state !== 'known') {
+        // Under genus 2 every counter self-frames (count*4), so an UNKNOWN code
+        // is framed-and-continued rather than halting; under genus 1 an
+        // unframable body halts, since v1 cannot size an unrecognized group.
+        if (genus !== 2 && framed.node.group.state !== 'known') {
             return {
                 items,
                 end: pos,
@@ -520,7 +696,7 @@ export function parse(bytes: Uint8Array, opts: ParseOptions = {}): ParseResult {
         // When no decoder handles this serialization, the body is framed but
         // left undecoded (sad = null).
 
-        const seq = frameGroupSequence(bytes, bodyEnd, n);
+        const seq = frameGroupSequence(bytes, bodyEnd, n, ver.genus);
         if (seq.short) {
             // The stream ends inside this message's attachments. The message
             // body is whole, but emitting it would double-emit when the caller

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -86,18 +86,22 @@ export interface ParseOptions {
 /** A stable symbolic code for a framing failure — branch on this, not the prose. */
 export type ParseErrorCode =
     | 'no-version-string' // no CESR version string — not a recognizable message
+    | 'invalid-version-size' // a size too small to contain the version string itself
     | 'malformed-body' // the version size is claimed but the body does not decode
     | 'unparseable-counter' // a '-' counter code that could not be parsed
-    | 'unframable-group'; // a recognized counter whose group could not be framed
+    | 'unframable-group' // a recognized counter whose group could not be framed
+    | 'incomplete'; // the stream ends inside an element — RECOVERABLE, more bytes may complete it
 
 /** A framing failure, with a stable code, the byte position, and its permanence. */
 export interface ParseError {
     code: ParseErrorCode;
     message: string;
     span: ByteSpan;
-    /** The parser is pure and deterministic — the same bytes always fail the
-     * same way. */
-    permanent: true;
+    /** False only for `incomplete`, the one failure more bytes can cure. Every
+     * other code is a verdict on bytes that are all present, and the parser is
+     * pure, so re-parsing them fails identically. A caller feeding a growing
+     * buffer must branch on this: wait, or give up. */
+    permanent: boolean;
 }
 
 /** The result of parsing a stream: what parsed, what failed, and how far we got. */
@@ -121,6 +125,8 @@ interface Version {
     version: string;
     kind: string;
     size: number;
+    /** The version-string TOKEN's own length; a message cannot be shorter. */
+    length: number;
 }
 
 /** Parse the version string at `at`, or null if none is present in the leading
@@ -134,6 +140,7 @@ export function parseVersion(bytes: Uint8Array, at: number): Version | null {
         version: `${m[2]}.${m[3]}`,
         kind: m[4],
         size: parseInt(m[5], 16),
+        length: m[0].length,
     };
 }
 
@@ -170,11 +177,45 @@ interface FramedGroup {
     end: number;
 }
 
+/** Why an element could not be framed: `short` = the stream ends inside it, so
+ * more bytes would complete it; `bad` = the bytes that ARE present cannot be
+ * framed. Nothing but the size tables can tell these apart, which is why sizing
+ * is probed before construction. */
+type Shortfall = 'short' | 'bad';
+/** A framing attempt: the framed node, or why it failed. */
+type Attempt<T> = { node: T } | { fail: Shortfall };
+const failed = <T>(a: Attempt<T>): a is { fail: Shortfall } => 'fail' in a;
+
 /** The outcome of framing a run of attachment groups over a byte window. */
 interface GroupSequence {
     items: AttachmentGroup[];
     end: number; // where framing stopped
     error?: ParseError; // set when framing halted on a group it could not frame
+    short?: true; // the window ends inside an element — the caller decides whether that is an error
+}
+
+/** The full byte length of the primitive at `at`, read from the Matter/Indexer
+ * size tables BEFORE construction. Probing rather than catching is what
+ * separates a truncated primitive from a malformed one: the constructor throws
+ * for both. */
+function probePrimitive(
+    bytes: Uint8Array,
+    at: number,
+    part: PrimitivePart
+): Attempt<number> {
+    const hards = part === 'sig' ? Indexer.Hards : Matter.Hards;
+    const sizes = part === 'sig' ? Indexer.Sizes : Matter.Sizes;
+    const avail = bytes.length - at;
+    if (avail <= 0) return { fail: 'short' };
+    const head = td().decode(bytes.subarray(at, at + 8));
+    const hs = hards.get(head[0]);
+    if (hs === undefined) return { fail: 'bad' }; // an unrecognized selector is wrong, not short
+    if (avail < hs) return { fail: 'short' }; // the hard code itself is cut off
+    const sizage = sizes.get(head.slice(0, hs));
+    if (!sizage) return { fail: 'bad' };
+    const fs = sizage.fs;
+    if (fs === undefined || fs < 0) return { fail: 'bad' }; // variable-size codes are unsupported
+    return avail < fs ? { fail: 'short' } : { node: fs };
 }
 
 /** Frame one primitive of the given part kind at `at`, delegating sizing to the
@@ -183,33 +224,46 @@ function framePrimitive(
     bytes: Uint8Array,
     at: number,
     part: PrimitivePart
-): Primitive | null {
-    const q = td().decode(bytes.subarray(at, at + 128));
+): Attempt<Primitive> {
+    const probe = probePrimitive(bytes, at, part);
+    if (failed(probe)) return probe;
+    const q = td().decode(bytes.subarray(at, at + probe.node));
     try {
         const prim =
             part === 'sig' ? new Indexer({ qb64: q }) : new Matter({ qb64: q });
         const cls = part === 'sig' ? 'indexer' : 'matter';
         return {
-            kind: 'primitive',
-            code: prim.code,
-            class: cls,
-            span: { start: at, end: at + prim.qb64.length },
+            node: {
+                kind: 'primitive',
+                code: prim.code,
+                class: cls,
+                span: { start: at, end: at + prim.qb64.length },
+            },
         };
     } catch {
-        return null;
+        return { fail: 'bad' };
     }
 }
 
-/** Frame one attachment group at `at`. Returns null if the counter itself is
- * unparseable. */
-function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
+/** Frame one attachment group at `at`. */
+function frameGroup(bytes: Uint8Array, at: number): Attempt<FramedGroup> {
+    // A counter header cut off by the end of the stream is short, not
+    // unparseable, so the header's own length is checked against the tables
+    // before Counter is asked to parse it.
+    const avail = bytes.length - at;
+    const head = td().decode(bytes.subarray(at, at + 8));
+    if (avail < 2) return { fail: 'short' }; // not even the two-character selector is here
+    const hs = Counter.Hards.get(head.slice(0, 2));
+    if (hs === undefined) return { fail: 'bad' };
+    if (avail < hs) return { fail: 'short' };
+    const sizage = Counter.Sizes.get(head.slice(0, hs));
+    if (!sizage) return { fail: 'bad' };
+    if (avail < sizage.hs + sizage.ss) return { fail: 'short' };
     let counter: Counter;
     try {
-        counter = new Counter({
-            qb64: td().decode(bytes.subarray(at, at + 8)),
-        });
+        counter = new Counter({ qb64: head });
     } catch {
-        return null;
+        return { fail: 'bad' };
     }
     const { code, count } = counter;
     const headerLen = counter.qb64.length;
@@ -222,13 +276,15 @@ function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
         // unknown so the walk stays resilient rather than halting.
         const end = at + headerLen;
         return {
-            group: {
-                ...base,
-                span: { start: at, end },
-                state: 'unknown',
-                items: [],
+            node: {
+                group: {
+                    ...base,
+                    span: { start: at, end },
+                    state: 'unknown',
+                    items: [],
+                },
+                end,
             },
-            end,
         };
     }
 
@@ -238,18 +294,23 @@ function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
         // decompose it.
         const innerStart = at + headerLen;
         const innerEnd = innerStart + count * 4;
+        // ...unless the declared quadlets run past the end of the stream, in
+        // which case the wrapper is not all here yet: short, not framed.
+        if (innerEnd > bytes.length) return { fail: 'short' };
         if (code === '-L') {
             // -L (PathedMaterialQuadlets) leads with a path primitive, not a
             // plain group run; its inner decomposition is deferred, so the
             // quadlet body stays opaque for now.
             return {
-                group: {
-                    ...base,
-                    span: { start: at, end: innerEnd },
-                    state: 'known',
-                    items: [],
+                node: {
+                    group: {
+                        ...base,
+                        span: { start: at, end: innerEnd },
+                        state: 'known',
+                        items: [],
+                    },
+                    end: innerEnd,
                 },
-                end: innerEnd,
             };
         }
         // -V / -0V universal wrappers: recurse into a typed nested group
@@ -260,18 +321,35 @@ function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
         // resilient than leaving it opaque.
         const seq = frameGroupSequence(bytes, innerStart, innerEnd);
         return {
-            group: {
-                ...base,
-                span: { start: at, end: innerEnd },
-                state: 'known',
-                items: seq.items,
+            node: {
+                group: {
+                    ...base,
+                    span: { start: at, end: innerEnd },
+                    state: 'known',
+                    items: seq.items,
+                },
+                end: innerEnd,
             },
-            end: innerEnd,
         };
     }
 
+    // A counted group is NOT self-framing: its length is the sum of its items',
+    // so running out of bytes partway through is indistinguishable from a bad
+    // item unless the shortfall says which. A shortfall propagates; a bad item
+    // leaves the group invalid, as before.
     const parts = spec.parts as Part[];
     const items: AttachmentNode[] = [];
+    const invalid = (p: number): Attempt<FramedGroup> => ({
+        node: {
+            group: {
+                ...base,
+                span: { start: at, end: p },
+                state: 'invalid',
+                items,
+            },
+            end: p,
+        },
+    });
     let p = at + headerLen;
     for (let k = 0; k < count; k++) {
         for (const part of parts) {
@@ -280,46 +358,34 @@ function frameGroup(bytes: Uint8Array, at: number): FramedGroup | null {
                 // -F/-H); frame it recursively and require it fully known, else
                 // this item — and so this group — cannot be framed.
                 const nested = frameGroup(bytes, p);
-                if (!nested || nested.group.state !== 'known') {
-                    return {
-                        group: {
-                            ...base,
-                            span: { start: at, end: p },
-                            state: 'invalid',
-                            items,
-                        },
-                        end: p,
-                    };
+                if (failed(nested)) {
+                    if (nested.fail === 'short') return nested;
+                    return invalid(p);
                 }
-                items.push(nested.group);
-                p = nested.end;
+                if (nested.node.group.state !== 'known') return invalid(p);
+                items.push(nested.node.group);
+                p = nested.node.end;
             } else {
                 const prim = framePrimitive(bytes, p, part);
-                if (!prim) {
-                    // A malformed item — we can no longer frame this group.
-                    return {
-                        group: {
-                            ...base,
-                            span: { start: at, end: p },
-                            state: 'invalid',
-                            items,
-                        },
-                        end: p,
-                    };
+                if (failed(prim)) {
+                    if (prim.fail === 'short') return prim;
+                    return invalid(p); // a malformed item — this group cannot be framed
                 }
-                items.push(prim);
-                p = prim.span.end;
+                items.push(prim.node);
+                p = prim.node.span.end;
             }
         }
     }
     return {
-        group: {
-            ...base,
-            span: { start: at, end: p },
-            state: 'known',
-            items,
+        node: {
+            group: {
+                ...base,
+                span: { start: at, end: p },
+                state: 'known',
+                items,
+            },
+            end: p,
         },
-        end: p,
     };
 }
 
@@ -336,7 +402,14 @@ function frameGroupSequence(
     let pos = start;
     while (pos < limit && bytes[pos] === DASH) {
         const framed = frameGroup(bytes, pos);
-        if (!framed) {
+        if (failed(framed)) {
+            // A group the stream ends inside is reported as a shortfall, not an
+            // error: only the caller knows whether this window is the live end
+            // of the stream (incomplete) or the inside of a sized wrapper,
+            // where the wrapper's own bytes are all present.
+            if (framed.fail === 'short') {
+                return { items, end: pos, short: true };
+            }
             return {
                 items,
                 end: pos,
@@ -348,20 +421,25 @@ function frameGroupSequence(
                 },
             };
         }
-        items.push(framed.group);
-        if (framed.group.state !== 'known') {
+        // A group that frames past this window belongs to no one: stop, and let
+        // the enclosing wrapper's declared size carry the walk forward. At the
+        // top level `limit` is the end of the stream, and frameGroup has already
+        // reported that case as short.
+        if (framed.node.end > limit) break;
+        items.push(framed.node.group);
+        if (framed.node.group.state !== 'known') {
             return {
                 items,
                 end: pos,
                 error: {
                     code: 'unframable-group',
-                    message: `The ${framed.group.code} group at byte ${pos} could not be framed.`,
+                    message: `The ${framed.node.group.code} group at byte ${pos} could not be framed.`,
                     span: { start: pos, end: limit },
                     permanent: true,
                 },
             };
         }
-        pos = framed.end;
+        pos = framed.node.end;
     }
     return { items, end: pos };
 }
@@ -394,7 +472,32 @@ export function parse(bytes: Uint8Array, opts: ParseOptions = {}): ParseResult {
             });
             break;
         }
+        if (ver.size < ver.length) {
+            // A message cannot be shorter than the version string inside it.
+            // Rejecting this is also what guarantees the loop ADVANCES:
+            // bodyEnd > i on every iteration, so a size of 0 can no longer spin
+            // here forever, allocating a message per pass.
+            errors.push({
+                code: 'invalid-version-size',
+                message: `The version string at byte ${i} declares a size of ${ver.size} bytes, too small to contain the version string itself.`,
+                span: { start: i, end: n },
+                permanent: true,
+            });
+            break;
+        }
         const bodyEnd = i + ver.size;
+        if (bodyEnd > n) {
+            // The declared size runs past the end of the stream. Note that
+            // `subarray` would have CLAMPED silently here, so without this check
+            // a truncated message decodes as a whole one.
+            errors.push({
+                code: 'incomplete',
+                message: `The message at byte ${i} declares ${ver.size} bytes but only ${n - i} are present.`,
+                span: { start: i, end: n },
+                permanent: false,
+            });
+            break; // `i` is left at the message start, so a caller can append bytes and re-parse
+        }
         const decoder = decoders[ver.kind]; // undefined if none for this kind
         let sad: Record<string, unknown> | null = null;
         if (decoder) {
@@ -414,6 +517,19 @@ export function parse(bytes: Uint8Array, opts: ParseOptions = {}): ParseResult {
         // left undecoded (sad = null).
 
         const seq = frameGroupSequence(bytes, bodyEnd, n);
+        if (seq.short) {
+            // The stream ends inside this message's attachments. The message
+            // body is whole, but emitting it would double-emit when the caller
+            // comes back with the rest, so the whole message waits and
+            // `consumed` stays at its first byte.
+            errors.push({
+                code: 'incomplete',
+                message: `The attachments of the message at byte ${i} end mid-element at byte ${n}.`,
+                span: { start: i, end: n },
+                permanent: false,
+            });
+            break;
+        }
         messages.push({
             proto: ver.proto,
             version: ver.version,

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -67,7 +67,11 @@ export interface CesrMessage {
     version: string; // e.g. '1.0'
     kind: string; // serialization, e.g. 'JSON'
     ilk: string | null; // the `t` field, null for ACDCs
-    sn: string | null; // the `s` field (hex sequence number), where present
+    /** The sequence number — a hex-encoded integer — from the `s` field of a
+     * KERI event, where present. Null under any other protocol: an ACDC also
+     * carries an `s` field, but it holds the schema SAID, which is not a
+     * sequence number and must not be read as one. Take that from `sad.s`. */
+    sn: string | null;
     said: string | null; // the `d` field
     /** The deserialized body, or null when framed but not decoded. */
     sad: Record<string, unknown> | null;
@@ -715,7 +719,12 @@ export function parse(bytes: Uint8Array, opts: ParseOptions = {}): ParseResult {
             version: ver.version,
             kind: ver.kind,
             ilk: sad && typeof sad.t === 'string' ? sad.t : null,
-            sn: sad && typeof sad.s === 'string' ? sad.s : null,
+            // `s` is the sequence number under KERI and the schema SAID under
+            // ACDC — same field name, unrelated meanings — so gate on the proto.
+            sn:
+                ver.proto === 'KERI' && sad && typeof sad.s === 'string'
+                    ? sad.s
+                    : null,
             said: sad && typeof sad.d === 'string' ? sad.d : null,
             sad,
             span: { start: i, end: bodyEnd },

--- a/src/keri/core/parsing.ts
+++ b/src/keri/core/parsing.ts
@@ -213,8 +213,12 @@ function probePrimitive(
     if (avail < hs) return { fail: 'short' }; // the hard code itself is cut off
     const sizage = sizes.get(head.slice(0, hs));
     if (!sizage) return { fail: 'bad' };
+    // A variable-size code carries no full size — the Sizes tables store that as
+    // null, which their own `fs?: number` type does not admit, so this tests the
+    // VALUE rather than trusting the type. `fs < 0` alone would let null through
+    // (null >= 0 is true) and hand back a null length.
     const fs = sizage.fs;
-    if (fs === undefined || fs < 0) return { fail: 'bad' }; // variable-size codes are unsupported
+    if (typeof fs !== 'number' || fs < 0) return { fail: 'bad' }; // variable-size: unsupported
     return avail < fs ? { fail: 'short' } : { node: fs };
 }
 

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -434,6 +434,83 @@ describe('parse — resilience', () => {
         assert.equal(group.items.length, 1); // only the first primitive framed
         assertLike(errors[0], { code: 'unframable-group', permanent: true });
     });
+
+    it('marks a group invalid when a primitive is the right SIZE but the wrong bytes', () => {
+        // A well-formed 44-char Matter 'E' digest by the size tables, so it passes
+        // the shortage probe and fails inside the constructor on non-zero prepad
+        // bits: the probe's blind spot is sizing says yes, decoding says no.
+        const badDigest = 'E' + 'Q' + 'A'.repeat(42);
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-IAB' + badDigest);
+        const { messages, errors } = parse(stream);
+        assertLike(messages[0].attachments[0], {
+            code: '-I',
+            state: 'invalid',
+        });
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+    });
+
+    it('reports a counter whose bytes are present but are not ASCII', () => {
+        // 5 BYTES ('-A' + a 3-byte '€') but only 3 CHARS, so the byte-length check
+        // passes and Counter still cannot read a 4-char header. Bad, not short.
+        const { errors } = parse(bytesOf(mkMessage({ t: 'ixn' }) + '-A€'));
+        assertLike(errors[0], {
+            code: 'unparseable-counter',
+            permanent: true,
+        });
+    });
+
+    it('marks a compound group invalid when its NESTED group is malformed', () => {
+        // -F is prefixer, seqner, saider, then a nested -A; '####' is no counter
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-FAB' + SAID + SEQNER + SAID + '####'
+        );
+        const { messages, errors } = parse(stream);
+        assertLike(messages[0].attachments[0], {
+            code: '-F',
+            state: 'invalid',
+        });
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+    });
+
+    it('separates a primitive that is cut off from one whose code is unusable', () => {
+        const at = mkMessage({ t: 'ixn' }) + '-IAB' + SAID + SEQNER; // -I wants a 3rd
+        // '0' selects a 2-char hard code and one byte is left: short, so the walk waits
+        assertLike(parse(bytesOf(at + '0')).errors[0], {
+            code: 'incomplete',
+            permanent: false,
+        });
+        // '0Z' is a well-formed selector whose 2-char code is in no size table: bad
+        assertLike(parse(bytesOf(at + '0Z' + 'A'.repeat(22))).errors[0], {
+            code: 'unframable-group',
+            permanent: true,
+        });
+        // '4A' IS in the table, as a variable-size code with no full size: also bad
+        assertLike(parse(bytesOf(at + '4A' + 'A'.repeat(22))).errors[0], {
+            code: 'unframable-group',
+            permanent: true,
+        });
+    });
+
+    it('reports a big counter whose 3-character hard code is cut off as incomplete', () => {
+        // '-0' selects a 3-char hard code (-0V and friends) and 2 bytes are here
+        const { errors } = parse(bytesOf(mkMessage({ t: 'ixn' }) + '-0'));
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('keeps a -V known when an inner group is wholly present but OVERFLOWS the wrapper', () => {
+        // -V claims 1 quadlet (4 bytes) and encloses a 72-byte -G that is entirely
+        // in the stream: not short — it simply belongs to no one — so decomposition
+        // stops and the wrapper stands.
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-VAB' + G_GROUP);
+        const { messages, errors } = parse(stream);
+        const v = messages[0].attachments[0];
+        assertLike(v, { code: '-V', state: 'known', items: [] });
+        assert.equal(v.span.end, v.span.start + 8); // header(4) + count*4(4)
+        assert.deepStrictEqual(
+            errors.filter((e) => e.code === 'incomplete'),
+            []
+        );
+    });
 });
 
 describe('parse — truncation is incomplete, not complete and not condemned', () => {
@@ -492,6 +569,18 @@ describe('parse — truncation is incomplete, not complete and not condemned', (
         // -A says 2 signatures; one is present
         const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-AAC' + SIG);
         const { errors } = parse(stream);
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('reports a compound group whose NESTED group is cut off as incomplete', () => {
+        // the same shape as the malformed-nested case above, but the nested counter
+        // runs out of bytes rather than being wrong: the shortfall propagates out
+        // through the compound group instead of condemning it
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-FAB' + SAID + SEQNER + SAID + '-A'
+        );
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(messages, []);
         assertLike(errors[0], { code: 'incomplete', permanent: false });
     });
 

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -435,3 +435,150 @@ describe('parse — resilience', () => {
         assertLike(errors[0], { code: 'unframable-group', permanent: true });
     });
 });
+
+describe('parse — truncation is incomplete, not complete and not condemned', () => {
+    it('does not frame a body whose declared size runs past the end of the stream', () => {
+        // 25 bytes claiming 0x100000: subarray clamps silently and the clamped
+        // slice is valid JSON, so this framed as one COMPLETE message.
+        const stream = bytesOf('{"v":"KERI10JSON100000_"}');
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(messages, []);
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+        assert.equal(consumed, 0); // the caller resumes here once more bytes arrive
+    });
+
+    it('does not frame a truncated body that is not accidentally valid JSON either', () => {
+        const stream = bytesOf('{"v":"KERI10JSON0000f0_","t":"icp"}'); // claims 240, has 35
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(messages, []);
+        // NOT malformed-body: the bytes present are fine, there are just too few
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('rejects a size too small to hold the version string, rather than looping forever', () => {
+        // Size 0 with a serialization that has no decoder: bodyEnd === i, no
+        // counter follows, so the cursor never advanced and the loop allocated a
+        // message per pass until the heap died.
+        const stream = bytesOf('{"v":"KERI10XXXX000000_"}');
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(messages, []);
+        assertLike(errors[0], {
+            code: 'invalid-version-size',
+            permanent: true,
+        });
+    });
+
+    it('reports a truncated self-framing wrapper as incomplete, not as a framed one', () => {
+        // -V claims 19 quadlets (76 bytes) and only 30 are present
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-VAS' + G_GROUP.slice(0, 30)
+        );
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(messages, []);
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+        assert.equal(consumed, 0);
+    });
+
+    it('reports a counted group cut off mid-item as incomplete, not unframable', () => {
+        // -A count 1 with 40 of the signature's 88 bytes: absent, not wrong
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-AAB' + SIG.slice(0, 40)
+        );
+        const { errors } = parse(stream);
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('reports a counted group short of its own count as incomplete', () => {
+        // -A says 2 signatures; one is present
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-AAC' + SIG);
+        const { errors } = parse(stream);
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('resumes exactly where consumed left off when the missing bytes arrive', () => {
+        const whole = bytesOf(mkMessage({ t: 'ixn' }) + A_GROUP);
+        const first = parse(whole.slice(0, whole.length - 20));
+        assertLike(first.errors[0], { code: 'incomplete', permanent: false });
+        assert.equal(first.messages.length, 0);
+        // the contract: keep from `consumed`, append the rest, parse again —
+        // nothing is emitted twice
+        const second = parse(whole.slice(first.consumed));
+        assert.deepStrictEqual(second.errors, []);
+        assert.equal(second.messages.length, 1);
+        assert.equal(second.consumed, whole.length - first.consumed);
+    });
+});
+
+describe('parse — truncation sweep: every vector cut at every byte', () => {
+    // The class of bug, not the one example, is what went undetected: a truncated
+    // body, a truncated wrapper and a size-0 loop were three faces of one missing
+    // bounds check. This sweeps the whole class — every prefix of every vector
+    // must terminate, never throw, and never claim bytes the caller did not pass.
+    const msg = mkMessage({ t: 'ixn' });
+    const VECTORS: Record<string, string> = {
+        'bare message': msg,
+        'two messages': msg + mkMessage({ t: 'rot' }),
+        'controller sigs': msg + A_GROUP,
+        '-V wrapper': msg + '-VAS' + G_GROUP,
+        'nested -V wrappers': msg + '-VAT' + '-VAS' + G_GROUP,
+        '-F with a nested -A': msg + '-FAB' + SAID + SEQNER + SAID + A_GROUP,
+        'receipt couple': msg + '-CAB' + VER + CIG,
+        'replay couple': msg + '-EAB' + SEQNER + DAT,
+        'message then attachments then message':
+            msg + A_GROUP + mkMessage({ t: 'rot' }) + A_GROUP,
+    };
+
+    /** Every node in an attachment forest, groups and primitives alike. */
+    const nodesOf = (n: AttachmentNode): AttachmentNode[] =>
+        n.kind === 'group' ? [n, ...n.items.flatMap(nodesOf)] : [n];
+
+    for (const [name, text] of Object.entries(VECTORS)) {
+        it(`holds its invariants for every prefix of the ${name} vector`, () => {
+            const whole = bytesOf(text);
+            for (let cut = 1; cut <= whole.length; cut++) {
+                const prefix = whole.slice(0, cut);
+                // must not throw, and must terminate
+                const { messages, errors, consumed } = parse(prefix);
+                assert.ok(consumed <= cut, `consumed ${consumed} > ${cut}`);
+                for (const m of messages) {
+                    assert.ok(m.span.end <= cut, `message span past ${cut}`);
+                    for (const node of m.attachments.flatMap(nodesOf)) {
+                        assert.ok(
+                            node.span.end <= cut,
+                            `${node.kind} span past ${cut}`
+                        );
+                    }
+                }
+                // A prefix of a VALID stream can fail only by running out, so
+                // every error is `incomplete` — except where the cut lands inside
+                // a version string, which is still reported as no-version-string.
+                // That one remaining corner is pinned here rather than waved at:
+                // it may happen ONLY with the token's own span left in the buffer.
+                for (const e of errors) {
+                    if (e.code === 'no-version-string') {
+                        assert.ok(
+                            cut - e.span.start < 32,
+                            `no-version-string with ${cut - e.span.start} bytes left`
+                        );
+                    } else {
+                        assertLike(e, {
+                            code: 'incomplete',
+                            permanent: false,
+                        });
+                    }
+                }
+            }
+        });
+    }
+
+    it('parses each vector whole with no incomplete error', () => {
+        for (const text of Object.values(VECTORS)) {
+            const { errors, consumed } = parse(bytesOf(text));
+            assert.deepStrictEqual(
+                errors.filter((e) => e.code === 'incomplete'),
+                []
+            );
+            assert.equal(consumed, bytesOf(text).length);
+        }
+    });
+});

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -67,18 +67,188 @@ function mkMessage(fields: Record<string, unknown>, proto = 'KERI'): string {
 }
 const bytesOf = (s: string) => new TextEncoder().encode(s);
 
+// --- CESR 2.0 (genus 2) vectors and helpers. ---
+const B64 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_';
+/** Encode an integer as `len` base64url chars (v2 counter soft / size fields). */
+function intToB64(n: number, len: number): string {
+    let s = '';
+    for (let i = 0; i < len; i++) {
+        s = B64[n % 64] + s;
+        n = Math.floor(n / 64);
+    }
+    return s;
+}
+/** A v2 counter header: code + base64 quadlet count (soft is 2 chars for `-X`,
+ * 5 for `--X`). */
+const ctr2 = (code: string, quadlets: number) =>
+    code + intToB64(quadlets, code.startsWith('--') ? 5 : 2);
+/** Build a self-framed v2 JSON message with a correct base64 version-string size. */
+function mkMessageV2(fields: Record<string, unknown>): string {
+    const placeholder = JSON.stringify({ v: 'KERICAACAAJSONAAAA.', ...fields });
+    const size = new TextEncoder().encode(placeholder).length;
+    return placeholder.replace(
+        'KERICAACAAJSONAAAA.',
+        `KERICAACAAJSON${intToB64(size, 4)}.`
+    );
+}
+/** A real keripy 2.0.0-dev6 witness-role OOBI (CESR genus 2, PII-free synthetic):
+ * one icp message whose -C AttachmentGroup wrapper (the v2 analog of v1 -V) holds
+ * a -K ControllerIdxSigs group and a -O FirstSeenReplayCouples group. */
+const V2_OOBI =
+    '{"v":"KERICAACAAJSONAAD_.","t":"icp","d":"EP16vD37O8CcvmgKRrjI5WbrtAioC34lY-eXX7-VTxt6","i":"BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9","s":"0","kt":"1","k":["BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-CAi-KAWAADx_HNvu67xglnKrv21Y9foLfEAOCyraOvsonbDvhXeEMxwmQgj6afrUxSJGs-MA_YFlc59_aO0rMp0pD-kHSEE-OAKMAAA1AAG2026-07-21T19c49c46d674250p00c00';
+
 describe('parseVersion', () => {
-    it('reads proto, version, kind and size from a v1 version string', () => {
+    it('reads proto, version, kind, size and CESR genus 1 from a v1 version string', () => {
         const v = parseVersion(bytesOf(mkMessage({ t: 'ixn' })), 0);
         assert.ok(v);
         assert.equal(v.proto, 'KERI');
         assert.equal(v.version, '1.0');
         assert.equal(v.kind, 'JSON');
         assert.equal(typeof v.size, 'number');
+        assert.equal(v.genus, 1);
     });
 
     it('returns null when there is no version string', () => {
         assert.equal(parseVersion(bytesOf('{"x":1}'), 0), null);
+    });
+
+    it('reads proto, protocol version, CESR genus and a base64 size from a v2 string', () => {
+        // AAD_ base64 = 255 = the exact JSON body length of the v2 OOBI sample.
+        assertLike(parseVersion(bytesOf(V2_OOBI), 0), {
+            proto: 'KERI',
+            version: '2.0',
+            kind: 'JSON',
+            size: 255,
+            genus: 2,
+        });
+    });
+
+    it('decodes the v2 size field as base64, not hex', () => {
+        // AAEv base64 = 4*64 + 47 = 303.
+        const v = parseVersion(bytesOf('{"v":"KERICAACAAJSONAAEv."}'), 0);
+        assert.equal(v?.size, 303);
+    });
+});
+
+describe('parse — CESR 2.0 framing (keripy sample)', () => {
+    it('frames a v2 message and its self-framing attachment groups', () => {
+        const bytes = bytesOf(V2_OOBI);
+        const { messages, errors, consumed } = parse(bytes);
+        assert.deepEqual(errors, []);
+        assert.equal(consumed, bytes.length); // delta 0
+        assert.equal(messages.length, 1);
+        assertLike(messages[0], {
+            proto: 'KERI',
+            version: '2.0',
+            kind: 'JSON',
+            ilk: 'icp',
+            sn: '0',
+        });
+        const c = asGroup(messages[0].attachments[0]);
+        assertLike(c, { code: '-C', genus: 2, state: 'known' });
+        const inner = c.items.map(asGroup);
+        assert.deepEqual(
+            inner.map((x) => x.code),
+            ['-K', '-O'] // ControllerIdxSigs, then FirstSeenReplayCouples
+        );
+        // -K holds an indexed signature (Indexer class), -O holds Matter primitives
+        assert.ok(inner[0].items.every((p) => primClass(p) === 'indexer'));
+        assert.ok(inner[1].items.every((p) => primClass(p) === 'matter'));
+        // byte-alignment invariant: inner groups tile the wrapper exactly
+        assert.equal(inner[0].span.start, c.span.start + 4); // past the -C header
+        assert.equal(inner[inner.length - 1].span.end, c.span.end);
+    });
+});
+
+describe('parse — CESR 2.0 synthetic structure and resilience', () => {
+    const V2ICP = { t: 'icp', d: SAID, i: SAID, s: '0' };
+
+    it('self-frames an UNRECOGNIZED v2 counter and keeps parsing (unknown-but-framed)', () => {
+        const unknown = ctr2('-d', 1) + 'A'.repeat(4); // -d not in CtrDex_2_0
+        const known = ctr2('-K', 22) + SIG;
+        const wrap = ctr2('-C', (unknown.length + known.length) / 4);
+        const stream = bytesOf(mkMessageV2(V2ICP) + wrap + unknown + known);
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const inner = asGroup(messages[0].attachments[0]).items.map(asGroup);
+        assertLike(inner[0], { code: '-d', state: 'unknown', items: [] });
+        assertLike(inner[1], { code: '-K', state: 'known' });
+    });
+
+    it('frames a big (--C) attachment wrapper (hard 3 / soft 5)', () => {
+        const k = ctr2('-K', 22) + SIG;
+        const stream = bytesOf(
+            mkMessageV2(V2ICP) + ctr2('--C', k.length / 4) + k
+        );
+        const { messages, errors } = parse(stream);
+        assert.deepEqual(errors, []);
+        const w = asGroup(messages[0].attachments[0]);
+        assert.equal(w.code, '--C');
+        assert.equal(asGroup(w.items[0]).code, '-K');
+    });
+
+    it('marks an unrecognized genus-version counter unknown-but-bodyless, then resumes', () => {
+        const stream = bytesOf(
+            mkMessageV2(V2ICP) + '-_AABCAA' + ctr2('-K', 22) + SIG
+        );
+        const atts = parse(stream).messages[0].attachments;
+        assertLike(atts[0], { code: '-_AAB', state: 'unknown', items: [] });
+        assert.equal(atts[1].code, '-K');
+    });
+
+    it('frames the -_AAA genus-version counter as a bodyless declaration', () => {
+        const stream = bytesOf(
+            mkMessageV2(V2ICP) + '-_AAACAA' + ctr2('-K', 22) + SIG
+        );
+        const atts = parse(stream).messages[0].attachments;
+        assertLike(atts[0], { code: '-_AAA', state: 'known', items: [] });
+        assert.equal(atts[1].code, '-K');
+    });
+
+    it('reports an unparseable v2 counter and stops', () => {
+        // "-C**": the soft count is all present, and is not base64 — bad bytes
+        const { errors } = parse(bytesOf(mkMessageV2(V2ICP) + '-C**'));
+        assertLike(errors[0], { code: 'unparseable-counter', permanent: true });
+    });
+
+    it('reports a v2 counter cut off by the end of the stream as incomplete', () => {
+        // a lone "-C" with no room for its 2-char soft count: absent, not wrong
+        const { errors } = parse(bytesOf(mkMessageV2(V2ICP) + '-C'));
+        assertLike(errors[0], { code: 'incomplete', permanent: false });
+    });
+
+    it('keeps a self-framed wrapper known when an inner GROUP overflows its bound', () => {
+        const corrupt = ctr2('-C', 1) + ctr2('-K', 22) + SIG; // -C claims 4 bytes
+        const w = asGroup(
+            parse(bytesOf(mkMessageV2(V2ICP) + corrupt)).messages[0]
+                .attachments[0]
+        );
+        assertLike(w, { code: '-C', state: 'known', items: [] });
+    });
+
+    it('keeps a self-framed group known when an inner primitive overflows or is malformed', () => {
+        const overflow = ctr2('-K', 1) + SIG; // claims 1 quadlet, 88-char sig
+        const kOver = asGroup(
+            parse(bytesOf(mkMessageV2(V2ICP) + overflow)).messages[0]
+                .attachments[0]
+        );
+        assertLike(kOver, { code: '-K', state: 'known', items: [] });
+        const malformed = ctr2('-K', 22) + '@'.repeat(88); // not a signature
+        const kBad = asGroup(
+            parse(bytesOf(mkMessageV2(V2ICP) + malformed)).messages[0]
+                .attachments[0]
+        );
+        assertLike(kBad, { code: '-K', state: 'known', items: [] });
+    });
+
+    it('keeps a self-framed wrapper known when inner bytes are not a valid counter', () => {
+        const corrupt = ctr2('-C', 1) + '-A..'; // non-base64 soft
+        const w = asGroup(
+            parse(bytesOf(mkMessageV2(V2ICP) + corrupt)).messages[0]
+                .attachments[0]
+        );
+        assertLike(w, { code: '-C', state: 'known', items: [] });
     });
 });
 
@@ -615,6 +785,11 @@ describe('parse — truncation sweep: every vector cut at every byte', () => {
         'replay couple': msg + '-EAB' + SEQNER + DAT,
         'message then attachments then message':
             msg + A_GROUP + mkMessage({ t: 'rot' }) + A_GROUP,
+        // v2 (genus 2): a real keripy OOBI, and two of it back to back — every v2
+        // group self-frames on count*4, which is exactly the declared length a
+        // truncated stream makes a lie of.
+        'v2 OOBI': V2_OOBI,
+        'two v2 OOBIs': V2_OOBI + V2_OOBI,
     };
 
     /** Every node in an attachment forest, groups and primitives alike. */

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -97,6 +97,12 @@ function mkMessageV2(fields: Record<string, unknown>): string {
 const V2_OOBI =
     '{"v":"KERICAACAAJSONAAD_.","t":"icp","d":"EP16vD37O8CcvmgKRrjI5WbrtAioC34lY-eXX7-VTxt6","i":"BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9","s":"0","kt":"1","k":["BBDzeCI8m9Ls3OBw_LTOnJSEUyWXMD-Xggp4ufqeAE_9"],"nt":"0","n":[],"bt":"0","b":[],"c":[],"a":[]}-CAi-KAWAADx_HNvu67xglnKrv21Y9foLfEAOCyraOvsonbDvhXeEMxwmQgj6afrUxSJGs-MA_YFlc59_aO0rMp0pD-kHSEE-OAKMAAA1AAG2026-07-21T19c49c46d674250p00c00';
 
+/** The SAD-path example from the CESR spec (§ SAD Path Examples,
+ * https://trustoverip.github.io/kswg-cesr-specification/#sad-path-examples):
+ * a bare genus-2 ACDC, no attachments. Reported by @daidoji on PR #403. */
+const V2_ACDC_SAD =
+    '{"v":"ACDCCAACAAJSONAAIe.","t":"acm","d":"EO3117lnAbjDt66qe2PtgHooXKAYQT_C6SIbESMcJ5lN","i":"EEDGM_DvZ9qFEAPf_FX08J3HX49ycrVvYVXe9isaP5SW","s":"EGU_SHY-8ywNBJOqPKHr4sXV9tOtOwpYzYOM63_zUCDW","a":{"d":"ED1wMKzV72L7YI1yJ3NXlClPUgvEerw4jRocOYxaZGtH","i":"ECsGDKWAYtHBCkiDrzajkxs3Iw2g-dls3bLUsRP4yVdT","dt":"2025-06-09T17:35:54.169967+00:00","personal":{"name":"John Doe","home":"Atlanta"},"p":[{"ref0":{"name":"Amy","i":"ECmiMVHTfZIjhA_rovnfx73T3G_FJzIQtzDn1meBVLAz"}},{"ref1":{"name":"Bob","i":"ECWJZFBtllh99fESUOrBvT3EtBujWtDKCmyzDAXWhYmf"}}]}}';
+
 describe('parseVersion', () => {
     it('reads proto, version, kind, size and CESR genus 1 from a v1 version string', () => {
         const v = parseVersion(bytesOf(mkMessage({ t: 'ixn' })), 0);
@@ -157,6 +163,41 @@ describe('parse — CESR 2.0 framing (keripy sample)', () => {
         // byte-alignment invariant: inner groups tile the wrapper exactly
         assert.equal(inner[0].span.start, c.span.start + 4); // past the -C header
         assert.equal(inner[inner.length - 1].span.end, c.span.end);
+    });
+});
+
+describe('parse — CESR 2.0 ACDC (CESR spec SAD-path example)', () => {
+    it('reads the v2 ACDC version string, including the base64 size', () => {
+        // AAIe base64 = 2*4096 + 8*64 + 30 = 542, the byte length of the SAD.
+        assertLike(parseVersion(bytesOf(V2_ACDC_SAD), 0), {
+            proto: 'ACDC',
+            version: '2.0',
+            kind: 'JSON',
+            size: 542,
+            genus: 2,
+        });
+    });
+
+    it('frames the whole SAD as one attachment-free message', () => {
+        const bytes = bytesOf(V2_ACDC_SAD);
+        const { messages, errors, consumed } = parse(bytes);
+        assert.deepEqual(errors, []);
+        assert.equal(consumed, bytes.length); // delta 0
+        assert.equal(messages.length, 1);
+        assertLike(messages[0], {
+            proto: 'ACDC',
+            version: '2.0',
+            kind: 'JSON',
+            ilk: 'acm',
+            said: 'EO3117lnAbjDt66qe2PtgHooXKAYQT_C6SIbESMcJ5lN',
+            sn: null, // `s` here is the schema SAID, not a sequence number
+            span: { start: 0, end: bytes.length },
+        });
+        assert.deepEqual(messages[0].attachments, []);
+        // the nested attribute block survives the round trip intact
+        const a = messages[0].sad?.a as Record<string, unknown>;
+        assert.equal(a.i, 'ECsGDKWAYtHBCkiDrzajkxs3Iw2g-dls3bLUsRP4yVdT');
+        assert.equal((a.p as unknown[]).length, 2);
     });
 });
 

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -1,0 +1,437 @@
+import { assert, describe, it } from 'vitest';
+import {
+    parse,
+    parseVersion,
+    type AttachmentGroup,
+    type AttachmentNode,
+    type Primitive,
+} from '../../src/keri/core/parsing.ts';
+
+/** Narrow an attachment node to a group for nested-item assertions. */
+const asGroup = (n: AttachmentNode) => n as AttachmentGroup;
+/** Read the Matter/Indexer class off a primitive node. */
+const primClass = (n: AttachmentNode) => (n as Primitive).class;
+
+/** Recursive PARTIAL deep-match: every key present in `expected` must match
+ * `actual`; keys absent from `expected` are ignored (the equivalent of jest's
+ * toMatchObject, expressed with vitest's assert). */
+function assertLike(actual: unknown, expected: unknown, path = 'value'): void {
+    if (Array.isArray(expected)) {
+        assert.ok(Array.isArray(actual), `${path}: expected an array`);
+        expected.forEach((e, i) =>
+            assertLike((actual as unknown[])[i], e, `${path}[${i}]`)
+        );
+        return;
+    }
+    if (expected !== null && typeof expected === 'object') {
+        assert.ok(
+            actual !== null && typeof actual === 'object',
+            `${path}: expected an object`
+        );
+        for (const k of Object.keys(expected as Record<string, unknown>)) {
+            assertLike(
+                (actual as Record<string, unknown>)[k],
+                (expected as Record<string, unknown>)[k],
+                `${path}.${k}`
+            );
+        }
+        return;
+    }
+    assert.strictEqual(actual, expected, path);
+}
+
+// Throwaway primitives from keripy, for the compound trans-sig/receipt groups.
+const SAID = 'ELXXiPwoaWOVOTLMOAmg4IKkjFHFs3q2hsL9tHvuuC2D'; // 44-char Blake3 digest (Matter 'E')
+const SEQNER = '0A' + 'A'.repeat(22); // 24-char Number/Seqner primitive (sn 0)
+const G_GROUP = '-GAB' + SEQNER + SAID; // one -G seal-source-couple = 72 bytes (18 quadlets)
+const SIG =
+    'AACMeIMNXpYbryJsyq2VCJsFl1trtbhBMUetIKvC9aft4uI_bMFz0YvTNA2w-PAgkzMfXeV8tzeyWVr7SBlkmZoC'; // 88-char indexed Siger
+const DAT = '1AAG2020-08-22T17c50c09d988921p00c00'; // 36-char Dater (datetime)
+const VER = 'DDVHH3ix0_aawmzCf-IBLdRe2UiFGCxEdXFuiecqyLEy'; // 44-char Verfer (Ed25519 public key)
+const CIG =
+    '0BCMeIMNXpYbryJsyq2VCJsFl1trtbhBMUetIKvC9aft4uI_bMFz0YvTNA2w-PAgkzMfXeV8tzeyWVr7SBlkmZoC'; // 88-char non-indexed Cigar
+const A_GROUP = '-AAB' + SIG; // one -A ControllerIdxSigs group (count 1)
+
+/** Build a self-framed v1 message with a correct version-string size. */
+function mkMessage(fields: Record<string, unknown>, proto = 'KERI'): string {
+    const enc = new TextEncoder();
+    const placeholder = JSON.stringify({
+        v: `${proto}10JSON000000_`,
+        ...fields,
+    });
+    const size = enc.encode(placeholder).length;
+    return placeholder.replace(
+        `${proto}10JSON000000_`,
+        `${proto}10JSON${size.toString(16).padStart(6, '0')}_`
+    );
+}
+const bytesOf = (s: string) => new TextEncoder().encode(s);
+
+describe('parseVersion', () => {
+    it('reads proto, version, kind and size from a v1 version string', () => {
+        const v = parseVersion(bytesOf(mkMessage({ t: 'ixn' })), 0);
+        assert.ok(v);
+        assert.equal(v.proto, 'KERI');
+        assert.equal(v.version, '1.0');
+        assert.equal(v.kind, 'JSON');
+        assert.equal(typeof v.size, 'number');
+    });
+
+    it('returns null when there is no version string', () => {
+        assert.equal(parseVersion(bytesOf('{"x":1}'), 0), null);
+    });
+});
+
+describe('parse — -V/-0V inner decomposition', () => {
+    const attach = (payload: string) =>
+        bytesOf(mkMessage({ t: 'ixn' }) + payload);
+
+    it('decomposes a -V wrapper into its typed inner group and primitives', () => {
+        const stream = attach('-VAS' + G_GROUP); // 72 inner bytes = 18 quadlets
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const v = messages[0].attachments[0];
+        assertLike(v, {
+            kind: 'group',
+            code: '-V',
+            count: 18,
+            state: 'known',
+            span: { start: messages[0].span.end, end: stream.length },
+            items: [
+                {
+                    kind: 'group',
+                    code: '-G',
+                    count: 1,
+                    state: 'known',
+                    items: [{ kind: 'primitive' }, { kind: 'primitive' }],
+                },
+            ],
+        });
+        // the inner group is byte-exact: it begins right after the 4-byte -V header
+        assert.deepStrictEqual(asGroup(v.items[0]).span, {
+            start: messages[0].span.end + 4,
+            end: stream.length,
+        });
+    });
+
+    it('decomposes a -V wrapper carrying two inner groups', () => {
+        const stream = attach('-VAk' + G_GROUP + G_GROUP); // 144 inner bytes = 36 quadlets
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        const v = messages[0].attachments[0];
+        assert.equal(v.state, 'known');
+        assert.deepStrictEqual(
+            v.items.map((it) => asGroup(it).code),
+            ['-G', '-G']
+        );
+    });
+
+    it('decomposes a -0V big wrapper the same way as -V', () => {
+        const stream = attach('-0VAAAAS' + G_GROUP); // 8-byte header, 18 quadlets
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        const v = messages[0].attachments[0];
+        assertLike(v, { code: '-0V', count: 18, state: 'known' });
+        assertLike(asGroup(v.items[0]), { code: '-G', state: 'known' });
+    });
+
+    it('recurses nested -V wrappers', () => {
+        const inner = '-VAS' + G_GROUP; // 76 bytes = 19 quadlets
+        const stream = attach('-VAT' + inner);
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        const outer = messages[0].attachments[0];
+        assertLike(outer, { code: '-V', state: 'known' });
+        const mid = asGroup(outer.items[0]);
+        assertLike(mid, { code: '-V', state: 'known' });
+        assert.equal(asGroup(mid.items[0]).code, '-G');
+    });
+
+    it('leaves -L (pathed material) opaque, not recursed', () => {
+        const stream = attach('-LAB' + 'AAAA'); // count 1 -> 4 opaque bytes
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assertLike(messages[0].attachments[0], {
+            code: '-L',
+            state: 'known',
+            items: [],
+        });
+    });
+
+    it('treats a -V as a resilience boundary: an unparseable inner counter does not halt the walk', () => {
+        const msg2 = mkMessage({ t: 'ixn', s: '2' });
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-VAB' + '-ZAB' + msg2
+        ); // -Z unsupported, inside -V
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []); // the wrapper's known size absorbs the undecodable content
+        assert.equal(messages.length, 2); // the walk resumes past the wrapper and reaches msg2
+        assertLike(messages[0].attachments[0], {
+            code: '-V',
+            state: 'known',
+            items: [],
+        });
+        assert.equal(consumed, stream.length);
+    });
+
+    it('leaves a recognized-but-unmodelled inner counter as an unknown child, without halting', () => {
+        const msg2 = mkMessage({ t: 'ixn', s: '2' });
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-VAB' + '-JAB' + msg2
+        ); // -J: known counter, unframed
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(messages.length, 2);
+        const v = messages[0].attachments[0];
+        assertLike(v, { code: '-V', state: 'known' });
+        assertLike(asGroup(v.items[0]), { code: '-J', state: 'unknown' });
+    });
+
+    it('stops decomposing a -V when inner content underfills it, keeping the wrapper and continuing', () => {
+        const msg2 = mkMessage({ t: 'ixn', s: '2' });
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-VAT' + G_GROUP + 'AAAA' + msg2
+        ); // group + 4 filler
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(messages.length, 2);
+        const v = messages[0].attachments[0];
+        assertLike(v, { code: '-V', state: 'known' });
+        assert.equal(asGroup(v.items[0]).code, '-G'); // decoded up to the filler, then stopped
+    });
+});
+
+describe('parse — compound trans-sig and receipt groups', () => {
+    const attach = (payload: string) =>
+        bytesOf(mkMessage({ t: 'ixn' }) + payload);
+
+    it('frames a -F TransIdxSigGroups: prefixer, seqner, saider, then a nested -A group', () => {
+        const stream = attach('-FAB' + SAID + SEQNER + SAID + A_GROUP);
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const f = messages[0].attachments[0];
+        assertLike(f, { code: '-F', count: 1, state: 'known' });
+        assert.deepStrictEqual(
+            f.items.map((it) => it.kind),
+            ['primitive', 'primitive', 'primitive', 'group']
+        );
+        const nested = asGroup(f.items[3]);
+        assertLike(nested, { code: '-A', state: 'known' });
+        assert.equal(nested.items.length, 1); // one indexed sig
+    });
+
+    it('frames a -H TransLastIdxSigGroups: prefixer, then a nested -A group', () => {
+        const stream = attach('-HAB' + SAID + A_GROUP);
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        const h = messages[0].attachments[0];
+        assertLike(h, { code: '-H', count: 1, state: 'known' });
+        assert.deepStrictEqual(
+            h.items.map((it) => it.kind),
+            ['primitive', 'group']
+        );
+        assertLike(asGroup(h.items[1]), { code: '-A', state: 'known' });
+    });
+
+    it('frames a -D TransReceiptQuadruples of (prefixer, seqner, saider, siger)', () => {
+        const stream = attach('-DAB' + SAID + SEQNER + SAID + SIG);
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const d = messages[0].attachments[0];
+        assertLike(d, { code: '-D', count: 1, state: 'known' });
+        assert.equal(d.items.length, 4);
+        assert.ok(d.items.every((it) => it.kind === 'primitive'));
+    });
+
+    it('frames a -E FirstSeenReplayCouples of (seqner, dater)', () => {
+        const stream = attach('-EAB' + SEQNER + DAT);
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        const e = messages[0].attachments[0];
+        assertLike(e, { code: '-E', count: 1, state: 'known' });
+        assert.equal(e.items.length, 2);
+    });
+
+    it('frames a -C NonTransReceiptCouples of (verfer, cigar)', () => {
+        const stream = attach('-CAB' + VER + CIG);
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const c = messages[0].attachments[0];
+        assertLike(c, { code: '-C', count: 1, state: 'known' });
+        assert.equal(c.items.length, 2);
+    });
+
+    it('marks a -F invalid when its nested -A group is malformed', () => {
+        const stream = attach('-FAB' + SAID + SEQNER + SAID + '-AAB' + '####'); // bad sig in nested -A
+        const { messages, errors } = parse(stream);
+        assertLike(messages[0].attachments[0], {
+            code: '-F',
+            state: 'invalid',
+        });
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+    });
+});
+
+describe('parse — primitive class discriminator', () => {
+    it('tags a -F group: prefixer/seqner/saider as matter, the nested -A sig as indexer', () => {
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-FAB' + SAID + SEQNER + SAID + A_GROUP
+        );
+        const f = parse(stream).messages[0].attachments[0];
+        assert.deepStrictEqual(f.items.slice(0, 3).map(primClass), [
+            'matter',
+            'matter',
+            'matter',
+        ]);
+        const nestedA = asGroup(f.items[3]);
+        assert.equal(primClass(nestedA.items[0]), 'indexer');
+    });
+
+    it('tags a -D quadruple as three matter primitives then an indexer siger', () => {
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-DAB' + SAID + SEQNER + SAID + SIG
+        );
+        const d = parse(stream).messages[0].attachments[0];
+        assert.deepStrictEqual(d.items.map(primClass), [
+            'matter',
+            'matter',
+            'matter',
+            'indexer',
+        ]);
+    });
+
+    it('tags a -A controller-sig child as indexer', () => {
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + A_GROUP);
+        const a = parse(stream).messages[0].attachments[0];
+        assert.equal(primClass(a.items[0]), 'indexer');
+    });
+});
+
+describe('parse — synthetic structure', () => {
+    it('frames a message with no attachments', () => {
+        const { messages, errors, consumed } = parse(
+            bytesOf(mkMessage({ t: 'ixn', s: '1', d: 'E_' }))
+        );
+        assert.deepStrictEqual(errors, []);
+        assert.equal(messages.length, 1);
+        assert.deepStrictEqual(messages[0].attachments, []);
+        assert.equal(consumed, messages[0].span.end);
+    });
+
+    it('frames an -I seal-source-triple group into typed (i, s, d) primitives', () => {
+        const iGroup = '-IAB' + SAID + SEQNER + SAID; // count 1: prefixer, seqner, saider
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + iGroup);
+        const { messages, errors, consumed } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assert.equal(consumed, stream.length);
+        const group = messages[0].attachments[0];
+        assertLike(group, {
+            kind: 'group',
+            code: '-I',
+            count: 1,
+            state: 'known',
+        });
+        assert.deepStrictEqual(
+            group.items.map((it) => ({
+                code: (it as Primitive).code,
+                class: primClass(it),
+            })),
+            [
+                { code: 'E', class: 'matter' },
+                { code: '0A', class: 'matter' },
+                { code: 'E', class: 'matter' },
+            ]
+        );
+    });
+
+    it('frames a -G seal-source-couple group into (s, d) primitives', () => {
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-GAB' + SEQNER + SAID
+        );
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(errors, []);
+        assertLike(messages[0].attachments[0], {
+            code: '-G',
+            count: 1,
+            state: 'known',
+        });
+        assert.equal(messages[0].attachments[0].items.length, 2);
+    });
+
+    it('nulls ilk, sn and said when the fields are absent (e.g. an ACDC)', () => {
+        const { messages } = parse(
+            bytesOf(mkMessage({ i: 'E_holder' }, 'ACDC'))
+        );
+        assertLike(messages[0], {
+            ilk: null,
+            sn: null,
+            said: null,
+            proto: 'ACDC',
+        });
+    });
+});
+
+describe('parse — resilience', () => {
+    it('errors and stops when the stream has no version string at its start', () => {
+        const { messages, errors, consumed } = parse(bytesOf('garbage'));
+        assert.deepStrictEqual(messages, []);
+        assert.equal(consumed, 0);
+        assertLike(errors[0], { code: 'no-version-string', permanent: true });
+    });
+
+    it('errors when a { has no version string', () => {
+        const { errors } = parse(bytesOf('{"x":1}'));
+        assertLike(errors[0], { code: 'no-version-string', permanent: true });
+    });
+
+    it('errors on a malformed message body', () => {
+        // version claims 32 bytes but the body is not valid JSON
+        const stream = bytesOf('{"v":"KERI10JSON000020_"XXXXXXXX');
+        const { messages, errors } = parse(stream);
+        assert.deepStrictEqual(messages, []);
+        assertLike(errors[0], { code: 'malformed-body', permanent: true });
+    });
+
+    it('keeps the message but marks an unrecognized (unframable) counter and stops', () => {
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-JAB'); // -J: a known code we do not yet frame
+        const { messages, errors, consumed } = parse(stream);
+        assert.equal(messages.length, 1);
+        assertLike(messages[0].attachments[0], {
+            code: '-J',
+            state: 'unknown',
+        });
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+        assert.ok(consumed < stream.length);
+    });
+
+    it('reports an unparseable counter code', () => {
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-ZAB'); // -Z: unsupported code
+        const { errors } = parse(stream);
+        assertLike(errors[0], { code: 'unparseable-counter', permanent: true });
+    });
+
+    it('marks an indexed-sig group invalid when an item is malformed', () => {
+        const stream = bytesOf(mkMessage({ t: 'ixn' }) + '-AAB' + '####'); // count 1, garbage item
+        const { messages, errors } = parse(stream);
+        assertLike(messages[0].attachments[0], {
+            code: '-A',
+            state: 'invalid',
+        });
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+    });
+
+    it('marks a primitive group invalid when a primitive item is malformed', () => {
+        const stream = bytesOf(
+            mkMessage({ t: 'ixn' }) + '-IAB' + SAID + '####'
+        ); // 2nd part unparseable
+        const { messages, errors } = parse(stream);
+        const group = messages[0].attachments[0];
+        assertLike(group, { code: '-I', state: 'invalid' });
+        assert.equal(group.items.length, 1); // only the first primitive framed
+        assertLike(errors[0], { code: 'unframable-group', permanent: true });
+    });
+});

--- a/test/core/parsing.test.ts
+++ b/test/core/parsing.test.ts
@@ -543,6 +543,14 @@ describe('parse — synthetic structure', () => {
             proto: 'ACDC',
         });
     });
+
+    it("does not read an ACDC's `s` (the schema SAID) as a sequence number", () => {
+        const { messages } = parse(
+            bytesOf(mkMessage({ i: SAID, s: SAID }, 'ACDC'))
+        );
+        assert.equal(messages[0].sn, null);
+        assert.equal(messages[0].sad?.s, SAID); // still available on the body
+    });
 });
 
 describe('parse — resilience', () => {


### PR DESCRIPTION
## Summary

Adds **CESR 2.0 / KERI 2.x** support to the stream parser introduced in #402.
The parser now frames both CESR-1 and CESR-2 streams to the same resilience
posture, ground-truthed against keripy `2.0.0-dev6`.

> **Stacked on #402.** This branch is based on `feat/cesr-stream-parser`, so
> until #402 merges the diff here shows both commits; the change owned by *this*
> PR is the second commit (`feat(parsing): frame CESR 2.0 (v2) streams via genus
> dispatch`). Please review/merge #402 first — this will then narrow to just the
> v2 commit and can retarget cleanly onto `main`.

## What it does

- **`parseVersion`** now parses the v2 version string
  (`proto` + protocol-version + embedded **CESR-genus-version** + `kind` +
  base64 `size` + `.` terminator) and returns the genus.
- **`frameGroup` dispatches by CESR genus.** Native v2 counter framing (from
  keripy's `CtrDex_2_0`) is added because signify-ts's `Counter` carries only the
  v1 table and **silently misframes** v2 codes — they collide with v1 code
  strings but denote different groups (e.g. v1 `-C` is `NonTransReceiptCouples`;
  v2 `-C` is the `AttachmentGroup` wrapper). Every v2 group counts its body in
  **quadlets**, so it self-frames as `count*4` bytes: decomposition is uniform,
  even unrecognized codes are *unknown-but-framed*, and the v1 `-V`
  resilience-boundary rule generalizes to all groups.
- **Primitives still delegate** to `Matter`/`Indexer` even under v2 — primitive
  codes are genus-stable, so a v2 AID/SAID/key/signature parses unchanged.
- `AttachmentGroup` gains a `genus` field, since a code's meaning depends on it.

## Tests

Adds v2 `parseVersion`, framing, and resilience/corruption tests, plus a real
keripy-generated v2 witness-OOBI vector (PII-free synthetic). All four CI gates
(build, lint, `pretty:check`, tests) pass locally.

## Provenance

Developed and proven in a downstream viewer against a corpus of keripy
`2.0.0-dev6` streams, then contributed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
