### PR TITLE
chore: bump version to 0.4.1 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.4.1] - 2026-08-26
+
+### Release highlights
+
+- **Breaking API changes:** Replaced the exported `Authenticater` class with the asynchronous `Authenticator`, `SignedHeaderAuthenticator`, and `EssrAuthenticator` APIs, requiring direct callers to migrate from `sign`/`verify` to `prepare`/`verify`; removed `SignifyClient.saveOldPasscode` and `.deletePasscode`; made client delegation approval internal; and changed `Controller.approveDelegation` to return both the event and signatures ([#335](https://github.com/WebOfTrust/signify-ts/pull/335), [#405](https://github.com/WebOfTrust/signify-ts/pull/405)).
+- **ESSR:** Added opt-in End-to-End Secure Request authentication for KERIA, including sealed request and response transport, encryption, signature and sender/destination verification, and corrected HTTP serialization and parsing; signed-header authentication remains the default ([#335](https://github.com/WebOfTrust/signify-ts/pull/335), coordinated with [KERIA #351](https://github.com/WebOfTrust/keria/pull/351)).
+- Made `boot`, `state`, and `connect` cancellable with `AbortSignal`; restored connections from KERIA's authoritative controller sequence; avoided duplicate delegation approval; and now fail clearly on malformed state or rejected approval ([#405](https://github.com/WebOfTrust/signify-ts/pull/405)).
+- **Identifier state API change:** Regenerated the KERIA API models and made pending multisig inception explicit with `PendingHabState`, `isAccepted`, and `requireKeyState`; `identifiers().get` and `.update` now require accepted key state by default, so callers that need pending state must pass `false` and handle `PendingHabState` ([#407](https://github.com/WebOfTrust/signify-ts/pull/407)).
+- Exported generated KERIA OpenAPI types and enums through the `KeriaApi` namespace, addressing [#384](https://github.com/WebOfTrust/signify-ts/issues/384) ([#385](https://github.com/WebOfTrust/signify-ts/pull/385)), and tightened salty signer index and `ondex` typing and validation ([#382](https://github.com/WebOfTrust/signify-ts/pull/382)).
+- Updated Docker and CI integration coverage for KERIA 0.4.0 and the 0.4.1 development image, aligned multisig notification expectations, and exercised both signed-header and ESSR modes, resolving [#392](https://github.com/WebOfTrust/signify-ts/issues/392) ([#391](https://github.com/WebOfTrust/signify-ts/pull/391), [#397](https://github.com/WebOfTrust/signify-ts/pull/397), [#405](https://github.com/WebOfTrust/signify-ts/pull/405)).
+- Added OIDC-based npm Trusted Publishing through GitHub Actions and documented the release flow ([#383](https://github.com/WebOfTrust/signify-ts/pull/383)).
+- Established the versioned changelog requested in [#387](https://github.com/WebOfTrust/signify-ts/issues/387) and backfilled earlier releases ([#389](https://github.com/WebOfTrust/signify-ts/pull/389)).
+- Refreshed Vitest, Vite/esbuild, markdown-it, js-yaml, linkify-it, and postcss dependencies, including parser and CSS security updates ([#386](https://github.com/WebOfTrust/signify-ts/pull/386), [#394](https://github.com/WebOfTrust/signify-ts/pull/394), [#395](https://github.com/WebOfTrust/signify-ts/pull/395), [#396](https://github.com/WebOfTrust/signify-ts/pull/396), [#404](https://github.com/WebOfTrust/signify-ts/pull/404), [#406](https://github.com/WebOfTrust/signify-ts/pull/406), [#409](https://github.com/WebOfTrust/signify-ts/pull/409)).
+
+Version 0.4.1 centers on the new ESSR transport boundary: SignifyTS can now seal and sign complete KERIA API requests, then authenticate, decrypt, and reconstruct the responses, without changing the default signed-header path. The surrounding work makes connection and delegation failures explicit, represents pending multisig identifiers honestly in the type system, exposes KERIA's generated API surface, and strengthens release and compatibility testing.
+
 ## [0.4.0] - 2026-05-11
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signify-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signify-ts",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@noble/curves": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signify-ts",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Signing at the edge for KERI, ACDC, and KERIA",
   "keywords": [
     "keri",


### PR DESCRIPTION
Adds release highlights, bumps package.json to 0.4.1