### PR TITLE
feat: expose the keys the next rotation will reveal

### DIFF
--- a/src/keri/core/keeping.ts
+++ b/src/keri/core/keeping.ts
@@ -268,6 +268,38 @@ export class SaltyIdentifierManager implements IdentifierManager {
     public algo: Algos = Algos.salty;
     public signers: Signer[];
 
+    /**
+     * The verification keys the next rotation will reveal.
+     *
+     * `incept` and `rotate` both derive these in order to publish their digests,
+     * and this is that same derivation rather than a second copy of it. A caller
+     * that has to commit to the next key in a form KERI does not publish, a
+     * Cardano key hash for instance, would otherwise reimplement the index
+     * arithmetic; a copy that drifts commits to a key nobody holds, and the
+     * commitment is only discovered to be wrong at the rotation it blocks.
+     *
+     * The keys themselves never leave the keeper in normal use: callers are
+     * expected to hash or commit to them, not to publish them, since publishing
+     * one is what pre-rotation exists to avoid.
+     */
+    public nextSigners(): Signer[] {
+        return this.creator.create(
+            this.ncodes,
+            this.ncount,
+            this.ncode,
+            this.transferable,
+            this.pidx,
+            0,
+            this.kidx + (this.icodes?.length ?? 0),
+            false
+        ).signers;
+    }
+
+    /** Verfers of {@link nextSigners}, which is what a digest is taken over. */
+    public nextVerfers(): Verfer[] {
+        return this.nextSigners().map((signer) => signer.verfer);
+    }
+
     constructor(
         salter: Salter,
         pidx: number,
@@ -370,19 +402,9 @@ export class SaltyIdentifierManager implements IdentifierManager {
         );
         const verfers = signers.signers.map((signer) => signer.verfer.qb64);
 
-        const nsigners = this.creator.create(
-            this.ncodes,
-            this.ncount,
-            this.ncode,
-            this.transferable,
-            this.pidx,
-            0,
-            this.icodes?.length,
-            false
-        );
-        const digers = nsigners.signers.map(
-            (nsigner) =>
-                new Diger({ code: this.dcode }, nsigner.verfer.qb64b).qb64
+        // kidx is 0 here, so this is the same index the next keys live at
+        const digers = this.nextVerfers().map(
+            (nverfer) => new Diger({ code: this.dcode }, nverfer.qb64b).qb64
         );
 
         return [verfers, digers];
@@ -407,19 +429,8 @@ export class SaltyIdentifierManager implements IdentifierManager {
         const verfers = signers.signers.map((signer) => signer.verfer.qb64);
 
         this.kidx = this.kidx! + this.icodes!.length;
-        const nsigners = this.creator.create(
-            this.ncodes,
-            this.ncount,
-            this.ncode,
-            this.transferable,
-            this.pidx,
-            0,
-            this.kidx + this.icodes!.length,
-            false
-        );
-        const digers = nsigners.signers.map(
-            (nsigner) =>
-                new Diger({ code: this.dcode }, nsigner.verfer.qb64b).qb64
+        const digers = this.nextVerfers().map(
+            (nverfer) => new Diger({ code: this.dcode }, nverfer.qb64b).qb64
         );
 
         return [verfers, digers];

--- a/test/core/keeping.test.ts
+++ b/test/core/keeping.test.ts
@@ -150,3 +150,80 @@ function groupSigningFixtures() {
 
     return { keys, priorNextDigests };
 }
+
+/**
+ * Pre-rotation publishes a digest of the next key, never the key. A caller that
+ * has to commit to it in a form KERI does not publish, a Cardano key hash for
+ * one, cannot work from the digest and would otherwise reimplement the index
+ * arithmetic incept and rotate use. A copy that drifts commits to a key nobody
+ * holds, and that is only discovered at the rotation it blocks.
+ *
+ * So the property worth pinning is that what nextVerfers returns is exactly what
+ * the next rotation reveals.
+ */
+describe('SaltyIdentifierManager next keys', () => {
+    const newManager = () =>
+        new SaltyIdentifierManager(
+            new Salter({ raw: b('0123456789abcdef') }),
+            0,
+            0,
+            Tier.low,
+            true
+        );
+
+    it('returns the key the next rotation goes on to reveal', async () => {
+        await libsodium.ready;
+
+        const manager = newManager();
+        await manager.incept(true);
+        const predicted = manager.nextVerfers().map((v) => v.qb64);
+
+        const [revealed] = await manager.rotate([MtrDex.Ed25519_Seed], true);
+        assert.deepEqual(revealed, predicted);
+    });
+
+    it('still does, one rotation later', async () => {
+        await libsodium.ready;
+
+        const manager = newManager();
+        await manager.incept(true);
+        await manager.rotate([MtrDex.Ed25519_Seed], true);
+
+        const predicted = manager.nextVerfers().map((v) => v.qb64);
+        const [revealed] = await manager.rotate([MtrDex.Ed25519_Seed], true);
+        assert.deepEqual(revealed, predicted);
+    });
+
+    it('agrees with the digest incept published, which is the same derivation', async () => {
+        await libsodium.ready;
+
+        const manager = newManager();
+        const [, digers] = await manager.incept(true);
+        const fromKeys = manager
+            .nextVerfers()
+            .map((v) => new Diger({ code: MtrDex.Blake3_256 }, v.qb64b).qb64);
+
+        assert.deepEqual(fromKeys, digers);
+    });
+
+    it('is not the current key, or pre-rotation would be pointless', async () => {
+        await libsodium.ready;
+
+        const manager = newManager();
+        const [verfers] = await manager.incept(true);
+        const next = manager.nextVerfers().map((v) => v.qb64);
+
+        assert.notDeepEqual(next, verfers);
+    });
+
+    it('is stable across calls, since it is derived and not drawn', async () => {
+        await libsodium.ready;
+
+        const manager = newManager();
+        await manager.incept(true);
+        assert.deepEqual(
+            manager.nextVerfers().map((v) => v.qb64),
+            manager.nextVerfers().map((v) => v.qb64)
+        );
+    });
+});


### PR DESCRIPTION
`nextVerfers()` and `nextSigners()` on `SaltyIdentifierManager`.

`incept` and `rotate` already derive the next signers to publish their digests; both now call this instead of repeating the derivation, so it cannot drift from what they commit to.

A caller that needs to commit to the next key in a form KERI does not publish has no way to get there from the KEL: the digest is Blake3 over the CESR form, and something like a Cardano payment credential is blake2b-224 over the raw key. Without this they reimplement the index arithmetic, and a copy that drifts commits to a key nobody holds, which is only discovered at the rotation it blocks.

Five tests: what it returns is exactly what the next `rotate()` reveals, across two rotations, and it agrees with the digest `incept()` publishes.

No behaviour change, the `IdentifierManager` interface is untouched, and the Randy and Group keepers are untouched.
